### PR TITLE
Dress electrons in IsolatedLeptonFinder

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,92 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     125
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+JavaScriptQuotes: Leave
+...

--- a/Analysis/IsolatedLeptonFinder/README
+++ b/Analysis/IsolatedLeptonFinder/README
@@ -4,6 +4,7 @@ IsolatedLeptonFinderProcessor:
 Authors:
   Ryo Yonamine <yonamine@post.kek.jp>
   Tomohiko Tanabe <tomohiko@icepp.s.u-tokyo.ac.jp>
+  Andreas Alexander Maier <andreas.alexander.maier@cern.ch>
 
 Description:
   This processor takes an input collection of ReconstructedParticle.
@@ -69,13 +70,13 @@ Description:
 
         The minimum and maximum values of Xt and Z can be specified.
         - JetIsolationVetoMinimumXt
-        - JetIsolationVetoMaximumXt 
+        - JetIsolationVetoMaximumXt
         - JetIsolationVetoMinimumZ
         - JetIsolationVetoMaximumZ
         Cuts on these vairables will be applied as veto of non-isolated
         leptons, applied as the AND requirement.
 
-        One needs to supply the jet collection name for jets which are 
+        One needs to supply the jet collection name for jets which are
         clustered before the isolated lepton finder runs.
         - JetCollection
         In general, this jet finder can be (and often should be)
@@ -129,5 +130,12 @@ Description:
      - ImpactParameterMaxZ0Significance
      - ImpactParameterMin3DSignificance
      - ImpactParameterMax3DSignificance
+
+  6) Optionally, close-by photons and low-energy leptons can be merged
+     into the lepton candidates, referred to as lepton dressing. The
+     lepton dressing can be controlled via the WhichLeptons parameter.
+     The maximum merging angles for both, leptons and photons can be
+     set. When merging leptons, the lower energy lepton within the
+     defined cone is merged into the higher energy lepton.
 
 [End of Description]

--- a/Analysis/IsolatedLeptonFinder/example/steer.xml
+++ b/Analysis/IsolatedLeptonFinder/example/steer.xml
@@ -89,4 +89,22 @@
   <!--Maximum impact parameter in 3D-->
   <parameter name="ImpactParameterMax3D" type="float">0.01 </parameter>
 
+  <!-------------------------------->
+  <!-- Lepton dressing parameters -->
+  <!-------------------------------->
+
+  <!-- Use DRESSED or UNDRESSED lepton algorithms -->
+  <parameter name="WhichLeptons" type="string">UNDRESSED</parameter>
+
+  <!-- Merge close-by electrons into higher energy lepton -->
+  <parameter name="MergeCloseElectrons" type="bool">true</parameter>
+
+  <!-- Half-angle (in degrees) of the cone used for lepton merging -->
+  <parameter name="MergeLeptonConeAngle" type="float">2</parameter>
+  <!-- Half-angle (in degrees) of the cone used for lepton dressing with photons -->
+  <parameter name="DressPhotonConeAngle" type="float">1</parameter>
+
+  <!-- Use Pandora particle IDs for algorithm -->
+  <parameter name="UsePandoraIDs" type="bool">false</parameter>
+
 </processor>

--- a/Analysis/IsolatedLeptonFinder/example/steer.xml
+++ b/Analysis/IsolatedLeptonFinder/example/steer.xml
@@ -93,8 +93,8 @@
   <!-- Lepton dressing parameters -->
   <!-------------------------------->
 
