### PR TITLE
Fixes and improvements for CLICPfoSelector/TauFinder

### DIFF
--- a/Analysis/CLICPfoSelector/include/CLICDstChecker.h
+++ b/Analysis/CLICPfoSelector/include/CLICDstChecker.h
@@ -82,7 +82,6 @@ class CLICDstChecker : public Processor {
  private:
   std::vector<ReconstructedParticle*> m_pfoVector{};
   std::set<MCParticle*> m_mcSet{};
-  static bool PfoSortFunction(ReconstructedParticle* lhs,ReconstructedParticle* rhs); 
   LCRelationNavigator* m_pfoToMcNavigator=NULL;
 
 } ;

--- a/Analysis/CLICPfoSelector/include/CLICDstChecker.h
+++ b/Analysis/CLICPfoSelector/include/CLICDstChecker.h
@@ -11,8 +11,8 @@
 #include <set>
 #include <algorithm>
 
-#define FORMATTED_OUTPUT_TRACK_CLUSTER(N1, E1,E2,E3,N2,N3)             		                \
-    std::cout  <<                                                                               \
+#define FORMATTED_OUTPUT_TRACK_CLUSTER(out, N1, E1,E2,E3,N2,N3) \
+    out <<                                                                                      \
     std::right << std::setw(widthInt)      <<    N1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E2        <<                                   \
@@ -20,8 +20,8 @@
     std::right << std::setw(widthSmallInt) <<    N2        <<                                   \
     std::right << std::setw(widthSmallInt) <<    N3
 
-#define FORMATTED_OUTPUT_TRACK(N1, E1,E2,E3,N2,N3)                                              \
-    std::cout  <<                                                                               \
+#define FORMATTED_OUTPUT_TRACK(out, N1, E1,E2,E3,N2,N3) \
+    out <<                                                                                      \
     std::right << std::setw(widthInt)      <<    N1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E2        <<                                   \
@@ -29,8 +29,8 @@
     std::right << std::setw(widthSmallInt) <<    N2        <<                                   \
     std::right << std::setw(widthSmallInt) <<    N3 
 
-#define FORMATTED_OUTPUT_CLUSTER(N1, E1,E2,E3,N2,N3)                                            \
-    std::cout  <<                                                                               \
+#define FORMATTED_OUTPUT_CLUSTER(out, N1, E1,E2,E3,N2,N3) \
+    out <<                                                                                      \
     std::right << std::setw(widthInt)      <<    N1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E2        <<                                   \
@@ -38,8 +38,8 @@
     std::right << std::setw(widthSmallInt) <<    N2        <<                                   \
     std::right << std::setw(widthSmallInt) <<    N3 
 
-#define FORMATTED_OUTPUT_MC(N1,E1)                                                              \
-    std::cout  <<                                                                               \
+#define FORMATTED_OUTPUT_MC(out, N1,E1) \
+    out <<                                                                                      \
     std::right << std::setw(widthInt)      <<    N1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E1
 

--- a/Analysis/CLICPfoSelector/include/CLICPfoSelector.h
+++ b/Analysis/CLICPfoSelector/include/CLICPfoSelector.h
@@ -11,8 +11,8 @@
 #include <set>
 #include <algorithm>
 
-#define FORMATTED_OUTPUT_TRACK_CLUSTER(N1, E1,E2,E3,N2,E4,N3,E5,E6,E7)	                        \
-    std::cout  <<                                                                               \
+#define FORMATTED_OUTPUT_TRACK_CLUSTER(out, N1, E1,E2,E3,N2,E4,N3,E5,E6,E7) \
+    out <<                                                                                      \
     std::right << std::setw(widthInt)      <<    N1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E1        <<                                   \
     std::right << std::setw(widthFloat)    <<    E2        <<                                   \
@@ -23,28 +23,6 @@
     std::right << std::setw(widthFloat)    <<    E5        <<                                   \
     std::right << std::setw(widthFloat)    <<    E6        <<                                   \
     std::right << std::setw(widthFloat)    <<    E7  << std::endl
