### PR TITLE
TauFinder: fix memory leak

### DIFF
--- a/Analysis/TauFinder/src/TauFinder.cc
+++ b/Analysis/TauFinder/src/TauFinder.cc
@@ -236,8 +236,6 @@ void TauFinder::processEvent( LCEvent * evt )
 	    chargedtracks++;
 	  else
 	    neutraltracks++;
-	  LCRelationImpl *rel = new LCRelationImpl(taurec,tau[tp]);
-	  relationcol->addElement( rel );
 	  taurec->addParticle(tau[tp]);
 	}
       
@@ -273,10 +271,16 @@ void TauFinder::processEvent( LCEvent * evt )
 	      double theta=180./TMath::Pi()*atan(pt_tau/fabs(mom[2])); 
 	      streamlog_out(DEBUG) <<"Tau candidate failed: minv="<<mass_inv<<"   pt="<<pt_tau<<" "<<E<<" Q trks:"<<chargedtracks<<" N trks:"<<neutraltracks<<" "<<phi<<" "<<theta<<endl;
 	    }
+	  delete taurec;
 	  continue;
 	}
       else
 	++iterT;
+
+      for(unsigned int tp=0;tp<tau.size();tp++) {
+	LCRelationImpl *rel = new LCRelationImpl(taurec,tau[tp]);
+	relationcol->addElement( rel );
+      }
       
       int pdg=15;
       if(charge<0)


### PR DESCRIPTION

delete ReconstructedParticleImpl object if it fails cuts and is not added to vector to be treated later
Move adding of relationships after we know whether to keep the particle or not so we do not have dangling pointer in the relationships

BEGINRELEASENOTES
- TauFinder: fix memory leak (few kB/event)

ENDRELEASENOTES