### PR TITLE
modify ECAL gap filling method

### DIFF
--- a/CaloDigi/Realistic/include/BruteForceEcalGapFiller.h
+++ b/CaloDigi/Realistic/include/BruteForceEcalGapFiller.h
@@ -43,6 +43,13 @@ class BruteForceEcalGapFiller : public Processor {
   std::string _cellIDModuleString;
   std::string _cellIDStaveString;
 
+
+  float _interModuleNonlinearFactor;
+  float _intraModuleNonlinearFactor;
+
+  float _interModuleFactor;
+  float _intraModuleFactor;
+
   LCFlagImpl _flag;
 
   enum {ECALENDCAP, ECALBARREL};

--- a/CaloDigi/Realistic/src/BruteForceEcalGapFiller.cc
+++ b/CaloDigi/Realistic/src/BruteForceEcalGapFiller.cc
@@ -65,6 +65,27 @@ BruteForceEcalGapFiller::BruteForceEcalGapFiller( )  : Processor( "BruteForceEca
 			     _interModuleDist,
 			     float (7.)
 			     );
+
+  registerProcessorParameter("interModuleNonlinearFactor",
+			     "nonlin factor f: E_corr = interModuleCorrectionFactor*(1/f)*log(1 + f*E_calc)",
+			     _interModuleNonlinearFactor,
+			     float (1.) );
+
+  registerProcessorParameter("intraModuleNonlinearFactor",
+			     "nonlin factor f: E_corr = intraModuleCorrectionFactor*(1/f)*log(1 + f*E_calc)",
+			     _intraModuleNonlinearFactor,
+			     float (1.) );
+
+  registerProcessorParameter("interModuleCorrectionFactor",
+			     "factor applied to calculated energy of inter-module gap hits",
+			     _interModuleFactor,
+			     float (0.35) );
+
+  registerProcessorParameter("intraModuleCorrectionFactor",
+			     "factor applied to calculated energy of intra-module gap hits",
+			     _intraModuleFactor,
+			     float (1.0) );
+
 }
 
 
@@ -272,7 +293,7 @@ void BruteForceEcalGapFiller::addIntraModuleGapHits( LCCollectionVec* newcol ) {
 		CHT::CaloID   cht_id   = CHT::ecal;
 		CHT::Layout   cht_lay  = (_currentLayout == ECALBARREL) ? CHT::barrel : (_currentLayout == ECALENDCAP) ? CHT::endcap : CHT::any;
 		CalorimeterHitImpl* newGapHit = new CalorimeterHitImpl();
-		newGapHit->setEnergy( extraEnergy );
+		newGapHit->setEnergy( _intraModuleFactor* std::log ( 1 + _intraModuleNonlinearFactor*extraEnergy )/_intraModuleNonlinearFactor );
 		newGapHit->setPosition( position );
 		newGapHit->setTime( mintime );
 		newGapHit->setType( CHT( cht_type , cht_id , cht_lay , il) );
@@ -359,7 +380,7 @@ void BruteForceEcalGapFiller::addInterModuleGapHits( LCCollectionVec* newcol ) {
 	      }
 	      if ( gap ) {
 
-		streamlog_out ( DEBUG1 ) << " addIntraModuleGapHits: found gap " << dist1d[0] << " " << dist1d[1] << " " << dist1d[2]<< endl;
+		streamlog_out ( DEBUG1 ) << " addInterModuleGapHits: found gap " << dist1d[0] << " " << dist1d[1] << " " << dist1d[2]<< endl;
 
 		float position[3]={0.};
 		for (int k=0; k<3; k++)
@@ -370,7 +391,7 @@ void BruteForceEcalGapFiller::addInterModuleGapHits( LCCollectionVec* newcol ) {
 		CHT::CaloID   cht_id   = CHT::ecal;
 		CHT::Layout   cht_lay  = (_currentLayout == ECALBARREL) ? CHT::barrel : (_currentLayout == ECALENDCAP) ? CHT::endcap : CHT::any;
 		CalorimeterHitImpl* newGapHit = new CalorimeterHitImpl();
-		newGapHit->setEnergy( extraEnergy );
+		newGapHit->setEnergy( _interModuleFactor* std::log ( 1 + _interModuleNonlinearFactor*extraEnergy )/_interModuleNonlinearFactor );
 		newGapHit->setPosition( position );
 		newGapHit->setTime( mintime );
 		newGapHit->setType( CHT( cht_type , cht_id , cht_lay , il) );


### PR DESCRIPTION
BEGINRELEASENOTES
- modify algorithm to fill ECAL gaps in BruteForceEcalGapFiller:
      - overall linear suppression gap hit energies [as was done in DBD]
      - additional logarithmic suppression to reduce large energy gap hits
      - separate parameters for (a) gaps between modules, and (b) gaps within modules
      - default values of new parameters seem reasonable for ILD_l4_v02 model

ENDRELEASENOTES