### PR TITLE
Fix duplicate parameters

### DIFF
--- a/Analysis/TauFinder/src/PrepareRECParticles.cc
+++ b/Analysis/TauFinder/src/PrepareRECParticles.cc
@@ -81,7 +81,7 @@ PrepareRECParticles::PrepareRECParticles() : Processor("PrepareRECParticles")
                             std::string("MCParticles_tau"));
   
   registerOutputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-                            "RecCollection",
+                            "RecCollection_Tracks",
                             "Collection of Rec Particles for TauFinder",
                             _outcolTracks ,
                             std::string("Tracks_tau"));

--- a/Tracking/V0Finder/src/V0Finder.cc
+++ b/Tracking/V0Finder/src/V0Finder.cc
@@ -88,11 +88,13 @@ V0Finder::V0Finder() : Processor("V0Finder") {
 			     "Minimum radius in xy plane for photon candidate",
 			     _rxyCutGamma,
 			     float(10.0));
+
   registerProcessorParameter("RxyCutK0S",
 			     "Minimum radius in xy plane for K0S candidate",
 			     _rxyCutK0S,
 			     float(30.0));
-  registerProcessorParameter("RxyCutGamma",
+
+  registerProcessorParameter("RxyCutLambda",
 			     "Minimum radius in xy plane for Lambda0 candidate",
 			     _rxyCutLambda,
 			     float(50.0));


### PR DESCRIPTION
These give tiny memory leaks spotted by valgrind, and also prevent configuration...

Should we add an exception in Marlin if two parameters have the same name?

BEGINRELEASENOTES
- TauFinder:: PrepareRecParticles: change second parameter with same name RecCollection --> RecCollection_Tracks
- V0Finder: Change second parameter to its correct Name RxyCutGamma --> RxyCutLambda

ENDRELEASENOTES