### PR TITLE
Move encoder initialisation into function

### DIFF
--- a/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h
+++ b/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h
@@ -156,8 +156,11 @@ protected:
   const LCObjectVec* getSimHits( TrackerHit* trkhit, const FloatVec* weights = NULL);
   const LCObjectVec* getCaloHits( CalorimeterHit* calohit, const FloatVec* weights = NULL);
   
-  UTIL::BitField64* _encoder;
-  int getDetectorID(TrackerHit* hit) { _encoder->setValue(hit->getCellID0()); return (*_encoder)[lcio::LCTrackerCellID::subdet()]; }
+  int getDetectorID(TrackerHit* hit) {
+    static UTIL::BitField64 _encoder = UTIL::BitField64(lcio::LCTrackerCellID::encoding_string());
+    _encoder.setValue(hit->getCellID0());
+    return _encoder[lcio::LCTrackerCellID::subdet()];
+  }
 
 
   /**  input collection names */

--- a/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
+++ b/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
@@ -60,8 +60,6 @@ RecoMCTruthLinker::RecoMCTruthLinker() : Processor("RecoMCTruthLinker") {
   pdgVecDef.push_back( 111 ) ;  // pi0
   pdgVecDef.push_back( 310 ) ;  // K0s
   
-  _encoder = new UTIL::BitField64(lcio::LCTrackerCellID::encoding_string());
-  
  
    //  >>>>> reconstructed or simulated thingis 
  


### PR DESCRIPTION

BEGINRELEASENOTES
- RecoMCTruthLinker: move encoder initialisation from constructor to function body to avoid accessing encoding_string too early

ENDRELEASENOTES