### PR TITLE
update to latest changes in LCIO

### DIFF
--- a/Clustering/PhotonFinderKit/src/EMShowerFinder.cc
+++ b/Clustering/PhotonFinderKit/src/EMShowerFinder.cc
@@ -140,7 +140,7 @@ void EMShowerFinder::processEvent( LCEvent * evt ) {
   try {
     
     LCCollection* colt = evt->getCollection(_colNameECAL.c_str()) ;
-    CellIDDecoder<CalorimeterHit>CDECAL =CellIDDecoder<CalorimeterHit>(colt);
+    CellIDDecoder<CalorimeterHit> CDECAL(colt);
 
     LCCollectionVec* clscol = new LCCollectionVec(LCIO::CLUSTER);
 

--- a/Clustering/PhotonFinderKit/src/KIT.cc
+++ b/Clustering/PhotonFinderKit/src/KIT.cc
@@ -95,7 +95,7 @@ void KIT::processEvent( LCEvent * evt ) {
  
   try{   
         LCCollection* colt = evt->getCollection(_Ecal_col.c_str()) ;
-	CellIDDecoder<CalorimeterHit>CDECAL =CellIDDecoder<CalorimeterHit>(colt);
+	CellIDDecoder<CalorimeterHit> CDECAL(colt);
 	LCCollectionVec * clscol = new LCCollectionVec(LCIO::CLUSTER);
       if( colt!=0)
 	{

--- a/TrackDigi/VTXDigi/src/CCDDigitizer.cc
+++ b/TrackDigi/VTXDigi/src/CCDDigitizer.cc
@@ -967,7 +967,7 @@ void CCDDigitizer::ProduceHits( SimTrackerHitImplVec & vectorOfHits) {
               // double pos[3] = {xCurrent, yCurrent, 0};
               // hit->setPosition( pos );
 
-              hit->setCellID( currentcellid );
+              hit->setCellID0( currentcellid );
               hit->setEDep( charge );
               vectorOfHits.push_back( hit );
             }

--- a/TrackDigi/VTXDigi/src/VTXDigitizer.cc
+++ b/TrackDigi/VTXDigi/src/VTXDigitizer.cc
@@ -841,7 +841,7 @@ void VTXDigitizer::ProduceHits( SimTrackerHitImplVec & vectorOfHits) {
               SimTrackerHitImpl * hit = new SimTrackerHitImpl();
               double pos[3] = {xCurrent, yCurrent, _layerHalfThickness[_currentLayer]};
               hit->setPosition( pos );
-              hit->setCellID( cellID );
+              hit->setCellID0( cellID );
               hit->setEDep( totCharge );
               vectorOfHits.push_back( hit );
             }

--- a/TrackDigi/VTXDigi/src/VTXNoiseClusters.cc
+++ b/TrackDigi/VTXDigi/src/VTXNoiseClusters.cc
@@ -290,7 +290,7 @@ void VTXNoiseClusters::modifyEvent( LCEvent * evt ) {
         hit->setEDep( 0. ) ; // FIXME: which dedx should be used for noise hits 
 
         //FIXME: encode a proper cellID
-        hit->setCellID(  i + 1  ) ; // fg: here we'd like to have ladder id as well ....
+        hit->setCellID0(  i + 1  ) ; // fg: here we'd like to have ladder id as well ....
 
 
         // now we need to add some cluster parameters  to the hit :


### PR DESCRIPTION
 - removed deprecated SimTrackerHit::setCellID
 - don't use assignment for CellIDDecoder

BEGINRELEASENOTES
- update to latest changes in LCIO
       - removed deprecated SimTrackerHit::setCellID
       - don't use assignment for CellIDDecoder

ENDRELEASENOTES