### PR TITLE
read parameters from dd4hep, fix iterator in tau candidate quality loop

### DIFF
--- a/Analysis/TauFinder/src/PrepareRECParticles.cc
+++ b/Analysis/TauFinder/src/PrepareRECParticles.cc
@@ -25,8 +25,8 @@ using namespace std;
 #include "IMPL/LCFlagImpl.h" 
 #include "UTIL/LCRelationNavigator.h"
 
-#include <gear/GEAR.h>
-#include <gear/BField.h>
+#include "DD4hep/LCDD.h"
+#include "DD4hep/DD4hepUnits.h"
 #include <marlin/Global.h>
 #include "HelixClass.h"
 
@@ -111,7 +111,11 @@ void PrepareRECParticles::init()
   
   // usually a good idea to
   printParameters() ;
-  _bField = Global::GEAR->getBField().at( gear::Vector3D( 0., 0., 0.) ).z() ;
+  DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
+  const double position[3]={0,0,0}; // position to calculate magnetic field at (the origin in this case)
+  double magneticFieldVector[3]={0,0,0}; // initialise object to hold magnetic field
+  lcdd.field().magneticField(position,magneticFieldVector); // get the magnetic field vector from DD4hep
+  _bField = magneticFieldVector[2]/dd4hep::tesla; // z component at (0,0,0)
   _nRun = 0 ;
   _nEvt = 0 ;
    

--- a/Analysis/TauFinder/src/PrepareRECParticles.cc
+++ b/Analysis/TauFinder/src/PrepareRECParticles.cc
@@ -25,8 +25,7 @@ using namespace std;
 #include "IMPL/LCFlagImpl.h" 
 #include "UTIL/LCRelationNavigator.h"
 
-#include "DD4hep/LCDD.h"
-#include "DD4hep/DD4hepUnits.h"
+#include <marlinutil/GeometryUtil.h>
 #include <marlin/Global.h>
 #include "HelixClass.h"
 
@@ -111,11 +110,7 @@ void PrepareRECParticles::init()
   
   // usually a good idea to
   printParameters() ;
-  DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
-  const double position[3]={0,0,0}; // position to calculate magnetic field at (the origin in this case)
-  double magneticFieldVector[3]={0,0,0}; // initialise object to hold magnetic field
-  lcdd.field().magneticField(position,magneticFieldVector); // get the magnetic field vector from DD4hep
-  _bField = magneticFieldVector[2]/dd4hep::tesla; // z component at (0,0,0)
+  _bField = MarlinUtil::getBzAtOrigin();
   _nRun = 0 ;
   _nEvt = 0 ;
    

--- a/Analysis/TauFinder/src/TauFinder.cc
+++ b/Analysis/TauFinder/src/TauFinder.cc
@@ -462,8 +462,7 @@ void TauFinder::processEvent( LCEvent * evt )
       else
 	{
 	  reccol->addElement(tau);  
-	    streamlog_out(DEBUG) << "Tau "<<tau->getEnergy()<<" "<<QTvec[t+erasecount]<<" "<<NTvec[t+erasecount]<<endl;
-	  if(QTvec[t+erasecount]>4)
+	  streamlog_out(DEBUG) << "Tau "<<tau->getEnergy()<<" "<<QTvec[t+erasecount]<<" "<<NTvec[t+erasecount]<<endl;	  
 	  iter++;
 	}
     }


### PR DESCRIPTION

BEGINRELEASENOTES
- read magnetic field from dd4hep in taufinder particle preparator
- remove leftover condition for former printout of the taufinder, which prevents the desired increment of the iterator, and thus deletes wrong taucandidates when filling the reconstructed tau's 
ENDRELEASENOTES