-
-#define FORMATTED_OUTPUT_CLUSTER(N1, E1,E2,E3,N3,E5,E6,E7)	                                \
-    std::cout  <<                                                                               \
-    std::right << std::setw(widthInt)      <<    N1        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E1        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E2        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E3        <<                                   \
-    std::right << std::setw(widthInt)      <<    " - "     <<                                   \
-    std::right << std::setw(widthFloat)    <<    " - "     <<                                   \
-    std::right << std::setw(widthInt  )    <<    N3        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E5        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E6        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E7        << std::endl
-
-#define FORMATTED_OUTPUT_TRACK(N1, E1,E2,E3,N2,E4)                             			\
-    std::cout  <<                                                                               \
-    std::right << std::setw(widthInt)      <<    N1        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E1        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E2        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E3        <<                                   \
-    std::right << std::setw(widthInt)      <<    N2        <<                                   \
-    std::right << std::setw(widthFloat)    <<    E4        << std::endl
 
 using namespace lcio ;
 using namespace marlin ;

--- a/Analysis/CLICPfoSelector/include/CLICPfoSelector.h
+++ b/Analysis/CLICPfoSelector/include/CLICPfoSelector.h
@@ -54,7 +54,6 @@ class CLICPfoSelector : public Processor {
   int _nEvt=-1;
 
   float _bField=0.0;
-  int   m_debug=-1;
 
   std::string     m_inputPfoCollection{};                 ///< Input PFO collection name
   std::string     m_selectedPfoCollection{};              ///< Output PFO collection name

--- a/Analysis/CLICPfoSelector/include/CLICPfoSelector.h
+++ b/Analysis/CLICPfoSelector/include/CLICPfoSelector.h
@@ -1,6 +1,7 @@
 #ifndef CLICPFOSELECTOR_H
 #define CLICPFOSELECTOR 1
 
+#include "PfoUtilities.h"
 #include "marlin/Processor.h"
 #include <EVENT/ReconstructedParticle.h>
 #include "lcio.h"
@@ -107,10 +108,6 @@ class CLICPfoSelector : public Processor {
   float           m_clusterLessPfoTrackTimeCut=10.0;      ///< Maximum arrival time at Ecal for cluster-less pfo
   float           m_forwardCosThetaForHighEnergyNeutralHadrons=0.95;   ///< Forward region of HCAL where timing cuts will be applied to all neutral hadrons
   float           m_forwardHighEnergyNeutralHadronsEnergy=10.0;        ///< Energy cut for specific HCAL timing requirements cuts for neutral hadrons
-
- private:
-  typedef std::vector<ReconstructedParticle*> PfoList;
-  static bool PfoSortFunction(ReconstructedParticle* lhs,ReconstructedParticle* rhs); 
 
 } ;
 

--- a/Analysis/CLICPfoSelector/include/PfoUtilities.h
+++ b/Analysis/CLICPfoSelector/include/PfoUtilities.h
@@ -1,0 +1,44 @@
+#ifndef PFOUTILITIES_H
+#define PFOUTILITIES_H 1
+
+#include <EVENT/ReconstructedParticle.h>
+#include <EVENT/LCObject.h>
+
+#include <vector>
+
+
+namespace PfoUtil{
+
+  typedef std::vector<EVENT::ReconstructedParticle*> PfoList;
+
+  static bool PfoSortFunction(EVENT::ReconstructedParticle* lhs,EVENT::ReconstructedParticle* rhs){
+
+  //  true if lhs goes before
+
+   const float lhs_energy  = lhs->getEnergy();
+   const float rhs_energy  = rhs->getEnergy();
+   const EVENT::ClusterVec lhs_clusters = lhs->getClusters();
+   const EVENT::TrackVec   lhs_tracks   = lhs->getTracks();
+   const EVENT::TrackVec   rhs_tracks   = rhs->getTracks();
+   const EVENT::ClusterVec rhs_clusters = rhs->getClusters();
+   const int lhs_particleType  = abs(lhs->getType());
+   const int rhs_particleType  = abs(rhs->getType());
+
+   int lhs_type(0);
+   int rhs_type(0);
+
+   if(lhs_clusters.size()==0)lhs_type=1;
+   if(rhs_clusters.size()==0)rhs_type=1;
+   if(lhs_particleType==22)lhs_type=10;
+   if(rhs_particleType==22)rhs_type=10;
+   if(lhs_particleType==2112)lhs_type=20;
+   if(rhs_particleType==2112)rhs_type=20;
+
+   if(lhs_type==rhs_type)return (lhs_energy>rhs_energy);
+   return (lhs_type<rhs_type);
+
+}
+
+}//namespace
+
+#endif // PFOUTILITIES_H

--- a/Analysis/CLICPfoSelector/src/CLICDstChecker.cc
+++ b/Analysis/CLICPfoSelector/src/CLICDstChecker.cc
@@ -115,7 +115,7 @@ void CLICDstChecker::processEvent( LCEvent * evt ) {
   try {
     LCCollection * col = evt->getCollection(m_inputPfoCollection.c_str());
     const int nelem = col->getNumberOfElements(); 
-    for (int iPfo=0; iPfo<nelem; ++iPfo)m_pfoVector.push_back(dynamic_cast<ReconstructedParticle*>(col->getElementAt(iPfo)));
+    for (int iPfo=0; iPfo<nelem; ++iPfo)m_pfoVector.push_back(static_cast<ReconstructedParticle*>(col->getElementAt(iPfo)));
     std::sort(m_pfoVector.begin(),m_pfoVector.end(),CLICDstChecker::PfoSortFunction);
   }
   catch( DataNotAvailableException &e ) {
@@ -128,7 +128,7 @@ void CLICDstChecker::processEvent( LCEvent * evt ) {
     LCCollection * col = evt->getCollection(m_inputMcParticleCollection.c_str());
     int nelem = col->getNumberOfElements(); 
     for (int iMc=0; iMc<nelem; ++iMc){
-      MCParticle * pMc = dynamic_cast<MCParticle*>(col->getElementAt(iMc));
+      MCParticle * pMc = static_cast<MCParticle*>(col->getElementAt(iMc));
       // insert all existing mc pointers into set *** MUST CHECK THIS BEFORE USING RELATION ***
       m_mcSet.insert(pMc);
       const float px(pMc->getMomentum()[0]);
@@ -161,7 +161,7 @@ void CLICDstChecker::processEvent( LCEvent * evt ) {
     LCObjectVec objectVec = m_pfoToMcNavigator->getRelatedToObjects(pPfo);
     if (objectVec.size() > 0) {
       for(unsigned int imc = 0; imc < objectVec.size(); imc++){
-	MCParticle * pMC = dynamic_cast<MCParticle*>(objectVec[imc]);
+	MCParticle * pMC = static_cast<MCParticle*>(objectVec[imc]);
 	// since only saving skimmed set of MC particles, check pMC points to an existing object 
 	if(m_mcSet.count(pMC)!=0){
 	  physicsPfos.push_back(pPfo);

--- a/Analysis/CLICPfoSelector/src/CLICDstChecker.cc
+++ b/Analysis/CLICPfoSelector/src/CLICDstChecker.cc
@@ -1,4 +1,5 @@
 #include "CLICDstChecker.h"
+#include "PfoUtilities.h"
 #include <iostream>
 #include <EVENT/LCObject.h>
 #include <EVENT/LCCollection.h>
@@ -116,7 +117,7 @@ void CLICDstChecker::processEvent( LCEvent * evt ) {
     LCCollection * col = evt->getCollection(m_inputPfoCollection.c_str());
     const int nelem = col->getNumberOfElements(); 
     for (int iPfo=0; iPfo<nelem; ++iPfo)m_pfoVector.push_back(static_cast<ReconstructedParticle*>(col->getElementAt(iPfo)));
-    std::sort(m_pfoVector.begin(),m_pfoVector.end(),CLICDstChecker::PfoSortFunction);
+    std::sort(m_pfoVector.begin(),m_pfoVector.end(),PfoUtil::PfoSortFunction);
   }
   catch( DataNotAvailableException &e ) {
     streamlog_out( MESSAGE ) << m_inputPfoCollection.c_str() << " collection is unavailable" << std::endl;
@@ -286,32 +287,3 @@ void CLICDstChecker::check(LCEvent * ) { }
 void CLICDstChecker::end() {
 
 }
-
-bool CLICDstChecker::PfoSortFunction(ReconstructedParticle* lhs,ReconstructedParticle* rhs){
-
-  //  true if lhs goes before
-
-   const float lhs_energy  = lhs->getEnergy();
-   const float rhs_energy  = rhs->getEnergy();
-   const ClusterVec lhs_clusters = lhs->getClusters();
-   const TrackVec   lhs_tracks   = lhs->getTracks();
-   const TrackVec   rhs_tracks   = rhs->getTracks();
-   const ClusterVec rhs_clusters = rhs->getClusters();
-   const int lhs_particleType  = abs(lhs->getType());
-   const int rhs_particleType  = abs(rhs->getType());
-
-   int lhs_type(0);
-   int rhs_type(0);
-   
-   if(lhs_clusters.size()==0)lhs_type=1;
-   if(rhs_clusters.size()==0)rhs_type=1;
-   if(lhs_particleType==22)lhs_type=10;
-   if(rhs_particleType==22)rhs_type=10;
-   if(lhs_particleType==2112)lhs_type=20;
-   if(rhs_particleType==2112)rhs_type=20;
-
-   if(lhs_type==rhs_type)return (lhs_energy>rhs_energy);
-   return (lhs_type<rhs_type);
-   
-}
-

--- a/Analysis/CLICPfoSelector/src/CLICDstChecker.cc
+++ b/Analysis/CLICPfoSelector/src/CLICDstChecker.cc
@@ -241,13 +241,21 @@ void CLICDstChecker::processEvent( LCEvent * evt ) {
 
 
       if (m_monitoring && (ipass==0 || (ipass ==1 && m_showBackground))) {
-	streamlog_out( MESSAGE ) << std::fixed;
-	streamlog_out( MESSAGE ) << std::setprecision(precision);
-	if(clusters.size()==0)FORMATTED_OUTPUT_TRACK(type,energy,pT,cosTheta,tracks.size(),0);
-	if(tracks.size()==0)FORMATTED_OUTPUT_CLUSTER(type,energy,pT,cosTheta,0,clusters.size());
-	if(tracks.size()>0&&clusters.size()>0)FORMATTED_OUTPUT_TRACK_CLUSTER(type,energy,pT,cosTheta,tracks.size(),clusters.size());
-	if(pMc!=NULL)FORMATTED_OUTPUT_MC(pMc->getPDG(),pMc->getEnergy());
-	streamlog_out( MESSAGE ) << std::endl;
+        std::stringstream output;
+        output << std::fixed;
+        output << std::setprecision(precision);
+        if(clusters.size()==0)
+          FORMATTED_OUTPUT_TRACK(output, type,energy,pT,cosTheta,tracks.size(),0);
+        if(tracks.size()==0)
+          FORMATTED_OUTPUT_CLUSTER(output, type,energy,pT,cosTheta,0,clusters.size());
+
+        if(tracks.size()>0&&clusters.size()>0)
+          FORMATTED_OUTPUT_TRACK_CLUSTER(output, type,energy,pT,cosTheta,tracks.size(),clusters.size());
+        if(pMc!=NULL)
+          FORMATTED_OUTPUT_MC(output, pMc->getPDG(),pMc->getEnergy());
+
+        streamlog_out( MESSAGE ) << output.str();
+        streamlog_out( MESSAGE ) << std::endl;
       }
     }
   }

--- a/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
+++ b/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
@@ -319,10 +319,10 @@ void CLICPfoSelector::processEvent( LCEvent * evt ) {
   try {
     LCCollection * col = evt->getCollection(m_inputPfoCollection.c_str());
     int nelem = col->getNumberOfElements();
-    PfoList pfos;
+    PfoUtil::PfoList pfos;
 
     for (int iPfo=0; iPfo<nelem; ++iPfo)pfos.push_back(dynamic_cast<ReconstructedParticle*>(col->getElementAt(iPfo)));
-    std::sort(pfos.begin(),pfos.end(),CLICPfoSelector::PfoSortFunction);
+    std::sort(pfos.begin(),pfos.end(),PfoUtil::PfoSortFunction);
 
     if (m_monitoring) {
       streamlog_out( MESSAGE ) << std::endl;
@@ -831,32 +831,3 @@ void CLICPfoSelector::check(LCEvent * ) { }
 void CLICPfoSelector::end() {
 
 }
-
-bool CLICPfoSelector::PfoSortFunction(ReconstructedParticle* lhs,ReconstructedParticle* rhs){
-
-  //  true if lhs goes before
-
-   const float lhs_energy  = lhs->getEnergy();
-   const float rhs_energy  = rhs->getEnergy();
-   const ClusterVec lhs_clusters = lhs->getClusters();
-   const TrackVec   lhs_tracks   = lhs->getTracks();
-   const TrackVec   rhs_tracks   = rhs->getTracks();
-   const ClusterVec rhs_clusters = rhs->getClusters();
-   const int lhs_particleType  = abs(lhs->getType());
-   const int rhs_particleType  = abs(rhs->getType());
-
-   int lhs_type(0);
-   int rhs_type(0);
-   
-   if(lhs_clusters.size()==0)lhs_type=1;
-   if(rhs_clusters.size()==0)rhs_type=1;
-   if(lhs_particleType==22)lhs_type=10;
-   if(rhs_particleType==22)rhs_type=10;
-   if(lhs_particleType==2112)lhs_type=20;
-   if(rhs_particleType==2112)rhs_type=20;
-
-   if(lhs_type==rhs_type)return (lhs_energy>rhs_energy);
-   return (lhs_type<rhs_type);
-   
-}
-

--- a/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
+++ b/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
@@ -316,7 +316,7 @@ void CLICPfoSelector::processEvent( LCEvent * evt ) {
     int nelem = col->getNumberOfElements();
     PfoUtil::PfoList pfos;
 
-    for (int iPfo=0; iPfo<nelem; ++iPfo)pfos.push_back(dynamic_cast<ReconstructedParticle*>(col->getElementAt(iPfo)));
+    for (int iPfo=0; iPfo<nelem; ++iPfo)pfos.push_back(static_cast<ReconstructedParticle*>(col->getElementAt(iPfo)));
     std::sort(pfos.begin(),pfos.end(),PfoUtil::PfoSortFunction);
 
     if (m_monitoring) {

--- a/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
+++ b/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
@@ -57,11 +57,6 @@ CLICPfoSelector::CLICPfoSelector() : Processor("CLICPfoSelector") {
 			   m_selectedPfoCollection,
 			   std::string("SelectedPandoraPFANewPFOs"));
 
-  registerProcessorParameter("Debug",
-			     "Activate debugging?",
-			     m_debug,
-			     int(0));
-
   registerProcessorParameter("Monitoring",
 			     "Monitoring",
 			     m_monitoring,

--- a/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
+++ b/Analysis/CLICPfoSelector/src/CLICPfoSelector.cc
@@ -326,16 +326,7 @@ void CLICPfoSelector::processEvent( LCEvent * evt ) {
       const float cosTheta = fabs(momentum[2])/p_pfo;
       const float energy  = pPfo->getEnergy();
       eTotalInput+=energy;
-      // float covMatrix[10];
-      // for(unsigned int i=0;i<10;i++)covMatrix[i] = pPfo->getCovMatrix()[i];
-//      const float mass = pPfo->getMass();
-//      const float charge = pPfo->getCharge();
-      // float referencePoint[3];
-      // for(unsigned int i=0;i<3;i++)referencePoint[i] = pPfo->getReferencePoint()[i];
-      //const ParticleIDVec particleIDs = pPfo->getParticleIDs();
-//      ParticleID *particleIDUsed = pPfo->getParticleIDUsed();
-//      const float goodnessOfPID = pPfo->getGoodnessOfPID();
-      //const ReconstructedParticleVec particles = pPfo->getParticles();
+
       const ClusterVec clusters = pPfo->getClusters();
       const TrackVec   tracks   = pPfo->getTracks();
       //const Vertex startVertex(pPfo->getStartVertex());
@@ -352,15 +343,6 @@ void CLICPfoSelector::processEvent( LCEvent * evt ) {
 
       for(unsigned int i = 0; i< tracks.size(); i++){
 	const Track *track = tracks[i];
-	const TrackerHitVec hitVec = track->getTrackerHits();
-	const int nHits = int(hitVec.size());
-	//	const int nHitsVTX = track->getSubdetectorHitNumbers()[6];
-	//const int nHitsFTD = track->getSubdetectorHitNumbers()[7];
-	//const int nHitsSIT = track->getSubdetectorHitNumbers()[8];
-	//const int nHitsTPC = track->getSubdetectorHitNumbers()[9];
-	//const int nHitsSET = track->getSubdetectorHitNumbers()[10];
-	//const int nHitsETD = track->getSubdetectorHitNumbers()[11];
-	float r2Min = std::numeric_limits<float>::max(); 
 	const float d0    = track->getD0();
 	const float z0    = track->getZ0();
 	const float omega = track->getOmega();
@@ -372,18 +354,10 @@ void CLICPfoSelector::processEvent( LCEvent * evt ) {
 	const float px = helix.getMomentum()[0];
 	const float py = helix.getMomentum()[1];
 	const float pz = helix.getMomentum()[2];
-	const float pT = sqrt(px*px+py*py);
-	const float p  = sqrt(pT*pT+pz*pz);
+	const float p  = sqrt(px*px+py*py+pz*pz);
 	float tof;
 	const float time = this->TimeAtEcal(track,tof);
-	for (int iH=0;iH<nHits;++iH) {
-	  const TrackerHit * hit = hitVec[iH];
-	  const float hitX = float(hit->getPosition()[0]);
-	  const float hitY = float(hit->getPosition()[1]);
-	  const float hitR2 = hitX*hitX+hitY*hitY;
-	  if (hitR2<r2Min)r2Min = hitR2;
-	}
-	if(fabs(time)<trackTime){
+	if( fabs(time) < trackTime ){
 	  trackTime = time;
 	  const float cproton = sqrt((p*p+0.94*0.94)/(p*p+0.14*0.14));
 	  const float ckaon = sqrt((p*p+0.49*0.49)/(p*p+0.14*0.14));

--- a/Analysis/TauFinder/src/EvaluateTauFinder.cc
+++ b/Analysis/TauFinder/src/EvaluateTauFinder.cc
@@ -194,7 +194,7 @@ void EvaluateTauFinder::processEvent( LCEvent * evt )
       HelixClass *mc_helix = new HelixClass();
       for(int k=0; k < nT; k++) 
 	{
-	  ReconstructedParticle *tau = dynamic_cast <ReconstructedParticle*>( colTau->getElementAt( k ) );
+	  ReconstructedParticle *tau = static_cast<ReconstructedParticle*>( colTau->getElementAt( k ) );
 	  const double *pvec=tau->getMomentum();
 	  double pt=sqrt(pvec[0]*pvec[0]+pvec[1]*pvec[1]);
 	  double p=sqrt(pvec[0]*pvec[0]+pvec[1]*pvec[1]+pvec[2]*pvec[2]);
@@ -227,7 +227,7 @@ void EvaluateTauFinder::processEvent( LCEvent * evt )
 	  
 // 	  for (int icomp=0; icomp<3; ++icomp) {
 // 	    mom[icomp]=(float)tau->getMomentum()[icomp];
-// 	    VertexImpl *vtx=dynamic_cast<VertexImpl*>(tau->getStartVertex());
+// 	    VertexImpl *vtx=static_cast<VertexImpl*>(tau->getStartVertex());
 // 	    if(vtx)
 // 	      {
 // 		const float *vpos=vtx->getPosition();
@@ -268,13 +268,13 @@ void EvaluateTauFinder::processEvent( LCEvent * evt )
 	      EVENT::LCObjectVec relobjFROM = relationNavigatorTau->getRelatedToObjects(tau);
 	      for(unsigned int o=0;o<relobjFROM.size();o++)
 		{
-		  ReconstructedParticle *rec=dynamic_cast <ReconstructedParticle*>(relobjFROM[o]);
+		  ReconstructedParticle *rec=static_cast<ReconstructedParticle*>(relobjFROM[o]);
 		  if(relationNavigatorPFOMC)
 		    {
 		      EVENT::LCObjectVec relobjMC = relationNavigatorPFOMC->getRelatedToObjects(rec);
 		      for(unsigned int m=0;m<relobjMC.size();m++)
 			{
-			  MCParticle *mc=dynamic_cast <MCParticle*>(relobjMC[m]);
+			  MCParticle *mc=static_cast<MCParticle*>(relobjMC[m]);
 			  //check whether particles parent is really a tau:
 			  MCParticle *dummy=mc;
 			  MCParticle *parent=mc;
@@ -339,13 +339,13 @@ void EvaluateTauFinder::processEvent( LCEvent * evt )
 		  int d1=0,d2=0,pdg=0;
 		  for(unsigned int o=0;o<relobjFROM.size();o++)
 		    {
-		      ReconstructedParticle *rec=dynamic_cast <ReconstructedParticle*>(relobjFROM[o]);
+		      ReconstructedParticle *rec=static_cast<ReconstructedParticle*>(relobjFROM[o]);
 		      if(relationNavigatorPFOMC)
 			{
 			  EVENT::LCObjectVec relobj = relationNavigatorPFOMC->getRelatedToObjects(rec);
 			  for(unsigned int m=0;m<relobj.size();m++)
 			    {
-			      MCParticle *mc=dynamic_cast <MCParticle*>(relobj[m]);
+			      MCParticle *mc=static_cast<MCParticle*>(relobj[m]);
 			      //need to catch broken relations in DST file for background particles
 			      if(mc==0)
 				continue;
@@ -394,7 +394,7 @@ void EvaluateTauFinder::processEvent( LCEvent * evt )
       HelixClass * helix = new HelixClass();
       for(int k=0; k < nMCP; k++) 
 	{
-	  MCParticle *particle = dynamic_cast<MCParticle*> (colMC->getElementAt(k) );
+	  MCParticle *particle = static_cast<MCParticle*>(colMC->getElementAt(k) );
 
 	  if(particle->getGeneratorStatus()==2 && fabs(particle->getPDG())==15 && particle->getDaughters().size()>1 )
 	    {
@@ -541,7 +541,7 @@ void EvaluateTauFinder::LoopDaughtersRelation(MCParticle *particle,LCRelationNav
 	      for(unsigned int o=0;o<relobjTO.size();o++)
 		{
 		  //relation to the reconstructed tau
-		  ReconstructedParticle *rec=dynamic_cast <ReconstructedParticle*>(relobjTO[o]);
+		  ReconstructedParticle *rec=static_cast<ReconstructedParticle*>(relobjTO[o]);
 		  EVENT::LCObjectVec relobj = relationNavigatorTau->getRelatedFromObjects(rec);
 		  if(relobj.size())
 		    relToTau=true;

--- a/Analysis/TauFinder/src/PrepareRECParticles.cc
+++ b/Analysis/TauFinder/src/PrepareRECParticles.cc
@@ -157,7 +157,7 @@ void PrepareRECParticles::processEvent( LCEvent * evt )
       int nMCP = colMC->getNumberOfElements();
       for(int k=0; k < nMCP; k++) 
 	{
-	  MCParticle *mc = dynamic_cast<MCParticle*> (colMC->getElementAt(k) );
+	  MCParticle *mc = static_cast<MCParticle*>(colMC->getElementAt(k));
 	  if(mc->getGeneratorStatus()==1)//only stable ones
 	    {
 	      //filter out the neutrinos and other invisibles
@@ -206,7 +206,7 @@ void PrepareRECParticles::processEvent( LCEvent * evt )
       int nt=colTrack->getNumberOfElements();
       for(int n=0;n<nt;n++)
 	{
-	  Track *tr=dynamic_cast <Track*>(colTrack->getElementAt(n));
+	  Track *tr=static_cast<Track*>(colTrack->getElementAt(n));
 	  ReconstructedParticleImpl *trec = new ReconstructedParticleImpl();
 	  //momentum of track assuming B along z
 	  double pt=fabs(_bField/tr->getOmega())*3e-4;

--- a/Analysis/TauFinder/src/TauFinder.cc
+++ b/Analysis/TauFinder/src/TauFinder.cc
@@ -494,7 +494,7 @@ bool TauFinder::FindTau(std::vector<ReconstructedParticle*> &Qvec,std::vector<Re
     }
   double OpAngleMax=0;
   //find a good tauseed, check impact parameter 
-  ReconstructedParticle *tauseed;
+  ReconstructedParticle *tauseed=NULL;
   std::vector<ReconstructedParticle*>::iterator iterS=Qvec.begin();
   for ( unsigned int s=0; s<Qvec.size() ; s++ )
     {

--- a/Analysis/TauFinder/src/TauFinder.cc
+++ b/Analysis/TauFinder/src/TauFinder.cc
@@ -183,7 +183,7 @@ void TauFinder::processEvent( LCEvent * evt )
   
       for (int i = 0; i < nRCP; i++) 
 	{
-	  ReconstructedParticle *particle = dynamic_cast <ReconstructedParticle*>( colRECO->getElementAt( i ) );
+	  ReconstructedParticle *particle = static_cast<ReconstructedParticle*>( colRECO->getElementAt( i ) );
 	  double pt=sqrt(particle->getMomentum()[0]*particle->getMomentum()[0]
 			 +particle->getMomentum()[1]*particle->getMomentum()[1]);
 	  double Cos_T  = fabs(particle->getMomentum()[2]) / sqrt(pow(particle->getMomentum()[0],2)+pow(particle->getMomentum()[1],2) + pow(particle->getMomentum()[2],2));
@@ -306,7 +306,7 @@ void TauFinder::processEvent( LCEvent * evt )
       int erasecount=0;
       for ( unsigned int t=0; t<tauRecvec.size() ; t++ )
 	{
-	  ReconstructedParticleImpl *tau=dynamic_cast<ReconstructedParticleImpl*>(tauRecvec[t]);
+	  ReconstructedParticleImpl *tau=static_cast<ReconstructedParticleImpl*>(tauRecvec[t]);
 	  const double *mom=tau->getMomentum();
 	  double pt_tau=sqrt(mom[0]*mom[0]+mom[1]*mom[1]);
 	  double phi=180./TMath::Pi()*atan(mom[1]/mom[0]);
@@ -316,7 +316,7 @@ void TauFinder::processEvent( LCEvent * evt )
 	  for ( unsigned int t2=t+1; t2<tauRecvec.size() ; t2++ )
 	    {
 	      iterC=tauRecvec.begin()+t2;
-	      ReconstructedParticleImpl *taun=dynamic_cast<ReconstructedParticleImpl*>(tauRecvec[t2]);
+	      ReconstructedParticleImpl *taun=static_cast<ReconstructedParticleImpl*>(tauRecvec[t2]);
 	      
 	      const double *momn=taun->getMomentum();
 	      angle=acos((mom[0]*momn[0]+mom[1]*momn[1]+mom[2]*momn[2])/
@@ -390,7 +390,7 @@ void TauFinder::processEvent( LCEvent * evt )
 		      EVENT::LCObjectVec relobjFROM = relationNavigator->getRelatedToObjects(taun);
 		      for(unsigned int o=0;o<relobjFROM.size();o++)
 			{
-			  ReconstructedParticle *rec=dynamic_cast <ReconstructedParticle*>(relobjFROM[o]);
+			  ReconstructedParticle *rec=static_cast<ReconstructedParticle*>(relobjFROM[o]);
 			  LCRelationImpl *rel = new LCRelationImpl(tau,rec);
 			  relationcol->addElement( rel );
 			}
@@ -410,7 +410,7 @@ void TauFinder::processEvent( LCEvent * evt )
   int erasecount=0;
   for ( unsigned int t=0; t<tauRecvec.size() ; t++ )
     {
-      ReconstructedParticleImpl *tau=dynamic_cast<ReconstructedParticleImpl*>(tauRecvec[t]);
+      ReconstructedParticleImpl *tau=static_cast<ReconstructedParticleImpl*>(tauRecvec[t]);
       double E_iso=0;
       int nparticles=0;
       const double *pvec_tau=tau->getMomentum();
@@ -433,7 +433,7 @@ void TauFinder::processEvent( LCEvent * evt )
       //isolation
       for ( unsigned int s=0; s<Avector.size() ; s++ )
 	{
-	  ReconstructedParticle *track=dynamic_cast<ReconstructedParticle*>(Avector[s]);
+	  ReconstructedParticle *track=static_cast<ReconstructedParticle*>(Avector[s]);
 	  const double *pvec=track->getMomentum();
 	  double angle=acos((pvec[0]*pvec_tau[0]+pvec[1]*pvec_tau[1]+pvec[2]*pvec_tau[2])/
 			    (sqrt(pvec[0]*pvec[0]+pvec[1]*pvec[1]+pvec[2]*pvec[2])*
@@ -498,7 +498,7 @@ bool TauFinder::FindTau(std::vector<ReconstructedParticle*> &Qvec,std::vector<Re
   std::vector<ReconstructedParticle*>::iterator iterS=Qvec.begin();
   for ( unsigned int s=0; s<Qvec.size() ; s++ )
     {
-      tauseed=dynamic_cast<ReconstructedParticle*>(Qvec[s]);
+      tauseed=static_cast<ReconstructedParticle*>(Qvec[s]);
       float mom[3];
       for (int icomp=0; icomp<3; ++icomp) 
 	mom[icomp]=(float)tauseed->getMomentum()[icomp];
@@ -546,7 +546,7 @@ bool TauFinder::FindTau(std::vector<ReconstructedParticle*> &Qvec,std::vector<Re
   std::vector<ReconstructedParticle*>::iterator iterQ=Qvec.begin();
   for (unsigned int s=0; s<Qvec.size() ; s++ )
     {
-      ReconstructedParticle *track=dynamic_cast<ReconstructedParticle*>(Qvec[s]);
+      ReconstructedParticle *track=static_cast<ReconstructedParticle*>(Qvec[s]);
 
       const double *pvec=track->getMomentum();
       double angle=acos((pvec[0]*pvec_tau[0]+pvec[1]*pvec_tau[1]+pvec[2]*pvec_tau[2])/


### PR DESCRIPTION

Needs ilcsoft/MarlinUtil#4

BEGINRELEASENOTES
- CLICPfoSelector: remove dependency on GEAR File; simplify calculation of TimeAtECal by using trackState at Calorimeter
- CLICPfoSelector: fix coverity defect
- TauFinder: fix coverity defects; use streamlog instead of cout

ENDRELEASENOTES