-  <!-- Use DRESSED or UNDRESSED lepton algorithms -->
-  <parameter name="WhichLeptons" type="string">UNDRESSED</parameter>
+  <!-- Dress leptons with close-by particles -->
+  <parameter name="UseDressedLeptons" type="bool">false</parameter>
 
   <!-- Merge close-by electrons into higher energy lepton -->
   <parameter name="MergeCloseElectrons" type="bool">true</parameter>

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -161,9 +161,9 @@ class IsolatedLeptonFinderProcessor : public Processor {
 
 
 		/** If set to true, uses lepton dressing */
-		float _dressPhotonCosConeAngle = 0;
-		float _mergeLeptonCosConeAngle = 0;
 		std::string _whichLeptons = "UNDRESSED";
+		float _dressPhotonConeAngle = 0;
+		float _mergeLeptonConeAngle = 0;
 		std::vector<int> _dressedPFOs {};
 
 		/** If set to true, uses Pandora particle IDs */

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -161,9 +161,9 @@ class IsolatedLeptonFinderProcessor : public Processor {
 
 
 		/** If set to true, uses lepton dressing */
-		bool _useLeptonDressing = false;
 		float _dressPhotonCosConeAngle = 0;
 		float _mergeLeptonCosConeAngle = 0;
+		std::string _whichLeptons = "UNDRESSED";
 		std::vector<int> _dressedPFOs {};
 
 		/** If set to true, uses Pandora particle IDs */

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -31,11 +31,11 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		virtual Processor*  newProcessor() { return new IsolatedLeptonFinderProcessor ; }
 
 		IsolatedLeptonFinderProcessor() ;
+		IsolatedLeptonFinderProcessor(const IsolatedLeptonFinderProcessor &);
+		IsolatedLeptonFinderProcessor & operator = (const IsolatedLeptonFinderProcessor &);
 
 		virtual void init() ;
-		virtual void processRunHeader( LCRunHeader* run ) ;
-		virtual void processEvent( LCEvent * evt ) ; 
-		virtual void check( LCEvent * evt ) ; 
+		virtual void processEvent( LCEvent * evt ) ;
 		virtual void end() ;
 
 	protected:
@@ -55,10 +55,10 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		bool IsLepton( ReconstructedParticle* pfo ) ;
 
 		/** Returns true if it passes impact parameter cuts */
-		bool PassesImpactParameterCuts( ReconstructedParticle* pfo ) ; 
+		bool PassesImpactParameterCuts( ReconstructedParticle* pfo ) ;
 
 		/** Returns true if it passes impact parameter significance cuts */
-		bool PassesImpactParameterSignificanceCuts( ReconstructedParticle* pfo ) ; 
+		bool PassesImpactParameterSignificanceCuts( ReconstructedParticle* pfo ) ;
 
 		/** Calculates the cone energy */
 		float getConeEnergy( ReconstructedParticle* pfo ) ;
@@ -67,73 +67,73 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		void getCalEnergy( ReconstructedParticle* pfo , float* cale) ;
 
 		/** Input collection */
-		std::string _inputPFOsCollection;
+		std::string _inputPFOsCollection{};
 
 		/** Output collection (all input with isolated leptons removed) */
-		std::string _outputPFOsRemovedIsoLepCollection;
+		std::string _outputPFOsRemovedIsoLepCollection{};
 
 		/** Output collection of isolated leptons */
-		std::string _outputIsoLepCollection;
+		std::string _outputIsoLepCollection{};
 
 		/** Output collection (all input with dressed isolated leptons removed) */
-		std::string _outputPFOsRemovedDressedIsoLepCollection;
+		std::string _outputPFOsRemovedDressedIsoLepCollection{};
 
 		/** Output collection of dressed isolated leptons */
-		std::string _outputDressedIsoLepCollection;
+		std::string _outputDressedIsoLepCollection{};
 
 		LCCollection* _pfoCol=nullptr;
 		float _cosConeAngle = 0;
 
 		/** If set to true, uses PID cuts */
-		bool _usePID;
-		float _electronMinEnergyDepositByMomentum;
-		float _electronMaxEnergyDepositByMomentum;
-		float _electronMinEcalToHcalFraction;
-		float _electronMaxEcalToHcalFraction;
-		float _muonMinEnergyDepositByMomentum;
-		float _muonMaxEnergyDepositByMomentum;
-		float _muonMinEcalToHcalFraction;
-		float _muonMaxEcalToHcalFraction;
+		bool _usePID = false;
+		float _electronMinEnergyDepositByMomentum = 0;
+		float _electronMaxEnergyDepositByMomentum = 0;
+		float _electronMinEcalToHcalFraction = 0;
+		float _electronMaxEcalToHcalFraction = 0;
+		float _muonMinEnergyDepositByMomentum = 0;
+		float _muonMaxEnergyDepositByMomentum = 0;
+		float _muonMinEcalToHcalFraction = 0;
+		float _muonMaxEcalToHcalFraction = 0;
 
 		/** If set to true, uses impact parameter cuts */
-		bool _useImpactParameter;
-		float _minD0;
-		float _maxD0;
-		float _minZ0;
-		float _maxZ0;
-		float _minR0;
-		float _maxR0;
+		bool _useImpactParameter = false;
+		float _minD0 = 0;
+		float _maxD0 = 0;
+		float _minZ0 = 0;
+		float _maxZ0 = 0;
+		float _minR0 = 0;
+		float _maxR0 = 0;
 
 		/** If set to true, uses impact parameter significance cuts */
-		bool _useImpactParameterSignificance;
-		float _minD0Sig;
-		float _maxD0Sig;
-		float _minZ0Sig;
-		float _maxZ0Sig;
-		float _minR0Sig;
-		float _maxR0Sig;
+		bool _useImpactParameterSignificance = false;
+		float _minD0Sig = 0;
+		float _maxD0Sig = 0;
+		float _minZ0Sig = 0;
+		float _maxZ0Sig = 0;
+		float _minR0Sig = 0;
+		float _maxR0Sig = 0;
 
 		/** If set to true, uses rectangular cuts for isolation */
-		bool _useRectangularIsolation;
-		float _isoMinTrackEnergy;
-		float _isoMaxTrackEnergy;
-		float _isoMinConeEnergy;
-		float _isoMaxConeEnergy;
+		bool _useRectangularIsolation = false;
+		float _isoMinTrackEnergy = 0;
+		float _isoMaxTrackEnergy = 0;
+		float _isoMinConeEnergy = 0;
+		float _isoMaxConeEnergy = 0;
 
 		/** If set to true, uses polynomial cuts for isolation */
-		bool _usePolynomialIsolation;
-		float _isoPolynomialA;
-		float _isoPolynomialB;
-		float _isoPolynomialC;
+		bool _usePolynomialIsolation = false;
+		float _isoPolynomialA = 0;
+		float _isoPolynomialB = 0;
+		float _isoPolynomialC = 0;
 
 		/** If set to true, uses jet-based isolation (LAL algorithm) */
-		bool _useJetIsolation;
-		std::string _jetCollectionName;
-		std::map<ReconstructedParticle*,ReconstructedParticle*> _rpJetMap;
-		float _jetIsoVetoMinXt;
-		float _jetIsoVetoMaxXt;
-		float _jetIsoVetoMinZ;
-		float _jetIsoVetoMaxZ;
+		bool _useJetIsolation = false;
+		std::string _jetCollectionName {};
+		std::map<ReconstructedParticle*,ReconstructedParticle*> _rpJetMap {};
+		float _jetIsoVetoMinXt = 0;
+		float _jetIsoVetoMaxXt = 0;
+		float _jetIsoVetoMinZ = 0;
+		float _jetIsoVetoMaxZ = 0;
 } ;
 
 #endif

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -168,7 +168,6 @@ class IsolatedLeptonFinderProcessor : public marlin::Processor {
 		bool _mergeCloseElectrons = false;
 		float _dressPhotonConeAngle = 0;
 		float _mergeLeptonConeAngle = 0;
-		std::vector<int> _dressedPFOs {};
 
 		/** If set to true, uses Pandora particle IDs */
 		bool _usePandoraIDs = false;

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -56,8 +56,14 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		/** Returns true if charged */
 		bool IsCharged( ReconstructedParticle* pfo ) ;
 
-		/** Returns true if it passes lepton ID cuts */
+		/** Returns true if it passes muon or electron ID cuts */
 		bool IsLepton( ReconstructedParticle* pfo ) ;
+
+		/** Returns true if it passes electron ID cuts */
+		bool IsElectron( ReconstructedParticle* pfo ) ;
+
+		/** Returns true if it passes muon ID cuts */
+		bool IsMuon( ReconstructedParticle* pfo ) ;
 
 		/** Returns true if it passes impact parameter cuts */
 		bool PassesImpactParameterCuts( ReconstructedParticle* pfo ) ;

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -40,6 +40,9 @@ class IsolatedLeptonFinderProcessor : public Processor {
 
 	protected:
 
+		/** Returns true if pfo is a lepton */
+		bool IsGoodLepton( ReconstructedParticle* pfo ) ;
+
 		/** Returns true if pfo is an isolated lepton */
 		bool IsIsolatedLepton( ReconstructedParticle* pfo ) ;
 
@@ -134,6 +137,11 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		float _jetIsoVetoMaxXt = 0;
 		float _jetIsoVetoMinZ = 0;
 		float _jetIsoVetoMaxZ = 0;
+
+
+		/** If set to true, uses lepton dressing */
+		bool _useLeptonDressing = false;
+		float _dressCosConeAngle = 0;
 } ;
 
 #endif

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -65,6 +65,9 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		/** Returns true if it passes muon ID cuts */
 		bool IsMuon( ReconstructedParticle* pfo ) ;
 
+		/** Returns true if it passes photon ID cuts */
+		bool IsPhoton( ReconstructedParticle* pfo ) ;
+
 		/** Returns true if it passes impact parameter cuts */
 		bool PassesImpactParameterCuts( ReconstructedParticle* pfo ) ;
 

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -165,6 +165,7 @@ class IsolatedLeptonFinderProcessor : public Processor {
 
 		/** If set to true, uses lepton dressing */
 		std::string _whichLeptons = "UNDRESSED";
+		bool _mergeCloseElectrons = false;
 		float _dressPhotonConeAngle = 0;
 		float _mergeLeptonConeAngle = 0;
 		std::vector<int> _dressedPFOs {};

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -23,10 +23,8 @@
 #include "IMPL/ReconstructedParticleImpl.h"
 #include <UTIL/LCRelationNavigator.h>
 
-using namespace lcio ;
-using namespace marlin ;
 
-class IsolatedLeptonFinderProcessor : public Processor {
+class IsolatedLeptonFinderProcessor : public marlin::Processor {
 
 	public:
 

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -33,8 +33,9 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		virtual Processor*  newProcessor() { return new IsolatedLeptonFinderProcessor ; }
 
 		IsolatedLeptonFinderProcessor() ;
-		IsolatedLeptonFinderProcessor(const IsolatedLeptonFinderProcessor &);
-		IsolatedLeptonFinderProcessor & operator = (const IsolatedLeptonFinderProcessor &);
+
+		IsolatedLeptonFinderProcessor(const IsolatedLeptonFinderProcessor &) = delete;
+		IsolatedLeptonFinderProcessor & operator = (const IsolatedLeptonFinderProcessor &) = delete;
 
 		virtual void init() ;
 		virtual void processEvent( LCEvent * evt ) ;

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -166,6 +166,8 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		float _mergeLeptonCosConeAngle = 0;
 		std::vector<int> _dressedPFOs {};
 
+		/** If set to true, uses Pandora particle IDs */
+		bool _usePandoraIDs = false;
 } ;
 
 #endif

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -75,8 +75,14 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		/** Output collection of isolated leptons */
 		std::string _outputIsoLepCollection;
 
-		LCCollection* _pfoCol;
-		float _cosConeAngle;
+		/** Output collection (all input with dressed isolated leptons removed) */
+		std::string _outputPFOsRemovedDressedIsoLepCollection;
+
+		/** Output collection of dressed isolated leptons */
+		std::string _outputDressedIsoLepCollection;
+
+		LCCollection* _pfoCol=nullptr;
+		float _cosConeAngle = 0;
 
 		/** If set to true, uses PID cuts */
 		bool _usePID;

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -11,6 +11,7 @@
 #ifndef IsolatedLeptonFinderProcessor_h
 #define IsolatedLeptonFinderProcessor_h 1
 
+#include <algorithm>
 #include <string>
 #include <map>
 
@@ -64,8 +65,15 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		/** Returns true if it passes impact parameter significance cuts */
 		bool PassesImpactParameterSignificanceCuts( ReconstructedParticle* pfo ) ;
 
+		/** Helper function to order PFOS by energy */
+		bool isMoreEnergetic (int i, int j) {
+			ReconstructedParticle* pfo_i = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
+			ReconstructedParticle* pfo_j = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(j) );
+			return (pfo_i->getEnergy()>pfo_j->getEnergy());
+		}
+
 		/** Adds photons around lepton to four vector */
-		void dressWithPhotons( ReconstructedParticleImpl* pfo ) ;
+		void dressLepton( ReconstructedParticleImpl* pfo, int PFO_idx ) ;
 
 		/** Calculates the cone energy */
 		float getConeEnergy( ReconstructedParticle* pfo, bool omitDressed) ;
@@ -145,7 +153,8 @@ class IsolatedLeptonFinderProcessor : public Processor {
 
 		/** If set to true, uses lepton dressing */
 		bool _useLeptonDressing = false;
-		float _dressCosConeAngle = 0;
+		float _dressPhotonCosConeAngle = 0;
+		float _mergeLeptonCosConeAngle = 0;
 		std::vector<int> _dressedPFOs {};
 
 } ;

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -164,7 +164,7 @@ class IsolatedLeptonFinderProcessor : public marlin::Processor {
 
 
 		/** If set to true, uses lepton dressing */
-		std::string _whichLeptons = "UNDRESSED";
+		bool _useDressedLeptons = false;
 		bool _mergeCloseElectrons = false;
 		float _dressPhotonConeAngle = 0;
 		float _mergeLeptonConeAngle = 0;

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -19,6 +19,7 @@
 
 #include <EVENT/ReconstructedParticle.h>
 #include <EVENT/MCParticle.h>
+#include "IMPL/ReconstructedParticleImpl.h"
 #include <UTIL/LCRelationNavigator.h>
 
 using namespace lcio ;
@@ -44,11 +45,11 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		bool IsGoodLepton( ReconstructedParticle* pfo ) ;
 
 		/** Returns true if pfo is an isolated lepton */
-		bool IsIsolatedLepton( ReconstructedParticle* pfo ) ;
+		bool IsIsolatedLepton( ReconstructedParticle* pfo , bool omitDressed) ;
 
 		/** Returns true if isolated, as defined by the cone energy */
-		bool IsIsolatedRectangular( ReconstructedParticle* pfo ) ;
-		bool IsIsolatedPolynomial( ReconstructedParticle* pfo ) ;
+		bool IsIsolatedRectangular( ReconstructedParticle* pfo , bool omitDressed) ;
+		bool IsIsolatedPolynomial( ReconstructedParticle* pfo , bool omitDressed) ;
 		bool IsIsolatedJet( ReconstructedParticle* pfo ) ;
 
 		/** Returns true if charged */
@@ -63,8 +64,11 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		/** Returns true if it passes impact parameter significance cuts */
 		bool PassesImpactParameterSignificanceCuts( ReconstructedParticle* pfo ) ;
 
+		/** Adds photons around lepton to four vector */
+		void dressWithPhotons( ReconstructedParticleImpl* pfo ) ;
+
 		/** Calculates the cone energy */
-		float getConeEnergy( ReconstructedParticle* pfo ) ;
+		float getConeEnergy( ReconstructedParticle* pfo, bool omitDressed) ;
 
 		/** [0]:Ecal energy, [1]:Hcal energy */
 		void getCalEnergy( ReconstructedParticle* pfo , float* cale) ;
@@ -142,6 +146,8 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		/** If set to true, uses lepton dressing */
 		bool _useLeptonDressing = false;
 		float _dressCosConeAngle = 0;
+		std::vector<int> _dressedPFOs {};
+
 } ;
 
 #endif

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -90,6 +90,9 @@ class IsolatedLeptonFinderProcessor : public Processor {
 		/** [0]:Ecal energy, [1]:Hcal energy */
 		void getCalEnergy( ReconstructedParticle* pfo , float* cale) ;
 
+		/** Replace missing copy constructor by hand */
+		ReconstructedParticleImpl* CopyReconstructedParticle ( ReconstructedParticle* pfo ) ;
+
 		/** Input collection */
 		std::string _inputPFOsCollection{};
 

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -45,11 +45,11 @@ class IsolatedLeptonFinderProcessor : public marlin::Processor {
 		bool IsGoodLepton( ReconstructedParticle* pfo ) ;
 
 		/** Returns true if pfo is an isolated lepton */
-		bool IsIsolatedLepton( ReconstructedParticle* pfo , bool omitDressed) ;
+		bool IsIsolatedLepton( ReconstructedParticle* pfo) ;
 
 		/** Returns true if isolated, as defined by the cone energy */
-		bool IsIsolatedRectangular( ReconstructedParticle* pfo , bool omitDressed) ;
-		bool IsIsolatedPolynomial( ReconstructedParticle* pfo , bool omitDressed) ;
+		bool IsIsolatedRectangular( ReconstructedParticle* pfo) ;
+		bool IsIsolatedPolynomial( ReconstructedParticle* pfo) ;
 		bool IsIsolatedJet( ReconstructedParticle* pfo ) ;
 
 		/** Returns true if charged */
@@ -84,7 +84,7 @@ class IsolatedLeptonFinderProcessor : public marlin::Processor {
 		void dressLepton( ReconstructedParticleImpl* pfo, int PFO_idx ) ;
 
 		/** Calculates the cone energy */
-		float getConeEnergy( ReconstructedParticle* pfo, bool omitDressed) ;
+		float getConeEnergy( ReconstructedParticle* pfo) ;
 
 		/** [0]:Ecal energy, [1]:Hcal energy */
 		void getCalEnergy( ReconstructedParticle* pfo , float* cale) ;
@@ -109,6 +109,7 @@ class IsolatedLeptonFinderProcessor : public marlin::Processor {
 
 		LCCollection* _pfoCol=nullptr;
 		float _cosConeAngle = 0;
+		std::vector<ReconstructedParticle*> _workingList = {};
 
 		/** If set to true, uses PID cuts */
 		bool _usePID = false;

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -47,18 +47,6 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				_outputIsoLepCollection,
 				std::string("Isolep") );
 
-		registerOutputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-				"OutputCollectionWithoutDressedIsolatedLeptons",
-				"Copy of input collection but without the dressed isolated leptons",
-				_outputPFOsRemovedDressedIsoLepCollection,
-				std::string("PandoraPFOsWithoutDressedIsoLep") );
-
-		registerOutputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-				"OutputCollectionDressedIsolatedLeptons",
-				"Output collection of dressed isolated leptons",
-				_outputDressedIsoLepCollection,
-				std::string("DressedIsolep") );
-
 		registerProcessorParameter( "CosConeAngle",
 				"Cosine of the half-angle of the cone used in isolation criteria",
 				_cosConeAngle,
@@ -256,7 +244,7 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				float(0.6));
 
 		registerProcessorParameter( "WhichLeptons",
-				"Use DRESSED, UNDRESSED or BOTH lepton algorithms",
+				"Use DRESSED or UNDRESSED lepton algorithms",
 				_whichLeptons,
 				std::string("UNDRESSED"));
 
@@ -445,12 +433,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 
 	// Add PFOs to new collections
-	if (_whichLeptons == "BOTH"){
-		evt->addCollection( otPFOsRemovedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
-		evt->addCollection( otIsoLepCol.release(), _outputIsoLepCollection.c_str() );
-		evt->addCollection( otPFOsRemovedDressedIsoLepCol.release(), _outputPFOsRemovedDressedIsoLepCollection.c_str() );
-		evt->addCollection( otDressedIsoLepCol.release(), _outputDressedIsoLepCollection.c_str() );
-	}else if (_whichLeptons == "DRESSED"){
+	if (_whichLeptons == "DRESSED"){
 		evt->addCollection( otPFOsRemovedDressedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
 		evt->addCollection( otDressedIsoLepCol.release(), _outputIsoLepCollection.c_str() );
 	}else if (_whichLeptons == "UNDRESSED"){

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -48,7 +48,7 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				std::string("Isolep") );
 
 		registerOutputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-				"OutputCollectionWithoutDressedIsolatedLepton",
+				"OutputCollectionWithoutDressedIsolatedLeptons",
 				"Copy of input collection but without the dressed isolated leptons",
 				_outputPFOsRemovedDressedIsoLepCollection,
 				std::string("PandoraPFOsWithoutDressedIsoLep") );

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -377,14 +377,14 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	}
 
 	// PFO loop for filling remaining PFOs
-	for (int i = 0; i < _workingList.size(); i++ ) {
+	for (unsigned int i = 0; i < _workingList.size(); i++ ) {
 
 		// don't add leptons again
 		if (std::find(goodLeptonIndices.begin(), goodLeptonIndices.end(), i) != goodLeptonIndices.end()){
 			continue;
 		}
 
-		ReconstructedParticle* pfo_tmp = static_cast<ReconstructedParticle*>( _workingList->at(i) );
+		ReconstructedParticle* pfo_tmp = static_cast<ReconstructedParticle*>( _workingList.at(i) );
 		ReconstructedParticleImpl* pfo = CopyReconstructedParticle( pfo_tmp );
 
 		outPFOsRemovedDressedIsoLepCol->addElement( pfo );

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -504,7 +504,7 @@ bool IsolatedLeptonFinderProcessor::IsCharged( ReconstructedParticle* pfo ) {
 	return true;
 }
 
-bool IsolatedLeptonFinderProcessor::IsLepton( ReconstructedParticle* pfo ) {
+bool IsolatedLeptonFinderProcessor::IsElectron( ReconstructedParticle* pfo ) {
 
 	float CalE[2];
 	getCalEnergy( pfo , CalE );
@@ -515,20 +515,37 @@ bool IsolatedLeptonFinderProcessor::IsLepton( ReconstructedParticle* pfo ) {
 	double calSum = ecale+hcale;
 	double ecalFrac = calSum>0 ? ecale / calSum : 0;
 
-	// electron
 	if ( calByP >= _electronMinEnergyDepositByMomentum
 			&& calByP <= _electronMaxEnergyDepositByMomentum
 			&& ecalFrac >= _electronMinEcalToHcalFraction
 			&& ecalFrac <= _electronMaxEcalToHcalFraction )
 		return true;
 
-	// muon
+	return false;
+}
+bool IsolatedLeptonFinderProcessor::IsMuon( ReconstructedParticle* pfo ) {
+
+	float CalE[2];
+	getCalEnergy( pfo , CalE );
+	double ecale  = CalE[0];
+	double hcale  = CalE[1];
+	double p      = TVector3( pfo->getMomentum() ).Mag();
+	double calByP = p>0 ? (ecale + hcale)/p : 0;
+	double calSum = ecale+hcale;
+	double ecalFrac = calSum>0 ? ecale / calSum : 0;
+
 	if ( calByP >= _muonMinEnergyDepositByMomentum
 			&& calByP <= _muonMaxEnergyDepositByMomentum
 			&& ecalFrac >= _muonMinEcalToHcalFraction
 			&& ecalFrac <= _muonMaxEcalToHcalFraction )
 		return true;
 
+	return false;
+}
+bool IsolatedLeptonFinderProcessor::IsLepton( ReconstructedParticle* pfo ) {
+
+	if (IsElectron(pfo) || IsMuon(pfo))
+		return true;
 	return false;
 }
 

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -277,8 +277,8 @@ void IsolatedLeptonFinderProcessor::init() {
 
 void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
-	streamlog_out(MESSAGE) <<std::endl;
-	streamlog_out(MESSAGE) << "processing event: " << evt->getEventNumber() << "   in run:  " << evt->getRunNumber() << std::endl ;
+	streamlog_out(DEBUG) <<std::endl;
+	streamlog_out(DEBUG) << "processing event: " << evt->getEventNumber() << "   in run:  " << evt->getRunNumber() << std::endl ;
 
 	_rpJetMap.clear();
 	_workingList.clear();

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -466,7 +466,7 @@ void IsolatedLeptonFinderProcessor::dressLepton( ReconstructedParticleImpl* pfo,
 		ReconstructedParticle* pfo_dress = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 
 		// only add photons and electrons
-		bool isPhoton = (pfo_dress->getType() == 22);
+		bool isPhoton = IsPhoton(pfo_dress);
 		bool isElectron = (fabs(pfo_dress->getType()) == 11);
 		if (!isPhoton && !isElectron) continue;
 
@@ -504,6 +504,10 @@ bool IsolatedLeptonFinderProcessor::IsCharged( ReconstructedParticle* pfo ) {
 	return true;
 }
 
+bool IsolatedLeptonFinderProcessor::IsPhoton( ReconstructedParticle* pfo ) {
+	if ( pfo->getType() == 22 ) return true;
+	return false;
+}
 bool IsolatedLeptonFinderProcessor::IsElectron( ReconstructedParticle* pfo ) {
 
 	float CalE[2];

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -257,21 +257,18 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 	}
 
 
-void IsolatedLeptonFinderProcessor::init() { 
+void IsolatedLeptonFinderProcessor::init() {
 	streamlog_out(DEBUG) << "   init called  " << std::endl ;
 	printParameters() ;
 }
 
-void IsolatedLeptonFinderProcessor::processRunHeader( LCRunHeader* run) { 
-} 
-
-void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) { 
+void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 	_rpJetMap.clear();
 
 	_pfoCol = evt->getCollection( _inputPFOsCollection ) ;
 
-	// Output PFOs removed isolated leptons 
+	// Output PFOs removed isolated leptons
 	LCCollectionVec* otPFOsRemovedIsoLepCol = new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) ;
 	otPFOsRemovedIsoLepCol->setSubset(true) ;
 
@@ -297,14 +294,14 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	for (int i = 0; i < npfo; i++ ) {
 		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 
-		if ( IsIsolatedLepton( pfo ) ) 
+		if ( IsIsolatedLepton( pfo ) )
 			otIsoLepCol->addElement( pfo );
-		else 
+		else
 			otPFOsRemovedIsoLepCol->addElement( pfo );
 	}
 
-	streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber() 
-		<< "   in run:  " << evt->getRunNumber() 
+	streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber()
+		<< "   in run:  " << evt->getRunNumber()
 		<< std::endl ;
 
 	// Add PFOs to new collection
@@ -312,10 +309,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	evt->addCollection( otIsoLepCol, _outputIsoLepCollection.c_str() );
 }
 
-void IsolatedLeptonFinderProcessor::check( LCEvent * evt ) { 
-}
-
-void IsolatedLeptonFinderProcessor::end() { 
+void IsolatedLeptonFinderProcessor::end() {
 }
 
 bool IsolatedLeptonFinderProcessor::IsCharged( ReconstructedParticle* pfo ) {
@@ -477,12 +471,12 @@ float IsolatedLeptonFinderProcessor::getConeEnergy( ReconstructedParticle* pfo )
 		ReconstructedParticle* pfo_i = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 
 		// don't add itself to the cone energy
-		if ( pfo == pfo_i ) continue; 
+		if ( pfo == pfo_i ) continue;
 
 		TVector3 P_i( pfo_i->getMomentum() );
 		float cosTheta = P.Dot( P_i )/(P.Mag()*P_i.Mag());
 		if ( cosTheta >= _cosConeAngle )
-			coneE += pfo_i->getEnergy(); 
+			coneE += pfo_i->getEnergy();
 	}
 
 	return coneE;

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -302,11 +302,9 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 	// Output PFOs removed dressed isolated leptons
 	LCCollectionVec* otPFOsRemovedDressedIsoLepCol = new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) ;
-	otPFOsRemovedDressedIsoLepCol->setSubset(true) ;
 
 	// Output PFOs of dressed isolated leptons
 	LCCollectionVec* otDressedIsoLepCol = new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE );
-	otDressedIsoLepCol->setSubset(true);
 
 	// Prepare jet/recoparticle map for jet-based isolation
 	if (_useJetIsolation) {
@@ -359,18 +357,8 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	// dress them
 	for (unsigned int i = 0; i < goodLeptonIndices.size(); ++i)
 	{
-		// copy this in an ugly fashion to be modofiable - a versatile copy constructor would be much better!
 		ReconstructedParticle* pfo_tmp = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(goodLeptonIndices.at(i) ));
-		ReconstructedParticleImpl* pfo = new ReconstructedParticleImpl();
-		pfo->setMomentum(pfo_tmp->getMomentum());
-		pfo->setEnergy(pfo_tmp->getEnergy());
-		pfo->setType(pfo_tmp->getType());
-		pfo->setCovMatrix(pfo_tmp->getCovMatrix());
-		pfo->setMass(pfo_tmp->getMass());
-		pfo->setCharge(pfo_tmp->getCharge());
-		pfo->setParticleIDUsed(pfo_tmp->getParticleIDUsed());
-		pfo->setGoodnessOfPID(pfo_tmp->getGoodnessOfPID());
-		pfo->setStartVertex(pfo_tmp->getStartVertex());
+		ReconstructedParticleImpl* pfo = CopyReconstructedParticle( pfo_tmp );
 
 		// test how close they are to the other leptons
 
@@ -415,14 +403,13 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 			continue;
 		}
 
-		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
+		ReconstructedParticle* pfo_tmp = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
+		ReconstructedParticleImpl* pfo = CopyReconstructedParticle( pfo_tmp );
 		otPFOsRemovedDressedIsoLepCol->addElement( pfo );
 	}
 
 
-	streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber()
-		<< "   in run:  " << evt->getRunNumber()
-		<< std::endl ;
+	streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber() << "   in run:  " << evt->getRunNumber() << std::endl ;
 
 
 	// calculate total energy
@@ -510,7 +497,20 @@ void IsolatedLeptonFinderProcessor::dressLepton( ReconstructedParticleImpl* pfo,
 }
 void IsolatedLeptonFinderProcessor::end() {
 }
-
+ReconstructedParticleImpl* IsolatedLeptonFinderProcessor::CopyReconstructedParticle ( ReconstructedParticle* pfo_orig ) {
+	// copy this in an ugly fashion to be modifiable - a versatile copy constructor would be much better!
+	ReconstructedParticleImpl* pfo = new ReconstructedParticleImpl();
+	pfo->setMomentum(pfo_orig->getMomentum());
+	pfo->setEnergy(pfo_orig->getEnergy());
+	pfo->setType(pfo_orig->getType());
+	pfo->setCovMatrix(pfo_orig->getCovMatrix());
+	pfo->setMass(pfo_orig->getMass());
+	pfo->setCharge(pfo_orig->getCharge());
+	pfo->setParticleIDUsed(pfo_orig->getParticleIDUsed());
+	pfo->setGoodnessOfPID(pfo_orig->getGoodnessOfPID());
+	pfo->setStartVertex(pfo_orig->getStartVertex());
+	return pfo;
+}
 bool IsolatedLeptonFinderProcessor::IsCharged( ReconstructedParticle* pfo ) {
 	if ( pfo->getCharge() == 0 ) return false;
 	return true;

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -316,7 +316,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 		LCCollection *colJet = evt->getCollection(_jetCollectionName);
 		int njet = colJet->getNumberOfElements();
 		for (int i=0; i<njet; ++i) {
-			ReconstructedParticle* jet = dynamic_cast<ReconstructedParticle*>( colJet->getElementAt(i) );
+			ReconstructedParticle* jet = static_cast<ReconstructedParticle*>( colJet->getElementAt(i) );
 			for (ReconstructedParticleVec::const_iterator iter = jet->getParticles().begin();
 					iter != jet->getParticles().end(); ++iter) {
 				_rpJetMap.insert( std::make_pair( *iter, jet ) );
@@ -329,7 +329,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	std::vector<int> goodLeptonIndices;
 	int npfo = _pfoCol->getNumberOfElements();
 	for (int i = 0; i < npfo; i++ ) {
-		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 
 		if ( !IsGoodLepton( pfo )){
 			otPFOsRemovedIsoLepCol->addElement( pfo );
@@ -355,7 +355,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	// dress them
 	for (unsigned int i = 0; i < goodLeptonIndices.size(); ++i)
 	{
-		ReconstructedParticle* pfo_tmp = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(goodLeptonIndices.at(i) ));
+		ReconstructedParticle* pfo_tmp = static_cast<ReconstructedParticle*>( _pfoCol->getElementAt(goodLeptonIndices.at(i) ));
 		ReconstructedParticleImpl* pfo = CopyReconstructedParticle( pfo_tmp );
 
 
@@ -368,7 +368,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 		streamlog_out(DEBUG) << "Processing lep "<<i<<" with type "<< pfo->getType()<<" with E = "<<pfo->getEnergy()<<" isPhoton "<<IsPhoton(pfo)<< " isElectron "<<IsElectron(pfo)<<std::endl;
 		for (unsigned int j = i+1; j < goodLeptonIndices.size(); ++j)
 		{
-			ReconstructedParticle* pfo_other = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(goodLeptonIndices.at(j) ));
+			ReconstructedParticle* pfo_other = static_cast<ReconstructedParticle*>( _pfoCol->getElementAt(goodLeptonIndices.at(j) ));
 			TVector3 P_this( pfo->getMomentum() );
 			TVector3 P_other( pfo_other->getMomentum() );
 			float theta = TMath::ACos(P_this.Dot( P_other )/(P_this.Mag()*P_other.Mag())) * 360 / (2 * TMath::Pi());
@@ -401,7 +401,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 			continue;
 		}
 
-		ReconstructedParticle* pfo_tmp = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
+		ReconstructedParticle* pfo_tmp = static_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 		ReconstructedParticleImpl* pfo = CopyReconstructedParticle( pfo_tmp );
 		otPFOsRemovedDressedIsoLepCol->addElement( pfo );
 	}
@@ -414,23 +414,23 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	double etot_iso(0);
 	for (int i = 0; i < otPFOsRemovedIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( otPFOsRemovedIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otPFOsRemovedIsoLepCol->getElementAt(i) );
 		etot_iso += pfo->getEnergy();
 	}
 	for (int i = 0; i < otIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( otIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otIsoLepCol->getElementAt(i) );
 		etot_iso += pfo->getEnergy();
 	}
 	double etot_dressediso(0);
 	for (int i = 0; i < otPFOsRemovedDressedIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( otPFOsRemovedDressedIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otPFOsRemovedDressedIsoLepCol->getElementAt(i) );
 		etot_dressediso += pfo->getEnergy();
 	}
 	for (int i = 0; i < otDressedIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( otDressedIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otDressedIsoLepCol->getElementAt(i) );
 		etot_dressediso += pfo->getEnergy();
 	}
 
@@ -460,7 +460,7 @@ void IsolatedLeptonFinderProcessor::dressLepton( ReconstructedParticleImpl* pfo,
 	TVector3 P_lep( pfo->getMomentum() );
 	int npfo = _pfoCol->getNumberOfElements();
 	for ( int i = 0; i < npfo; i++ ) {
-		ReconstructedParticle* pfo_dress = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
+		ReconstructedParticle* pfo_dress = static_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 
 		// only add photons and electrons
 		bool isPhoton = IsPhoton(pfo_dress);
@@ -698,7 +698,7 @@ float IsolatedLeptonFinderProcessor::getConeEnergy( ReconstructedParticle* pfo, 
 	TVector3 P( pfo->getMomentum() );
 	int npfo = _pfoCol->getNumberOfElements();
 	for ( int i = 0; i < npfo; i++ ) {
-		ReconstructedParticle* pfo_i = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
+		ReconstructedParticle* pfo_i = static_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 
 		// don't add itself to the cone energy
 		if ( pfo == pfo_i ) continue;

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -254,6 +254,16 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				"Maximum Z in jet-based isolation",
 				_jetIsoVetoMaxZ,
 				float(0.6));
+
+		registerProcessorParameter( "UseLeptonDressing",
+				"Use lepton dressing",
+				_useLeptonDressing,
+				bool(true));
+
+		registerProcessorParameter( "DressCosConeAngle",
+				"Cosine of the half-angle of the cone used in lepton dressing procedure",
+				_dressCosConeAngle,
+				float(0.95));
 	}
 
 
@@ -294,7 +304,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	for (int i = 0; i < npfo; i++ ) {
 		ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 
-		if ( IsIsolatedLepton( pfo ) )
+		if ( IsGoodLepton( pfo ) && IsIsolatedLepton( pfo ) )
 			otIsoLepCol->addElement( pfo );
 		else
 			otPFOsRemovedIsoLepCol->addElement( pfo );
@@ -345,7 +355,8 @@ bool IsolatedLeptonFinderProcessor::IsLepton( ReconstructedParticle* pfo ) {
 	return false;
 }
 
-bool IsolatedLeptonFinderProcessor::IsIsolatedLepton( ReconstructedParticle* pfo ) {
+bool IsolatedLeptonFinderProcessor::IsGoodLepton( ReconstructedParticle* pfo ) {
+
 	if ( !IsCharged(pfo) )
 		return false;
 
@@ -357,6 +368,11 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedLepton( ReconstructedParticle* pfo
 
 	if ( _useImpactParameterSignificance && !PassesImpactParameterSignificanceCuts(pfo) )
 		return false ;
+
+	return true;
+}
+
+bool IsolatedLeptonFinderProcessor::IsIsolatedLepton( ReconstructedParticle* pfo ) {
 
 	if ( _useRectangularIsolation && !IsIsolatedRectangular(pfo) )
 		return false;

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -260,15 +260,15 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				_whichLeptons,
 				std::string("UNDRESSED"));
 
-		registerProcessorParameter( "DressPhotonCosConeAngle",
-				"Cosine of the half-angle of the cone used for lepton dressing with photons",
-				_dressPhotonCosConeAngle,
-				float(0.999848));
+		registerProcessorParameter( "DressPhotonConeAngle",
+				"Half-angle (in degrees) of the cone used for lepton dressing with photons",
+				_dressPhotonConeAngle,
+				float(1));
 
-		registerProcessorParameter( "MergeLeptonCosConeAngle",
-				"Cosine of the half-angle of the cone used for lepton merging",
-				_mergeLeptonCosConeAngle,
-				float(0.999048));
+		registerProcessorParameter( "MergeLeptonConeAngle",
+				"Half-angle (in degrees) of the cone used for lepton merging",
+				_mergeLeptonConeAngle,
+				float(2));
 
 		registerProcessorParameter( "UsePandoraIDs",
 				"Use Pandora particle IDs for algorithm",
@@ -486,18 +486,18 @@ void IsolatedLeptonFinderProcessor::dressLepton( ReconstructedParticleImpl* pfo,
 		if ( i == PFO_idx ) continue;
 
 		TVector3 Pdress( pfo_dress->getMomentum() );
-		float cosTheta = P_lep.Dot( Pdress )/(P_lep.Mag()*Pdress.Mag());
+		float theta = TMath::ACos(P_lep.Dot( Pdress )/(P_lep.Mag()*Pdress.Mag())) * 360 / (2 * TMath::Pi());
 
-		if ( (isPhoton && cosTheta >= _dressPhotonCosConeAngle) ||
-			 (isElectron && cosTheta >= _mergeLeptonCosConeAngle) ){
+		if ( (isPhoton && theta <= _dressPhotonConeAngle) ||
+			 (isElectron && theta <= _mergeLeptonConeAngle) ){
 			if (std::find(_dressedPFOs.begin(), _dressedPFOs.end(), i) != _dressedPFOs.end()){
-				if (isPhoton) streamlog_out(DEBUG) << "WARNING: photon "<<i<<" with cosTheta "<<cosTheta <<" and type "<<pfo->getType()<<" already close to another lepton!"<<std::endl;
-				if (isElectron) streamlog_out(DEBUG) << "WARNING: lepton "<<i<<" with cosTheta "<<cosTheta <<" and type "<<pfo->getType()<<" already close to another lepton!"<<std::endl;
+				if (isPhoton) streamlog_out(DEBUG) << "WARNING: photon "<<i<<" with theta "<<theta <<" and type "<<pfo->getType()<<" already close to another lepton!"<<std::endl;
+				if (isElectron) streamlog_out(DEBUG) << "WARNING: lepton "<<i<<" with theta "<<theta <<" and type "<<pfo->getType()<<" already close to another lepton!"<<std::endl;
 				// printf(" -- this lep: %.2f, %.2f ,%.2f ,%.2f\n", pfo->getMomentum()[0], pfo->getMomentum()[1], pfo->getMomentum()[2], pfo->getEnergy());
 				continue;
 			}
-			if (isPhoton) streamlog_out(DEBUG) << "MESSAGE: dressing photon "<<i<<" with cosTheta "<<cosTheta <<" and type "<<pfo->getType()<<std::endl;
-			if (isElectron) streamlog_out(DEBUG) << "MESSAGE: dressing lepton "<<i<<" with cosTheta "<<cosTheta <<" and type "<<pfo->getType()<<std::endl;
+			if (isPhoton) streamlog_out(DEBUG) << "MESSAGE: dressing photon "<<i<<" with theta "<<theta <<" and type "<<pfo->getType()<<std::endl;
+			if (isElectron) streamlog_out(DEBUG) << "MESSAGE: merging lepton "<<i<<" with theta "<<theta <<" and type "<<pfo->getType()<<std::endl;
 			_dressedPFOs.push_back(i);
 			double dressedMomentum[3] = {pfo->getMomentum()[0] + pfo_dress->getMomentum()[0],
 								  		 pfo->getMomentum()[1] + pfo_dress->getMomentum()[1],

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -243,10 +243,10 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				_jetIsoVetoMaxZ,
 				float(0.6));
 
-		registerProcessorParameter( "WhichLeptons",
-				"Use DRESSED or UNDRESSED lepton algorithms",
-				_whichLeptons,
-				std::string("UNDRESSED"));
+		registerProcessorParameter( "UseDressedLeptons",
+				"Dress leptons with close-by particles",
+				_useDressedLeptons,
+				bool(false));
 
 		registerProcessorParameter( "MergeCloseElectrons",
 				"Merge close-by electrons into higher energy lepton",
@@ -427,10 +427,10 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 
 	// Add PFOs to new collections
-	if (_whichLeptons == "DRESSED"){
+	if (_useDressedLeptons){
 		evt->addCollection( outPFOsRemovedDressedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
 		evt->addCollection( outDressedIsoLepCol.release(), _outputIsoLepCollection.c_str() );
-	}else if (_whichLeptons == "UNDRESSED"){
+	}else{
 		evt->addCollection( outPFOsRemovedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
 		evt->addCollection( outIsoLepCol.release(), _outputIsoLepCollection.c_str() );
 	}

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -349,16 +349,9 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 		if (IsLepton( pfo )) goodLeptonIndices.push_back(i);
 	}
 
-
 	// Dressed leptons
 	// order by energy
-	for (unsigned int i = 1; i < goodLeptonIndices.size(); ++i)
-	{
-		if (isMoreEnergetic(i, i-1)) {
-			std::swap(goodLeptonIndices.at(i), goodLeptonIndices.at(i-1));
-			i = 1;
-		}
-	}
+	std::sort(goodLeptonIndices.begin(), goodLeptonIndices.end(), [this](const int i, const int j) {return isMoreEnergetic(i, j);});
 	// dress them
 	for (unsigned int i = 0; i < goodLeptonIndices.size(); ++i)
 	{

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -287,18 +287,18 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	_pfoCol = evt->getCollection( _inputPFOsCollection ) ;
 
 	// Output PFOs removed isolated leptons
-	auto otPFOsRemovedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
-	otPFOsRemovedIsoLepCol->setSubset(true) ;
+	auto outPFOsRemovedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
+	outPFOsRemovedIsoLepCol->setSubset(true) ;
 
 	// Output PFOs of isolated leptons
-	auto otIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
-	otIsoLepCol->setSubset(true);
+	auto outIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
+	outIsoLepCol->setSubset(true);
 
 	// Output PFOs removed dressed isolated leptons
-	auto otPFOsRemovedDressedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
+	auto outPFOsRemovedDressedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
 
 	// Output PFOs of dressed isolated leptons
-	auto otDressedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
+	auto outDressedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
 
 	// Prepare jet/recoparticle map for jet-based isolation
 	if (_useJetIsolation) {
@@ -322,17 +322,17 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 		_workingList.push_back( pfo );
 
 		if ( !IsGoodLepton( pfo )){
-			otPFOsRemovedIsoLepCol->addElement( pfo );
+			outPFOsRemovedIsoLepCol->addElement( pfo );
 			continue;
 		}
 
 		if  ( IsIsolatedLepton( pfo ) ){
 			streamlog_out(DEBUG) << "ISOLATION undressed "<<pfo->getType()<<": SUCCESS !" << std::endl;
-			otIsoLepCol->addElement( pfo );
+			outIsoLepCol->addElement( pfo );
 		}
 		else{
 			streamlog_out(DEBUG) << "ISOLATION undressed "<<pfo->getType()<<": FAILED" << std::endl;
-			otPFOsRemovedIsoLepCol->addElement( pfo );
+			outPFOsRemovedIsoLepCol->addElement( pfo );
 		}
 
 		// remember lepton indices for dressing
@@ -370,11 +370,11 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 		if  ( IsIsolatedLepton( pfo ) ){
 			streamlog_out(DEBUG) << "ISOLATION dressed "<<pfo->getType()<<": SUCCESS !" << std::endl;
-			otDressedIsoLepCol->addElement( pfo );
+			outDressedIsoLepCol->addElement( pfo );
 		}
 		else{
 			streamlog_out(DEBUG) << "ISOLATION dressed "<<pfo->getType()<<": FAILED" << std::endl;
-			otPFOsRemovedDressedIsoLepCol->addElement( pfo );
+			outPFOsRemovedDressedIsoLepCol->addElement( pfo );
 		}
 	}
 
@@ -393,7 +393,7 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 		ReconstructedParticle* pfo_tmp = static_cast<ReconstructedParticle*>( _pfoCol->getElementAt(i) );
 		ReconstructedParticleImpl* pfo = CopyReconstructedParticle( pfo_tmp );
-		otPFOsRemovedDressedIsoLepCol->addElement( pfo );
+		outPFOsRemovedDressedIsoLepCol->addElement( pfo );
 	}
 
 
@@ -402,25 +402,25 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 	// calculate total energy
 	double etot_iso(0);
-	for (int i = 0; i < otPFOsRemovedIsoLepCol->getNumberOfElements(); ++i)
+	for (int i = 0; i < outPFOsRemovedIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otPFOsRemovedIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( outPFOsRemovedIsoLepCol->getElementAt(i) );
 		etot_iso += pfo->getEnergy();
 	}
-	for (int i = 0; i < otIsoLepCol->getNumberOfElements(); ++i)
+	for (int i = 0; i < outIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( outIsoLepCol->getElementAt(i) );
 		etot_iso += pfo->getEnergy();
 	}
 	double etot_dressediso(0);
-	for (int i = 0; i < otPFOsRemovedDressedIsoLepCol->getNumberOfElements(); ++i)
+	for (int i = 0; i < outPFOsRemovedDressedIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otPFOsRemovedDressedIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( outPFOsRemovedDressedIsoLepCol->getElementAt(i) );
 		etot_dressediso += pfo->getEnergy();
 	}
-	for (int i = 0; i < otDressedIsoLepCol->getNumberOfElements(); ++i)
+	for (int i = 0; i < outDressedIsoLepCol->getNumberOfElements(); ++i)
 	{
-		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( otDressedIsoLepCol->getElementAt(i) );
+		ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>( outDressedIsoLepCol->getElementAt(i) );
 		etot_dressediso += pfo->getEnergy();
 	}
 
@@ -428,17 +428,17 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	streamlog_out(DEBUG) << "nLepton:                  " <<goodLeptonIndices.size()<<std::endl;
 	streamlog_out(DEBUG) << "nDressed:                 " <<_dressedPFOs.size()<<std::endl;
 	streamlog_out(DEBUG) << "Energy:                   " <<etot_iso<<" and "<<etot_dressediso<<std::endl;
-	streamlog_out(DEBUG) << "Sizes removed collection: " <<otPFOsRemovedIsoLepCol->getNumberOfElements()<<" and "<<otPFOsRemovedDressedIsoLepCol->getNumberOfElements()<<std::endl;
-	streamlog_out(DEBUG) << "Sizes lepton collection:  " <<otIsoLepCol->getNumberOfElements()<<" and "<<otDressedIsoLepCol->getNumberOfElements()<<std::endl;
+	streamlog_out(DEBUG) << "Sizes removed collection: " <<outPFOsRemovedIsoLepCol->getNumberOfElements()<<" and "<<outPFOsRemovedDressedIsoLepCol->getNumberOfElements()<<std::endl;
+	streamlog_out(DEBUG) << "Sizes lepton collection:  " <<outIsoLepCol->getNumberOfElements()<<" and "<<outDressedIsoLepCol->getNumberOfElements()<<std::endl;
 
 
 	// Add PFOs to new collections
 	if (_whichLeptons == "DRESSED"){
-		evt->addCollection( otPFOsRemovedDressedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
-		evt->addCollection( otDressedIsoLepCol.release(), _outputIsoLepCollection.c_str() );
+		evt->addCollection( outPFOsRemovedDressedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( outDressedIsoLepCol.release(), _outputIsoLepCollection.c_str() );
 	}else if (_whichLeptons == "UNDRESSED"){
-		evt->addCollection( otPFOsRemovedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
-		evt->addCollection( otIsoLepCol.release(), _outputIsoLepCollection.c_str() );
+		evt->addCollection( outPFOsRemovedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( outIsoLepCol.release(), _outputIsoLepCollection.c_str() );
 	}
 }
 void IsolatedLeptonFinderProcessor::dressLepton( ReconstructedParticleImpl* pfo, int PFO_idx ) {

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -298,18 +298,18 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 	_pfoCol = evt->getCollection( _inputPFOsCollection ) ;
 
 	// Output PFOs removed isolated leptons
-	LCCollectionVec* otPFOsRemovedIsoLepCol = new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) ;
+	auto otPFOsRemovedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
 	otPFOsRemovedIsoLepCol->setSubset(true) ;
 
 	// Output PFOs of isolated leptons
-	LCCollectionVec* otIsoLepCol = new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE );
+	auto otIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
 	otIsoLepCol->setSubset(true);
 
 	// Output PFOs removed dressed isolated leptons
-	LCCollectionVec* otPFOsRemovedDressedIsoLepCol = new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) ;
+	auto otPFOsRemovedDressedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
 
 	// Output PFOs of dressed isolated leptons
-	LCCollectionVec* otDressedIsoLepCol = new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE );
+	auto otDressedIsoLepCol = std::unique_ptr<LCCollectionVec>(new LCCollectionVec( LCIO::RECONSTRUCTEDPARTICLE ) );
 
 	// Prepare jet/recoparticle map for jet-based isolation
 	if (_useJetIsolation) {
@@ -444,16 +444,16 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 	// Add PFOs to new collections
 	if (_whichLeptons == "BOTH"){
-		evt->addCollection( otPFOsRemovedIsoLepCol, _outputPFOsRemovedIsoLepCollection.c_str() );
-		evt->addCollection( otIsoLepCol, _outputIsoLepCollection.c_str() );
-		evt->addCollection( otPFOsRemovedDressedIsoLepCol, _outputPFOsRemovedDressedIsoLepCollection.c_str() );
-		evt->addCollection( otDressedIsoLepCol, _outputDressedIsoLepCollection.c_str() );
+		evt->addCollection( otPFOsRemovedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( otIsoLepCol.release(), _outputIsoLepCollection.c_str() );
+		evt->addCollection( otPFOsRemovedDressedIsoLepCol.release(), _outputPFOsRemovedDressedIsoLepCollection.c_str() );
+		evt->addCollection( otDressedIsoLepCol.release(), _outputDressedIsoLepCollection.c_str() );
 	}else if (_whichLeptons == "DRESSED"){
-		evt->addCollection( otPFOsRemovedDressedIsoLepCol, _outputPFOsRemovedIsoLepCollection.c_str() );
-		evt->addCollection( otDressedIsoLepCol, _outputIsoLepCollection.c_str() );
+		evt->addCollection( otPFOsRemovedDressedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( otDressedIsoLepCol.release(), _outputIsoLepCollection.c_str() );
 	}else if (_whichLeptons == "UNDRESSED"){
-		evt->addCollection( otPFOsRemovedIsoLepCol, _outputPFOsRemovedIsoLepCollection.c_str() );
-		evt->addCollection( otIsoLepCol, _outputIsoLepCollection.c_str() );
+		evt->addCollection( otPFOsRemovedIsoLepCol.release(), _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( otIsoLepCol.release(), _outputIsoLepCollection.c_str() );
 	}
 }
 void IsolatedLeptonFinderProcessor::dressLepton( ReconstructedParticleImpl* pfo, int PFO_idx ) {

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -255,10 +255,10 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				_jetIsoVetoMaxZ,
 				float(0.6));
 
-		registerProcessorParameter( "UseLeptonDressing",
-				"Use lepton dressing",
-				_useLeptonDressing,
-				bool(true));
+		registerProcessorParameter( "WhichLeptons",
+				"Use DRESSED, UNDRESSED or BOTH lepton algorithms",
+				_whichLeptons,
+				std::string("UNDRESSED"));
 
 		registerProcessorParameter( "DressPhotonCosConeAngle",
 				"Cosine of the half-angle of the cone used for lepton dressing with photons",
@@ -458,10 +458,18 @@ void IsolatedLeptonFinderProcessor::processEvent( LCEvent * evt ) {
 
 
 	// Add PFOs to new collections
-	evt->addCollection( otPFOsRemovedIsoLepCol, _outputPFOsRemovedIsoLepCollection.c_str() );
-	evt->addCollection( otIsoLepCol, _outputIsoLepCollection.c_str() );
-	evt->addCollection( otPFOsRemovedDressedIsoLepCol, _outputPFOsRemovedDressedIsoLepCollection.c_str() );
-	evt->addCollection( otDressedIsoLepCol, _outputDressedIsoLepCollection.c_str() );
+	if (_whichLeptons == "BOTH"){
+		evt->addCollection( otPFOsRemovedIsoLepCol, _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( otIsoLepCol, _outputIsoLepCollection.c_str() );
+		evt->addCollection( otPFOsRemovedDressedIsoLepCol, _outputPFOsRemovedDressedIsoLepCollection.c_str() );
+		evt->addCollection( otDressedIsoLepCol, _outputDressedIsoLepCollection.c_str() );
+	}else if (_whichLeptons == "DRESSED"){
+		evt->addCollection( otPFOsRemovedDressedIsoLepCol, _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( otDressedIsoLepCol, _outputIsoLepCollection.c_str() );
+	}else if (_whichLeptons == "UNDRESSED"){
+		evt->addCollection( otPFOsRemovedIsoLepCol, _outputPFOsRemovedIsoLepCollection.c_str() );
+		evt->addCollection( otIsoLepCol, _outputIsoLepCollection.c_str() );
+	}
 }
 void IsolatedLeptonFinderProcessor::dressLepton( ReconstructedParticleImpl* pfo, int PFO_idx ) {
 	TVector3 P_lep( pfo->getMomentum() );

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -47,6 +47,18 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
 				_outputIsoLepCollection,
 				std::string("Isolep") );
 
+		registerOutputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+				"OutputCollectionWithoutDressedIsolatedLepton",
+				"Copy of input collection but without the dressed isolated leptons",
+				_outputPFOsRemovedDressedIsoLepCollection,
+				std::string("PandoraPFOsWithoutDressedIsoLep") );
+
+		registerOutputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+				"OutputCollectionDressedIsolatedLeptons",
+				"Output collection of dressed isolated leptons",
+				_outputDressedIsoLepCollection,
+				std::string("DressedIsolep") );
+
 		registerProcessorParameter( "CosConeAngle",
 				"Cosine of the half-angle of the cone used in isolation criteria",
 				_cosConeAngle,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ FIND_PACKAGE( MarlinUtil 1.4 REQUIRED )
 FIND_PACKAGE( MarlinKinfit 0.0 REQUIRED )
 FIND_PACKAGE( MarlinTrk )
 FIND_PACKAGE( GSL REQUIRED )
-FIND_PACKAGE( ROOT 5.27 REQUIRED COMPONENTS MathMore TMVA)  
+FIND_PACKAGE( ROOT 5.27 REQUIRED COMPONENTS MathMore TMVA)
 FIND_PACKAGE( DD4hep COMPONENTS DDRec DDSegmentation)
 
 OPTION( MARLINRECO_AIDA "Set to ON to build MarlinReco with AIDA" ON )
@@ -80,7 +80,7 @@ IF( MARLINRECO_FORTRAN )
 
     FIND_PACKAGE( FORTRAN_LIBRARY REQUIRED )
     LINK_LIBRARIES( ${FORTRAN_LIBRARY} )
-    GET_FILENAME_COMPONENT( FORTRAN_LIBRARY_FULL_PATH ${FORTRAN_LIBRARY} REALPATH ) 
+    GET_FILENAME_COMPONENT( FORTRAN_LIBRARY_FULL_PATH ${FORTRAN_LIBRARY} REALPATH )
     INSTALL( PROGRAMS ${FORTRAN_LIBRARY_FULL_PATH} DESTINATION lib ) # PROGRAMS is like FILES but sets executable permissions
 
 
@@ -204,3 +204,12 @@ INSTALL_SHARED_LIBRARY( MarlinReco DESTINATION lib )
 # display some variables and write them to cache
 DISPLAY_STD_VARIABLES()
 
+
+### Load cpp format and check tools #######################################
+
+# Set the source files to clang-format (FIXME: determine this better)
+FILE(GLOB_RECURSE
+     CHECK_CXX_SOURCE_FILES
+        Analysis/IsolatedLeptonFinder/src/*.cc Analysis/IsolatedLeptonFinder/include/*.h
+     )
+INCLUDE("cmake/clang-cpp-checks.cmake")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ MarlinReco is distributed under the [GPLv3 License](http://www.gnu.org/licenses/
 [![License](https://www.gnu.org/graphics/gplv3-127x51.png)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 
+## Compilation
+```shell
+cd MarlinReco
+mkdir build && cd $_
+cmake .. # use the appropriate compiler flags
+[make format]  # apply Cpp format guidelines in place (optional)
+make install
+```
+
 ## License and Copyright
 Copyright (C), MarlinReco Authors
 

--- a/cmake/clang-cpp-checks.cmake
+++ b/cmake/clang-cpp-checks.cmake
@@ -1,0 +1,92 @@
+# Additional targets to perform clang-format/clang-tidy
+
+# Get all project files - FIXME: this should also use the list of generated targets
+IF(NOT CHECK_CXX_SOURCE_FILES)
+    MESSAGE(FATAL_ERROR "Variable CHECK_CXX_SOURCE_FILES not defined - set it to the list of files to auto-format")
+    RETURN()
+ENDIF()
+
+# Adding clang-format check and formatter if found
+FIND_PROGRAM(CLANG_FORMAT "clang-format")
+IF(CLANG_FORMAT)
+    ADD_CUSTOM_TARGET(
+        format
+        COMMAND
+        ${CLANG_FORMAT}
+        -i
+        -style=file
+        ${CHECK_CXX_SOURCE_FILES}
+        COMMENT "Auto formatting of all source files"
+    )
+
+    ADD_CUSTOM_TARGET(
+        check-format
+        COMMAND
+        ${CLANG_FORMAT}
+        -style=file
+        -output-replacements-xml
+        ${CHECK_CXX_SOURCE_FILES}
+        # print output
+        | tee ${CMAKE_BINARY_DIR}/check_format_file.txt | grep -c "replacement " |
+                tr -d "[:cntrl:]" && echo " replacements necessary"
+        # WARNING: fix to stop with error if there are problems
+        COMMAND ! grep -c "replacement "
+                  ${CMAKE_BINARY_DIR}/check_format_file.txt > /dev/null
+        COMMENT "Checking format compliance"
+    )
+ELSE()
+    MESSAGE(WARNING "clang-format not found on system, skip creating auto formatting target!")
+ENDIF()
+
+# Adding clang-tidy target if executable is found
+SET(CXX_STD 11)
+IF(${CMAKE_CXX_STANDARD})
+    SET(CXX_STD ${CMAKE_CXX_STANDARD})
+ENDIF()
+
+FIND_PROGRAM(CLANG_TIDY "clang-tidy")
+# Enable clang tidy only if using a clang compiler
+IF(CLANG_TIDY AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # If debug build enabled do automatic clang tidy
+    IF(CMAKE_BUILD_TYPE MATCHES Debug)
+        SET(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY} "-header-filter='${CMAKE_SOURCE_DIR}'")
+    ENDIF()
+
+    # Enable checking and formatting through run-clang-tidy if available
+    # FIXME Make finding this program more portable
+    GET_FILENAME_COMPONENT(CLANG_DIR ${CLANG_TIDY} DIRECTORY)
+    FIND_PROGRAM(RUN_CLANG_TIDY NAMES "run-clang-tidy.py" "run-clang-tidy-4.0.py" HINTS /usr/share/clang/ ${CLANG_DIR}/../share/clang/ /usr/bin/)
+    IF(RUN_CLANG_TIDY)
+        # Set export commands on
+        SET (CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+        # Get amount of processors to speed up linting
+        INCLUDE(ProcessorCount)
+        ProcessorCount(NPROC)
+        IF(NPROC EQUAL 0)
+            SET(NPROC 1)
+        ENDIF()
+
+        ADD_CUSTOM_TARGET(
+            lint COMMAND
+            ${RUN_CLANG_TIDY} -fix -format -header-filter=${CMAKE_SOURCE_DIR} -j${NPROC}
+            COMMENT "Auto fixing problems in all source files"
+        )
+
+        ADD_CUSTOM_TARGET(
+            check-lint COMMAND
+            ${RUN_CLANG_TIDY} -header-filter=${CMAKE_SOURCE_DIR} -j${NPROC}
+            | tee ${CMAKE_BINARY_DIR}/check_lint_file.txt
+            # WARNING: fix to stop with error if there are problems
+            COMMAND ! grep -c ": error: " ${CMAKE_BINARY_DIR}/check_lint_file.txt > /dev/null
+            COMMENT "Checking for problems in source files"
+        )
+    ENDIF()
+ELSE()
+    IF(NOT CLANG_TIDY)
+        MESSAGE(WARNING "clang-tidy not found on system, skip creating lint target!")
+    ENDIF()
+    IF(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        MESSAGE(WARNING "clang compiler not used, skip creating lint target!")
+    ENDIF()
+ENDIF()


### PR DESCRIPTION
This addition to the IsolatedLeptonFinderProcessor dresses electrons with close-by photons. It is currently under development and this PR serves as baseline for discussion.

BEGINRELEASENOTES

  - This package is an extension to the IsolatedLeptonFinderProcessor. The default functionality is untouched.
  - Optionally, it dresses leptons with close-by particles. By default it dresses electrons and muons with photons.
  - The algorithm starts with the highest energy lepton and adds all photons (and, optionally, electrons) in a cone of a given size around to it. As the original, it creates a collection with the dressed leptons and another collections with all remaining particles, except the ones that were dressed into the leptons.
  - All compiler warnings are fixed

ENDRELEASENOTES