### PR TITLE
 Set default from 'ON' to 'OFF' to build MarlinReco fortran sources.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ SET( ENV{CFLAGS} "-w -ansi -pedantic $ENV{CFLAGS}" ) # -w suppress all warning m
 
 ####################################################################################################
 
-OPTION( MARLINRECO_FORTRAN "Set to ON to build MarlinReco fortran sources" ON )
+OPTION( MARLINRECO_FORTRAN "Set to ON to build MarlinReco fortran sources" OFF )
 
 # project name
 IF( MARLINRECO_FORTRAN )


### PR DESCRIPTION

BEGINRELEASENOTES
- Set default from 'ON' to 'OFF' to build MarlinReco fortran sources.
- It could be switch on in the release-ilcsoft.cfg if you want.
- https://github.com/iLCSoft/iLCInstall/blob/master/releases/HEAD/release-ilcsoft.cfg#L116

ENDRELEASENOTES