### PR TITLE
SidEdx update2

### DIFF
--- a/Analysis/SiPID/include/AnalyseSidEdxProcessor.h
+++ b/Analysis/SiPID/include/AnalyseSidEdxProcessor.h
@@ -36,9 +36,9 @@ class AnalyseSidEdxProcessor : public Processor {
   virtual Processor*  newProcessor() { return new AnalyseSidEdxProcessor ; }
 
   AnalyseSidEdxProcessor() ;
-  AnalyseSidEdxProcessor(const AnalyseSidEdxProcessor&) ;
+  AnalyseSidEdxProcessor(const AnalyseSidEdxProcessor&) = delete ;
 
-  AnalyseSidEdxProcessor& operator=(const AnalyseSidEdxProcessor&) ;
+  AnalyseSidEdxProcessor& operator=(const AnalyseSidEdxProcessor&) = delete ;
 
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.

--- a/Analysis/SiPID/include/AnalyseSidEdxProcessor.h
+++ b/Analysis/SiPID/include/AnalyseSidEdxProcessor.h
@@ -36,6 +36,9 @@ class AnalyseSidEdxProcessor : public Processor {
   virtual Processor*  newProcessor() { return new AnalyseSidEdxProcessor ; }
 
   AnalyseSidEdxProcessor() ;
+  AnalyseSidEdxProcessor(const AnalyseSidEdxProcessor&) ;
+
+  AnalyseSidEdxProcessor& operator=(const AnalyseSidEdxProcessor&) ;
 
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.

--- a/Analysis/SiPID/include/LayerFinder.h
+++ b/Analysis/SiPID/include/LayerFinder.h
@@ -28,13 +28,16 @@ typedef std::map<EVENT::LCCollection*, CellIDDecoder<TrackerHitPlane>*> Collecti
 class LayerResolverBase {
 
 public:
-  LayerResolverBase(const LayerResolverBase &);
+  LayerResolverBase() = delete ;
+  LayerResolverBase(const LayerResolverBase &) = delete ;
   LayerResolverBase(const int _detTypeFlag,
                     const std::string _collectionName,
                     const std::string _detectorName,
                     double _sensThickCheatVal=-1.);
 
   virtual ~LayerResolverBase() ;
+
+  const LayerResolverBase& operator=(const LayerResolverBase&) = delete;
 
   /* The detector type flag helps to distinguish pointers
    * to plane from petal resolver objects at runtime.
@@ -58,7 +61,6 @@ public:
   int DecodeLayer(TrackerHitPlane* thit) const { return (*decoder)(thit)["layer"]; }
   int DecodeSystem(TrackerHitPlane* thit) const { return (*decoder)(thit)["system"]; }
 
-  const LayerResolverBase& operator=(const LayerResolverBase&);
 
   virtual double SensitiveThickness(int nLayer) const { return (this->*ThicknessSensitive)(nLayer); }
   virtual double SensitiveThickness(TrackerHitPlane* thit) const {
@@ -85,15 +87,14 @@ protected:
   EVENT::LCCollection *collection;
   CellIDDecoder<TrackerHitPlane>* decoder;
 
-  LayerResolverBase();
-
 };
 
 
 template <class T> class LayerResolver : public LayerResolverBase {
 
 public:
-  LayerResolver(const LayerResolver<T> &lt);
+  LayerResolver() = delete ;
+  LayerResolver(const LayerResolver<T> &lt) = delete ;
   LayerResolver(const int _detTypeFlag, T *,
                 const std::string _collectionName,
                 const std::string _detectorName,
@@ -103,14 +104,13 @@ public:
 
   unsigned GetNumberOfLayers() const { return layering->layers.size(); }
 
-  const LayerResolver& operator=(const LayerResolver<T>&);
+  const LayerResolver& operator=(const LayerResolver<T>&) = delete ;
   const T *GetLayering() const {return layering;};
 
 protected:
   double SensitiveThicknessRead(int nLayer) const ;
   const T *layering;
 
-  LayerResolver();
 };
 
 typedef LayerResolver<dd4hep::rec::ZDiskPetalsData> PetalResolver;

--- a/Analysis/SiPID/include/LayerFinder.h
+++ b/Analysis/SiPID/include/LayerFinder.h
@@ -29,7 +29,10 @@ class LayerResolverBase {
 
 public:
   LayerResolverBase(const LayerResolverBase &);
-  LayerResolverBase(const int _detTypeFlag, const std::string _collectionName, double _sensThickCheatVal=-1.);
+  LayerResolverBase(const int _detTypeFlag,
+                    const std::string _collectionName,
+                    const std::string _detectorName,
+                    double _sensThickCheatVal=-1.);
 
   virtual ~LayerResolverBase() ;
 
@@ -40,6 +43,7 @@ public:
 
   int SetCollection(EVENT::LCEvent *) ;
   std::string GetCollectionName() const { return collectionName; }
+  std::string GetDetectorName() const { return detectorName; }
   std::string GetCollectionType() const;
   std::string GetCollectionEncoding() const;
 
@@ -49,7 +53,7 @@ public:
 
   virtual unsigned GetNumberOfLayers() const = 0;
 
-  int Decode(TrackerHitPlane* thit) const { return (*decoder)(thit)["layer"];}
+  int Decode(TrackerHitPlane* thit, const char *what="layer") const { return (*decoder)(thit)[what];}
 
   const LayerResolverBase& operator=(const LayerResolverBase&);
 
@@ -69,6 +73,7 @@ protected:
   // Constant in run:
   int detTypeFlag;
   std::string collectionName;
+  std::string detectorName;
   // Event-to-event
   EVENT::LCCollection *collection;
   CellIDDecoder<TrackerHitPlane>* decoder;
@@ -84,6 +89,7 @@ public:
   LayerResolver(const LayerResolver<T> &lt);
   LayerResolver(const int _detTypeFlag, T *,
                 const std::string _collectionName,
+                const std::string _detectorName,
                 double _sensThickCheatVal=-1.);
 
   ~LayerResolver() {};
@@ -100,59 +106,10 @@ protected:
   LayerResolver();
 };
 
-typedef LayerResolver<dd4hep::rec::ZDiskPetalsData> PETAL_RESOLVER;
-typedef LayerResolver<dd4hep::rec::ZPlanarData> PLANE_RESOLVER;
-
-/*
-class PetalResolver : public LayerResolver{
-public:
-  PetalResolver(const PetalResolver &lt);
-  PetalResolver(const int _detTypeFlag,
-                dd4hep::rec::ZDiskPetalsData *,
-                const std::string _collectionName,
-                double _sensThickCheatVal=-1.);
-
-  ~PetalResolver() {};
-
-  int GetNumberOfLayers() const { return layering->layers.size(); }
-
-  const PetalResolver& operator=(const PetalResolver&);
-  const dd4hep::rec::ZDiskPetalsData *GetLayering() const {return layering;};
-
-protected:
-  double SensitiveThicknessRead(int nLayer) const ;
-  const dd4hep::rec::ZDiskPetalsData *layering;
-
-  PetalResolver();
-
-};
+typedef LayerResolver<dd4hep::rec::ZDiskPetalsData> PetalResolver;
+typedef LayerResolver<dd4hep::rec::ZPlanarData> PlaneResolver;
 
 
-class PlaneResolver : public LayerResolver{
-public:
-  PlaneResolver(const PlaneResolver &lt);
-  PlaneResolver(const int _detTypeFlag,
-                dd4hep::rec::ZPlanarData *,
-                const std::string _collectionName,
-                double _sensThickCheatVal=-1.);
-
-  ~PlaneResolver() {};
-
-  int GetNumberOfLayers() const { return layering->layers.size(); }
-
-  const PlaneResolver& operator=(const PlaneResolver&);
-  const dd4hep::rec::ZPlanarData *GetLayering() const {return layering;};
-
-
-protected:
-  double SensitiveThicknessRead(int nLayer) const ;
-  const dd4hep::rec::ZPlanarData *layering;
-
-  PlaneResolver();
-
-};
-
-*/
 
 /* LayerFinder class parses tracker hit collections in the event
  * finds where the hit belogs,
@@ -185,8 +142,11 @@ public:
   // Sensitive thickness of layer
   void ReportKnownDetectors();
 
+  typedef std::map<int, LayerResolverBase*> ResolverMap;
+  typedef ResolverMap::iterator ResolverMapIter;
+
 protected:
-  std::vector<LayerResolverBase*> knownDetectors{};
+  ResolverMap knownDetectors{};
 
   // Default constructor. Not very useful.
   LayerFinder();

--- a/Analysis/SiPID/include/LayerFinder.h
+++ b/Analysis/SiPID/include/LayerFinder.h
@@ -25,13 +25,13 @@ typedef std::map<EVENT::LCCollection*, CellIDDecoder<TrackerHitPlane>*> Collecti
  * - Hit collection
  * - decoder (layer number decoder string)
  */
-class LayerResolver {
+class LayerResolverBase {
 
 public:
-  LayerResolver(const LayerResolver &);
-  LayerResolver(const int _detTypeFlag, const std::string _collectionName, double _sensThickCheatVal=-1.);
+  LayerResolverBase(const LayerResolverBase &);
+  LayerResolverBase(const int _detTypeFlag, const std::string _collectionName, double _sensThickCheatVal=-1.);
 
-  virtual ~LayerResolver() ;
+  virtual ~LayerResolverBase() ;
 
   /* The detector type flag helps to distinguish pointers
    * to plane from petal resolver objects at runtime.
@@ -51,11 +51,11 @@ public:
 
   int Decode(TrackerHitPlane* thit) const { return (*decoder)(thit)["layer"];}
 
-  const LayerResolver& operator=(const LayerResolver&);
+  const LayerResolverBase& operator=(const LayerResolverBase&);
 
   virtual double SensitiveThickness(int nLayer) const { return (this->*ThicknessSensitive)(nLayer); }
-  typedef  double (LayerResolver::*LayerResolverFn)(int) const;
-  bool CheatsSensThickness() const { return (ThicknessSensitive==&LayerResolver::SensitiveThicknessCheat) ; }
+  typedef  double (LayerResolverBase::*LayerResolverFn)(int) const;
+  bool CheatsSensThickness() const { return (ThicknessSensitive==&LayerResolverBase::SensitiveThicknessCheat) ; }
 
 protected:
 
@@ -73,35 +73,35 @@ protected:
   EVENT::LCCollection *collection;
   CellIDDecoder<TrackerHitPlane>* decoder;
 
-  LayerResolver();
+  LayerResolverBase();
 
 };
 
 
-template <class T> class SmartResolver : public LayerResolver {
+template <class T> class LayerResolver : public LayerResolverBase {
 
 public:
-  SmartResolver(const SmartResolver<T> &lt);
-  SmartResolver(const int _detTypeFlag, T *,
+  LayerResolver(const LayerResolver<T> &lt);
+  LayerResolver(const int _detTypeFlag, T *,
                 const std::string _collectionName,
                 double _sensThickCheatVal=-1.);
 
-  ~SmartResolver() {};
+  ~LayerResolver() {};
 
   unsigned GetNumberOfLayers() const { return layering->layers.size(); }
 
-  const SmartResolver& operator=(const SmartResolver<T>&);
+  const LayerResolver& operator=(const LayerResolver<T>&);
   const T *GetLayering() const {return layering;};
 
 protected:
   double SensitiveThicknessRead(int nLayer) const ;
   const T *layering;
 
-  SmartResolver();
+  LayerResolver();
 };
 
-typedef SmartResolver<dd4hep::rec::ZDiskPetalsData> PETAL_RESOLVER;
-typedef SmartResolver<dd4hep::rec::ZPlanarData> PLANE_RESOLVER;
+typedef LayerResolver<dd4hep::rec::ZDiskPetalsData> PETAL_RESOLVER;
+typedef LayerResolver<dd4hep::rec::ZPlanarData> PLANE_RESOLVER;
 
 /*
 class PetalResolver : public LayerResolver{
@@ -186,7 +186,7 @@ public:
   void ReportKnownDetectors();
 
 protected:
-  std::vector<LayerResolver*> knownDetectors{};
+  std::vector<LayerResolverBase*> knownDetectors{};
 
   // Default constructor. Not very useful.
   LayerFinder();

--- a/Analysis/SiPID/include/LayerFinder.h
+++ b/Analysis/SiPID/include/LayerFinder.h
@@ -47,13 +47,13 @@ public:
   int   GetNumberOfHits() const;
   TrackerHitPlane* GetHit(int i) const;
 
-  virtual int GetNumberOfLayers() const = 0;
+  virtual unsigned GetNumberOfLayers() const = 0;
 
   int Decode(TrackerHitPlane* thit) const { return (*decoder)(thit)["layer"];}
 
   const LayerResolver& operator=(const LayerResolver&);
 
-  double SensitiveThickness(int nLayer) const { return (this->*ThicknessSensitive)(nLayer); }
+  virtual double SensitiveThickness(int nLayer) const { return (this->*ThicknessSensitive)(nLayer); }
   typedef  double (LayerResolver::*LayerResolverFn)(int) const;
   bool CheatsSensThickness() const { return (ThicknessSensitive==&LayerResolver::SensitiveThicknessCheat) ; }
 
@@ -78,6 +78,32 @@ protected:
 };
 
 
+template <class T> class SmartResolver : public LayerResolver {
+
+public:
+  SmartResolver(const SmartResolver<T> &lt);
+  SmartResolver(const int _detTypeFlag, T *,
+                const std::string _collectionName,
+                double _sensThickCheatVal=-1.);
+
+  ~SmartResolver() {};
+
+  unsigned GetNumberOfLayers() const { return layering->layers.size(); }
+
+  const SmartResolver& operator=(const SmartResolver<T>&);
+  const T *GetLayering() const {return layering;};
+
+protected:
+  double SensitiveThicknessRead(int nLayer) const ;
+  const T *layering;
+
+  SmartResolver();
+};
+
+typedef SmartResolver<dd4hep::rec::ZDiskPetalsData> PETAL_RESOLVER;
+typedef SmartResolver<dd4hep::rec::ZPlanarData> PLANE_RESOLVER;
+
+/*
 class PetalResolver : public LayerResolver{
 public:
   PetalResolver(const PetalResolver &lt);
@@ -126,7 +152,7 @@ protected:
 
 };
 
-
+*/
 
 /* LayerFinder class parses tracker hit collections in the event
  * finds where the hit belogs,

--- a/Analysis/SiPID/include/LayerFinder.h
+++ b/Analysis/SiPID/include/LayerFinder.h
@@ -54,6 +54,7 @@ public:
   virtual unsigned GetNumberOfLayers() const = 0;
 
   int Decode(TrackerHitPlane* thit, const char *what="layer") const { return (*decoder)(thit)[what];}
+  bool HasCollection() const { return static_cast<bool>(decoder); }
 
   const LayerResolverBase& operator=(const LayerResolverBase&);
 

--- a/Analysis/SiPID/include/LayerFinder.h
+++ b/Analysis/SiPID/include/LayerFinder.h
@@ -128,7 +128,7 @@ class LayerFinder {
 public:
   // Constructor with the vector of collection names that the finder
   // will use when looking for the collection.
-  LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector&, FloatVec sensThickCheatVals, int elementMask);
+  LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector&, FloatVec sensThickCheatVals);
   // Copy constructor
   LayerFinder( const LayerFinder& );
 

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -2,6 +2,7 @@
 #define SiTracker_dEdxProcessor_h 1
 
 #include <string>
+#include <chrono>
 
 #include "marlin/Processor.h"
 #include "MarlinTrk/Factory.h"
@@ -138,6 +139,17 @@ class SiTracker_dEdxProcessor : public Processor {
   LayerFinder *layerFinder{};
 
   int lastRunHeaderProcessed{};
+
+  unsigned nTimers = 8;
+  std::vector<std::chrono::duration<double>> timers;
+  std::chrono::high_resolution_clock::time_point lastTP;
+  std::chrono::high_resolution_clock::time_point newTP;
+  void addTime(int i) {
+    newTP = std::chrono::high_resolution_clock::now();
+    timers.at(i) += std::chrono::duration_cast<std::chrono::duration<double>>(newTP - lastTP);
+    lastTP = newTP;
+  }
+
 } ;
 
 #endif

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -54,6 +54,8 @@ class SiTracker_dEdxProcessor : public Processor {
   SiTracker_dEdxProcessor() ;
   SiTracker_dEdxProcessor(const SiTracker_dEdxProcessor &) ;
   
+  virtual ~SiTracker_dEdxProcessor() ;
+
   SiTracker_dEdxProcessor & operator = (const SiTracker_dEdxProcessor &);
 
   /** Called at the begin of the job before anything is read.

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -52,11 +52,11 @@ class SiTracker_dEdxProcessor : public Processor {
   virtual Processor*  newProcessor() { return new SiTracker_dEdxProcessor ; }
   
   SiTracker_dEdxProcessor() ;
-  SiTracker_dEdxProcessor(const SiTracker_dEdxProcessor &) ;
+  SiTracker_dEdxProcessor(const SiTracker_dEdxProcessor &) = delete;
   
   virtual ~SiTracker_dEdxProcessor() ;
 
-  SiTracker_dEdxProcessor & operator = (const SiTracker_dEdxProcessor &);
+  SiTracker_dEdxProcessor & operator = (const SiTracker_dEdxProcessor &) = delete;
 
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -108,8 +108,6 @@ class SiTracker_dEdxProcessor : public Processor {
    * (Check the order of tracker hit collections in the input LCIO file.)
    */
   StringVec m_trkHitCollNames{};
-  // Bit mask which tracker detector elements to use (respecting the order in LCDD)
-  int m_elementMask{};
 
   // Shall we cheat the sensitive thicknesses?
   bool m_cheatSensorThicknesses{};

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -92,20 +92,8 @@ class SiTracker_dEdxProcessor : public Processor {
   static double dEdxWgtHarmonic(dEdxVec, double &dEdxError);
   static double dEdxWgtHarmonic2(dEdxVec, double &dEdxError);
 
-  // Getters for the copy constructor
-  std::string getTrackCollName() const { return m_trackCollName; }
-  StringVec getTrkHitCollNames() const { return m_trkHitCollNames; }
-  int getElementMask() const { return m_elementMask; }
-  bool cheatsSensorThicknesses() const { return m_cheatSensorThicknesses; }
-  std::string getDEdxEstimator() const { return m_dEdxEstimator; }
-  const dd4hep::rec::SurfaceMap* getSurfaceMap() const { return surfMap; }
-  MarlinTrk::IMarlinTrkSystem* getTrkSystem() const { return trkSystem; }
-  double getBField() const { return _bField; }
-  LayerFinder* getLayerFinder() const { return layerFinder; }
-  int getLastRunHeaderProcessed() const { return lastRunHeaderProcessed; }
 
   typedef double (*evalChoice)(dEdxVec, double &dEdxError);
-  evalChoice getDEdxEval() const { return dEdxEval; }
 
   protected:
 

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -101,7 +101,7 @@ class SiTracker_dEdxProcessor : public Processor {
   evalChoice dEdxEval{};
 
   /*** Steerable parameters ***/
-  // Input collection names
+  // Name of the track collection
   std::string m_trackCollName{};
   /* Tracker hit collection names.
    * Must be in the same order as tracker detector elements in LCDD.

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -80,6 +80,9 @@ class SiTracker_dEdxProcessor : public Processor {
   static bool dEdxOrder(dEdxPoint p1, dEdxPoint p2) { return p1.Get_dEdx() < p2.Get_dEdx() ; }
   static double truncFractionUp;
   static double truncFractionLo;
+  static double dEdxGeneralTruncMean(dEdxVec, double &dEdxError,
+                              const double truncLo=0,
+                              const double truncHi=0);
   static double dEdxMean(dEdxVec, double &dEdxError);
   static double dEdxMedian(dEdxVec, double &dEdxError);
   static double dEdxTruncMean(dEdxVec, double &dEdxError);

--- a/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
+++ b/Analysis/SiPID/include/SiTracker_dEdxProcessor.h
@@ -20,13 +20,13 @@ using namespace marlin ;
 
 
 
-/**  SiTracker_dEdxProcessor for marlin.
+/**  SiTracker_dEdxProcessor for Marlin.
  *
  *  Calculates dEdx for planar silicon trackers and stores the information
  *  with the tracks in the lcio file.
  *
- * @author S. Lukic, Vinca, Belgrade
- * December 2016
+ * S. Lukic, Vinca, Belgrade
+ * Dec 2016 - Jan 2018
  */
 
 
@@ -63,8 +63,7 @@ class SiTracker_dEdxProcessor : public Processor {
    */
   virtual void init() ;
   
-  /** Called for every run.
-   * Really?
+  /** Called at the end of every run.
    */
   virtual void processRunHeader( LCRunHeader* run ) ;
   

--- a/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
+++ b/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
@@ -82,32 +82,6 @@ AnalyseSidEdxProcessor::AnalyseSidEdxProcessor() : Processor("AnalyseSidEdxProce
 }
 
 
-AnalyseSidEdxProcessor::AnalyseSidEdxProcessor(const AnalyseSidEdxProcessor& orig) :
-    Processor("AnalyseSidEdxProcessor"),
-    m_rootFileName(orig.m_rootFileName), m_trackColName(orig.m_trackColName),
-    m_linkColName(orig.m_linkColName), m_trkHitCollNames(orig.m_trkHitCollNames),
-    rootfile(NULL),
-    tree(NULL),
-    nTracks(orig.nTracks), lastRunHeaderProcessed(orig.lastRunHeaderProcessed)
-{
-
-}
-
-AnalyseSidEdxProcessor& AnalyseSidEdxProcessor::operator =(const AnalyseSidEdxProcessor& orig) {
-    if (this == &orig) return *this;
-    this->m_rootFileName = orig.m_rootFileName;
-    this->m_trackColName = orig.m_trackColName;
-    this->m_linkColName = orig.m_linkColName;
-    this->m_trkHitCollNames = orig.m_trkHitCollNames;
-    this->rootfile = orig.rootfile;
-    this->tree = orig.tree;
-    this->nTracks = orig.nTracks;
-    this->lastRunHeaderProcessed = orig.lastRunHeaderProcessed;
-
-    return *this;
-}
-
-
 void AnalyseSidEdxProcessor::init() {
 
   streamlog_out(DEBUG) << "   init called  " << std::endl ;

--- a/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
+++ b/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
@@ -217,8 +217,16 @@ void AnalyseSidEdxProcessor::processEvent( LCEvent * evt ) {
     /*** Find the associated MC particle ***/
 
     const LCObjectVec& mcParticles = track2mcNav->getRelatedToObjects(track);
+    if (mcParticles.size() == 0) {
+      streamlog_out(WARNING) << " No MCParticles connected to this track! Skipping track.\n";
+      continue;
+    }
     streamlog_out(DEBUG) << " Number of MCParticles connected to this track " << mcParticles.size() << std::endl;
     const FloatVec& mcpWeights = track2mcNav->getRelatedToWeights(track);
+    if (mcpWeights.size() == 0) {
+      streamlog_out(WARNING) << " Set of MC particle weights for this track is empty! Skipping track.\n";
+      continue;
+    }
     streamlog_out(DEBUG) << " Number of weights of MCParticle connections " << mcpWeights.size() << std::endl;
 
     if(mcParticles.size() != mcpWeights.size()) {
@@ -276,7 +284,7 @@ void AnalyseSidEdxProcessor::processEvent( LCEvent * evt ) {
       m.push_back(mass);
 
       nTrkHits.push_back(trackhits.size());
-      /**********************/
+      **********************/
 
       eDepHit += trackhits[ihit]->getEDep();
     }
@@ -285,11 +293,6 @@ void AnalyseSidEdxProcessor::processEvent( LCEvent * evt ) {
     // Repeatedly store total energy in event for easier analysis in ROOT
     eEvt.push_back(eThisEvt);
   }
-
-
-
-
-
 
   tree->Fill();
 

--- a/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
+++ b/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
@@ -86,8 +86,8 @@ AnalyseSidEdxProcessor::AnalyseSidEdxProcessor(const AnalyseSidEdxProcessor& ori
     Processor("AnalyseSidEdxProcessor"),
     m_rootFileName(orig.m_rootFileName), m_trackColName(orig.m_trackColName),
     m_linkColName(orig.m_linkColName), m_trkHitCollNames(orig.m_trkHitCollNames),
-    rootfile(orig.rootfile ? orig.rootfile : NULL),
-    tree(orig.tree ? orig.tree : NULL),
+    rootfile(NULL),
+    tree(NULL),
     nTracks(orig.nTracks), lastRunHeaderProcessed(orig.lastRunHeaderProcessed)
 {
 
@@ -338,6 +338,6 @@ void AnalyseSidEdxProcessor::end(){
   //     << " processed " << _nEvt << " events in " << _nRun << " runs "
   //     << std::endl ;
   rootfile->Write();
-
+  rootfile->Close();
 }
 

--- a/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
+++ b/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
@@ -82,6 +82,31 @@ AnalyseSidEdxProcessor::AnalyseSidEdxProcessor() : Processor("AnalyseSidEdxProce
 }
 
 
+AnalyseSidEdxProcessor::AnalyseSidEdxProcessor(const AnalyseSidEdxProcessor& orig) :
+    Processor("AnalyseSidEdxProcessor"),
+    m_rootFileName(orig.m_rootFileName), m_trackColName(orig.m_trackColName),
+    m_linkColName(orig.m_linkColName), m_trkHitCollNames(orig.m_trkHitCollNames),
+    rootfile(orig.rootfile ? orig.rootfile : NULL),
+    tree(orig.tree ? orig.tree : NULL),
+    nTracks(orig.nTracks), lastRunHeaderProcessed(orig.lastRunHeaderProcessed)
+{
+
+}
+
+AnalyseSidEdxProcessor& AnalyseSidEdxProcessor::operator =(const AnalyseSidEdxProcessor& orig) {
+    if (this == &orig) return *this;
+    this->m_rootFileName = orig.m_rootFileName;
+    this->m_trackColName = orig.m_trackColName;
+    this->m_linkColName = orig.m_linkColName;
+    this->m_trkHitCollNames = orig.m_trkHitCollNames;
+    this->rootfile = orig.rootfile;
+    this->tree = orig.tree;
+    this->nTracks = orig.nTracks;
+    this->lastRunHeaderProcessed = orig.lastRunHeaderProcessed;
+
+    return *this;
+}
+
 
 void AnalyseSidEdxProcessor::init() {
 

--- a/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
+++ b/Analysis/SiPID/src/AnalyseSidEdxProcessor.cc
@@ -145,14 +145,14 @@ void AnalyseSidEdxProcessor::processEvent( LCEvent * evt ) {
   zHit.clear(); xHit.clear(); yHit.clear(); eHit.clear(); typeHit.clear();
   double eThisEvt = 0.;
 
-  for(unsigned icoll=0; icoll<m_trkHitCollNames.size(); icoll++) {
+  for( auto hitCollName : m_trkHitCollNames) {
 
     LCCollection* hits = NULL;
     try {
-      hits = evt->getCollection(m_trkHitCollNames.at(icoll));
+      hits = evt->getCollection(hitCollName);
     }
     catch(EVENT::DataNotAvailableException &dataex) {
-      streamlog_out(DEBUG) << "Collection " << m_trkHitCollNames.at(icoll) << " not found in event #" << evt->getEventNumber() << ".\n";
+      streamlog_out(DEBUG) << "Collection " << hitCollName << " not found in event #" << evt->getEventNumber() << ".\n";
       hits = NULL;
       continue;
     }

--- a/Analysis/SiPID/src/LayerFinder.cc
+++ b/Analysis/SiPID/src/LayerFinder.cc
@@ -384,18 +384,6 @@ double LayerFinder::SensitiveThickness(TrackerHitPlane* thit, int &tf) {
         streamlog_out(DEBUG5) << " ... Thickness is " << t/dd4hep::mm << " mm.\n";
         return t;
 
-/*        if (tf & dd4hep::DetType::BARREL) {
-          double t = dynamic_cast<PlaneResolver*>(*cit)->SensitiveThickness(nLayer);
-          streamlog_out(DEBUG5) << " ... Thickness is " << t/dd4hep::mm << " mm.\n";
-          return t;
-        }
-        if (tf & dd4hep::DetType::ENDCAP) {
-          double t = dynamic_cast<PetalResolver*>(*cit)->SensitiveThickness(nLayer);
-          streamlog_out(DEBUG5) << " ... Thickness is " << t/dd4hep::mm << " mm.\n";
-          return t;
-        }
-        streamlog_out(WARNING) << " ... Detector type flag not found!!!\n";
-*/
         // We found it so we can stop searching
         break;
       }

--- a/Analysis/SiPID/src/LayerFinder.cc
+++ b/Analysis/SiPID/src/LayerFinder.cc
@@ -267,7 +267,7 @@ int LayerFinder::ReadCollections(EVENT::LCEvent *evt) {
 
   int nFound=0;
 
-  streamlog_out(DEBUG5) << "CollectionFinder::ReadCollections. Event #" << evt->getEventNumber()
+  streamlog_out(DEBUG5) << "LayerFinder::ReadCollections. Event #" << evt->getEventNumber()
       << ". Number of collections to look for: " << knownDetectors.size() << "\n";
 
   for(ResolverMapIter collit=knownDetectors.begin(); collit!=knownDetectors.end(); collit++) {

--- a/Analysis/SiPID/src/LayerFinder.cc
+++ b/Analysis/SiPID/src/LayerFinder.cc
@@ -170,7 +170,7 @@ double LayerResolver<T>::SensitiveThicknessRead(int nLayer) const {
  * ************************************** */
 
 LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& theDetector,
-                          FloatVec sensThickCheatVals, int elementMask) :
+                          FloatVec sensThickCheatVals) :
   knownDetectors(),
   decoder()
 {
@@ -191,11 +191,6 @@ LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& th
     streamlog_out(MESSAGE) << "\', named \'" << detElements.at(i).name() << "\'\n";
     streamlog_out(MESSAGE) << " ... expects collection name " << _collectionNames[i] << "\n";
     streamlog_out(MESSAGE) << " ... has type flags " << detElements.at(i).typeFlag() << "\n";
-
-    if(! (elementMask & 1 << i) ) {
-      streamlog_out(MESSAGE) << "Turned OFF in the element mask (see ElementMask parameter).\n";
-      continue;
-    }
 
     int tf = detElements.at(i).typeFlag();
 

--- a/Analysis/SiPID/src/LayerFinder.cc
+++ b/Analysis/SiPID/src/LayerFinder.cc
@@ -14,16 +14,6 @@
  * Implementation of base class LayerResolverBase
  * *********************************************** */
 
-LayerResolverBase::LayerResolverBase(const LayerResolverBase &lt) :
-  ThicknessSensitive( lt.CheatsSensThickness() ? &LayerResolverBase::SensitiveThicknessCheat : NULL ),
-  sensThickCheatVal(lt.SensitiveThicknessCheat(0)),
-  detTypeFlag(lt.GetDetTypeFlag()),
-  collectionName(lt.GetCollectionName()),
-  detectorName(lt.GetDetectorName()),
-  collection(lt.collection),
-  decoder(lt.decoder)
-{}
-
 LayerResolverBase::LayerResolverBase(const int _detTypeFlag,
     const std::string _collectionName, const std::string _detectorName, double _sensThickCheatVal) :
   ThicknessSensitive( _sensThickCheatVal>0. ? &LayerResolverBase::SensitiveThicknessCheat : NULL ),
@@ -35,28 +25,9 @@ LayerResolverBase::LayerResolverBase(const int _detTypeFlag,
   decoder(NULL)
 {}
 
-LayerResolverBase::LayerResolverBase() :
-  ThicknessSensitive(NULL),
-  sensThickCheatVal(0),
-  detTypeFlag(0),
-  collectionName(""),
-  detectorName(""),
-  collection(NULL),
-  decoder(NULL)
-{}
-
-
 LayerResolverBase::~LayerResolverBase() {
   if(decoder) delete decoder;
   decoder=NULL;
-}
-
-const LayerResolverBase& LayerResolverBase::operator =(const LayerResolverBase& lr) {
-  this->detTypeFlag = lr.detTypeFlag;
-  this->collectionName = lr.collectionName;
-  this->detectorName = lr.detectorName;
-  this->decoder = lr.decoder;
-  return *this;
 }
 
 std::string LayerResolverBase::GetCollectionType() const {
@@ -113,16 +84,6 @@ int LayerResolverBase::SetCollection(EVENT::LCEvent *evt) {
  * ************************************** */
 
 template <class T>
-LayerResolver<T>::LayerResolver(const LayerResolver<T> &lt) :
-  LayerResolverBase(lt),
-  layering(lt.GetLayering())
-{
-  ThicknessSensitive = (lt.CheatsSensThickness() ?
-      &LayerResolver::SensitiveThicknessCheat :
-      &LayerResolver::SensitiveThicknessRead );
-}
-
-template <class T>
 LayerResolver<T>::LayerResolver(const int _detTypeFlag,
           T *_layering,
           const std::string _collectionName,
@@ -131,32 +92,9 @@ LayerResolver<T>::LayerResolver(const int _detTypeFlag,
   LayerResolverBase(_detTypeFlag, _collectionName, _detectorName, _sensThickCheatVal),
   layering(_layering)
 {
-  if(_sensThickCheatVal < 0) ThicknessSensitive = (LayerResolverFn)(&LayerResolver::SensitiveThicknessRead);
+  if(_sensThickCheatVal < 0) ThicknessSensitive = (LayerResolverFn)(&LayerResolver<T>::SensitiveThicknessRead);
 }
 
-template <class T>
-LayerResolver<T>::LayerResolver() :
-  LayerResolverBase(),
-  layering(NULL)
-{}
-
-template <class T>
-const LayerResolver<T>& LayerResolver<T>::operator=(const LayerResolver<T>& pr)
-  {
-  this->sensThickCheatVal = pr.sensThickCheatVal;
-  this->detTypeFlag = pr.detTypeFlag;
-  this->collectionName = pr.collectionName;
-  this->detectorName = pr.detectorName;
-  this->collection = pr.collection;
-  this->decoder = pr.decoder;
-  this->layering = pr.layering;
-
-  this->ThicknessSensitive = (pr.CheatsSensThickness() ?
-      &LayerResolverBase::SensitiveThicknessCheat :
-      &LayerResolverBase::SensitiveThicknessRead );
-
-  return *this;
-}
 
 template <class T>
 double LayerResolver<T>::SensitiveThicknessRead(int nLayer) const {

--- a/Analysis/SiPID/src/LayerFinder.cc
+++ b/Analysis/SiPID/src/LayerFinder.cc
@@ -171,8 +171,7 @@ double LayerResolver<T>::SensitiveThicknessRead(int nLayer) const {
 
 LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& theDetector,
                           FloatVec sensThickCheatVals) :
-  knownDetectors(),
-  decoder()
+  layerResolvers()
 {
 
   const std::vector< dd4hep::DetElement > &detElements = theDetector.detectors("tracker", true);
@@ -235,9 +234,9 @@ LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& th
       streamlog_out(MESSAGE) << "\n";
     }
 
-    ResolverMapIter it = knownDetectors.find(detElements.at(i).id());
-    if (it == knownDetectors.end()) {
-      knownDetectors[detElements.at(i).id()] = sr;
+    ResolverMapIter it = layerResolvers.find(detElements.at(i).id());
+    if (it == layerResolvers.end()) {
+      layerResolvers[detElements.at(i).id()] = sr;
     }
     else {
       streamlog_out(ERROR) << "Detector element \'" << detElements.at(i).name()
@@ -258,43 +257,15 @@ LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& th
 }
 
 
-LayerFinder::LayerFinder( const LayerFinder& orig ) :
-  knownDetectors(orig.knownDetectors),
-  decoder(orig.decoder)
-{
-}
-
-
-LayerFinder& LayerFinder::operator = (const LayerFinder& orig) {
-
-  this->decoder = orig.decoder;
-  this->knownDetectors = orig.knownDetectors;
-
-  return *this;
-}
-
-
 int LayerFinder::ReadCollections(EVENT::LCEvent *evt) {
 
-  bool isDecoderUpToDate = false;
+  for(auto collit : layerResolvers) {
 
-  for(ResolverMapIter collit=knownDetectors.begin(); collit!=knownDetectors.end(); collit++) {
-
-    int collSet = collit->second->SetCollection(evt);
-
-    if (!isDecoderUpToDate) {
-      if (collSet == 0) {
-        decoder = collit->second->GetDecoder();
-        isDecoderUpToDate = true;
-      }
-    }
+    collit.second->SetCollection(evt);
 
   } // End loop over known detectors
 
-  if (isDecoderUpToDate) return 0;
-
-  return -1; // No tracker hit collections found.
-
+  return 0;
 }
 
 
@@ -303,17 +274,17 @@ double LayerFinder::SensitiveThickness(TrackerHitPlane* thit) {
   streamlog_out(DEBUG5) << "LayerFinder::SensitiveThickness() for hit ID = " << thit->getCellID0() << ".\n";
 
   // Decode system ID where the hit is located.
-  int systemID = Decode(thit, "system");
+  int systemID = FindSystem(thit);
 
   // Check if the system is registered for handling by the processor
-  ResolverMapIter resolver = knownDetectors.find(systemID);
-  if (resolver == knownDetectors.end()) {
+  ResolverMapIter resolver = layerResolvers.find(systemID);
+  if (resolver == layerResolvers.end()) {
     streamlog_out(WARNING) << "Hit is located in the system with ID " << systemID
-        << " which is not configured for handling by the processor.\n";
+        << " which is not handled by the processor.\n";
     return -1.;
   }
 
-  streamlog_out(DEBUG5) << "Hit is located in subdetector \'" << knownDetectors[systemID]->GetDetectorName()
+  streamlog_out(DEBUG5) << "Hit is located in subdetector \'" << resolver->second->GetDetectorName()
       << "\' with system ID " << systemID << "\n";
 
   double t = resolver->second->SensitiveThickness(thit);
@@ -323,18 +294,39 @@ double LayerFinder::SensitiveThickness(TrackerHitPlane* thit) {
 }
 
 
-void LayerFinder::ReportKnownDetectors() {
+void LayerFinder::ReportHandledDetectors() {
 
 
-  streamlog_out(DEBUG5) << "LayerFinder knows the following detectors:\n";
-  for(ResolverMapIter dit=knownDetectors.begin(); dit!=knownDetectors.end(); dit++) {
+  streamlog_out(DEBUG5) << "LayerFinder handles the following detectors:\n";
+  for(auto dit : layerResolvers) {
     std::string dettype;
-    if      (dit->second->GetDetTypeFlag() & dd4hep::DetType::BARREL) dettype = "BARREL";
-    else if (dit->second->GetDetTypeFlag() & dd4hep::DetType::ENDCAP) dettype = "ENDCAP";
-    streamlog_out(DEBUG5) << "Detector \'" << dit->second->GetDetectorName() << "\' of type \'" << dettype;
-    streamlog_out(DEBUG5) << "\' associated with collection name \'" << dit->second->GetCollectionName() << "\'.\n";
-    streamlog_out(DEBUG5) << "Currently looking at collection of type \'" << dit->second->GetCollectionType();
-    streamlog_out(DEBUG5) << "\' with encoding \'" << dit->second->GetCollectionEncoding() << "\'\n";
+    if      (dit.second->GetDetTypeFlag() & dd4hep::DetType::BARREL) dettype = "BARREL";
+    else if (dit.second->GetDetTypeFlag() & dd4hep::DetType::ENDCAP) dettype = "ENDCAP";
+    streamlog_out(DEBUG5) << "Detector \'" << dit.second->GetDetectorName() << "\' of type \'" << dettype;
+    streamlog_out(DEBUG5) << "\' associated with collection name \'" << dit.second->GetCollectionName() << "\'.\n";
+    streamlog_out(DEBUG5) << "Currently looking at collection of type \'" << dit.second->GetCollectionType();
+    streamlog_out(DEBUG5) << "\' with encoding \'" << dit.second->GetCollectionEncoding() << "\'\n";
   }
 }
 
+
+int LayerFinder::FindSystem(TrackerHitPlane* thit) const {
+
+  for( auto cit : layerResolvers) {
+
+    for(int i=0; i<cit.second->GetNumberOfHits(); i++) {
+
+      if( thit == cit.second->GetHit(i) ) {
+
+        streamlog_out(DEBUG5) << " ... Found matching hit " << cit.second->GetHit(i)->getCellID0()
+                                 << " with energy " << cit.second->GetHit(i)->getEDep()
+                                 << " in collection " << cit.second->GetCollectionName() << ".\n";
+
+        return cit.second->DecodeSystem(thit);
+      }
+    } // Loop over hits
+  } // Loop over collections
+
+  return -1;
+
+}

--- a/Analysis/SiPID/src/LayerFinder.cc
+++ b/Analysis/SiPID/src/LayerFinder.cc
@@ -177,9 +177,10 @@ LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& th
   const std::vector< dd4hep::DetElement > &detElements = theDetector.detectors("tracker", true);
 
   if(_collectionNames.size() != detElements.size()) {
-    streamlog_out(WARNING) << "There are " <<  detElements.size() << " tracker detector elements in "
+    streamlog_out(ERROR) << "There are " <<  detElements.size() << " tracker detector elements in "
         "the geometry and " << _collectionNames.size() << " tracker hit collection names have been "
             "set in the parameters.\n";
+    exit(0);
   }
 
   streamlog_out(MESSAGE) << "Tracker has " << detElements.size() << " elements:\n";

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -137,7 +137,7 @@ SiTracker_dEdxProcessor::SiTracker_dEdxProcessor() : Processor("SiTracker_dEdxPr
   registerProcessorParameter("dEdxEstimator" ,
                              "Type of estimator for dEdx.",
                              m_dEdxEstimator ,
-                             std::string("mean") ) ;
+                             std::string("median") ) ;
 
 }
 

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -50,7 +50,7 @@ SiTracker_dEdxProcessor & SiTracker_dEdxProcessor::operator = (const SiTracker_d
   this->surfMap = orig.surfMap;
   this->trkSystem = orig.trkSystem;
   this->_bField = orig._bField;
-  this->layerFinder = orig.layerFinder;
+  this->layerFinder = NULL;
   this->lastRunHeaderProcessed = orig.lastRunHeaderProcessed;
   this->dEdxEval = orig.dEdxEval;
 
@@ -62,7 +62,7 @@ SiTracker_dEdxProcessor::SiTracker_dEdxProcessor(const SiTracker_dEdxProcessor& 
     dEdxEval(orig.dEdxEval),
     m_trackCollName(orig.m_trackCollName), m_trkHitCollNames(orig.m_trkHitCollNames),
     m_elementMask(orig.m_elementMask), surfMap(orig.surfMap), trkSystem(orig.trkSystem),
-    _bField(orig._bField), layerFinder(orig.layerFinder),
+    _bField(orig._bField), layerFinder(NULL),
     lastRunHeaderProcessed(orig.lastRunHeaderProcessed),
     timers(orig.timers),
     lastTP(std::chrono::high_resolution_clock::now()),
@@ -141,6 +141,11 @@ SiTracker_dEdxProcessor::SiTracker_dEdxProcessor() : Processor("SiTracker_dEdxPr
 
 }
 
+
+SiTracker_dEdxProcessor::~SiTracker_dEdxProcessor() {
+
+  if (layerFinder) delete layerFinder;
+}
 
 
 void SiTracker_dEdxProcessor::init() {
@@ -398,6 +403,9 @@ void SiTracker_dEdxProcessor::end(){
   //   std::cout << "SiTracker_dEdxProcessor::end()  " << name()
   //     << " processed " << _nEvt << " events in " << _nRun << " runs "
   //     << std::endl ;
+
+  delete layerFinder;
+  layerFinder = NULL;
 }
 
 

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -38,35 +38,6 @@ dEdxPoint::dEdxPoint(const dEdxPoint& orig) :
 
 SiTracker_dEdxProcessor aSiTracker_dEdxProcessor ;
 
-/**/
-
-SiTracker_dEdxProcessor & SiTracker_dEdxProcessor::operator = (const SiTracker_dEdxProcessor &orig) {
-
-  if (this == &orig) return *this;
-
-  this->m_trackCollName = orig.m_trackCollName;
-  this->m_trkHitCollNames = orig.m_trkHitCollNames;
-  this->surfMap = orig.surfMap;
-  this->trkSystem = orig.trkSystem;
-  this->_bField = orig._bField;
-  this->layerFinder = NULL;
-  this->lastRunHeaderProcessed = orig.lastRunHeaderProcessed;
-  this->dEdxEval = orig.dEdxEval;
-
-  return *this;
-}
-
-SiTracker_dEdxProcessor::SiTracker_dEdxProcessor(const SiTracker_dEdxProcessor& orig) :
-    Processor("SiTracker_dEdxProcessor"),
-    dEdxEval(orig.dEdxEval),
-    m_trackCollName(orig.m_trackCollName), m_trkHitCollNames(orig.m_trkHitCollNames),
-    surfMap(orig.surfMap), trkSystem(orig.trkSystem),
-    _bField(orig._bField), layerFinder(NULL),
-    lastRunHeaderProcessed(orig.lastRunHeaderProcessed),
-    timers(orig.timers),
-    lastTP(std::chrono::high_resolution_clock::now()),
-    newTP(std::chrono::high_resolution_clock::now())
-{}
 
 SiTracker_dEdxProcessor::SiTracker_dEdxProcessor() : Processor("SiTracker_dEdxProcessor"),
     m_trackCollName(""), m_trkHitCollNames(),

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -46,7 +46,6 @@ SiTracker_dEdxProcessor & SiTracker_dEdxProcessor::operator = (const SiTracker_d
 
   this->m_trackCollName = orig.m_trackCollName;
   this->m_trkHitCollNames = orig.m_trkHitCollNames;
-  this->m_elementMask = orig.m_elementMask;
   this->surfMap = orig.surfMap;
   this->trkSystem = orig.trkSystem;
   this->_bField = orig._bField;
@@ -61,7 +60,7 @@ SiTracker_dEdxProcessor::SiTracker_dEdxProcessor(const SiTracker_dEdxProcessor& 
     Processor("SiTracker_dEdxProcessor"),
     dEdxEval(orig.dEdxEval),
     m_trackCollName(orig.m_trackCollName), m_trkHitCollNames(orig.m_trkHitCollNames),
-    m_elementMask(orig.m_elementMask), surfMap(orig.surfMap), trkSystem(orig.trkSystem),
+    surfMap(orig.surfMap), trkSystem(orig.trkSystem),
     _bField(orig._bField), layerFinder(NULL),
     lastRunHeaderProcessed(orig.lastRunHeaderProcessed),
     timers(orig.timers),
@@ -70,7 +69,7 @@ SiTracker_dEdxProcessor::SiTracker_dEdxProcessor(const SiTracker_dEdxProcessor& 
 {}
 
 SiTracker_dEdxProcessor::SiTracker_dEdxProcessor() : Processor("SiTracker_dEdxProcessor"),
-    m_trackCollName(""), m_trkHitCollNames(), m_elementMask(0),
+    m_trackCollName(""), m_trkHitCollNames(),
     surfMap(NULL), trkSystem(NULL), _bField(0),
     layerFinder(NULL),
     lastRunHeaderProcessed(-1),
@@ -110,11 +109,6 @@ SiTracker_dEdxProcessor::SiTracker_dEdxProcessor() : Processor("SiTracker_dEdxPr
   for (unsigned ibit=0; ibit<sizeof(int)*CHAR_BIT; ibit++) {
     elementMask += 1 << ibit;
   }
-
-  registerProcessorParameter("ElementMask" ,
-                             "Bit mask which tracker detector elements to use (respecting the order in LCDD)",
-                             m_elementMask ,
-                             elementMask ) ;
 
   registerProcessorParameter("CheatSensorThicknesses" ,
                              "Shall we use the sensitive thicknesses from parameters?",
@@ -194,7 +188,7 @@ void SiTracker_dEdxProcessor::init() {
     }
   }
 
-  layerFinder = new LayerFinder(m_trkHitCollNames, theDetector, m_sensThicknessCheatVals, m_elementMask);
+  layerFinder = new LayerFinder(m_trkHitCollNames, theDetector, m_sensThicknessCheatVals);
  // exit(0);
 
   const double pos[3]={0,0,0};

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -256,7 +256,6 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
   }
 
   layerFinder->ReportKnownDetectors();
-  streamlog_out(DEBUG5) << "Done reporting detectors.\n";
 
   int nTracks = tracks->getNumberOfElements()  ;
 
@@ -274,7 +273,6 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
       marlin_trk->addHit(*it);
     }//end loop on hits
 
-    streamlog_out(DEBUG5) << "Created marlin_trk.\n";
     const TrackStateImpl *trackState = dynamic_cast<const TrackStateImpl*>(track->getTrackState(TrackState::AtFirstHit));
     if (!trackState) {
       streamlog_out(WARNING) << "Cannot get track state for track #" << i
@@ -282,10 +280,8 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
       streamlog_out(WARNING) << "Skipping track.\n";
       continue;
     }
-    streamlog_out(DEBUG5) << "Got track state." << std::endl;
 
     marlin_trk->initialise( *trackState, _bField, MarlinTrk::IMarlinTrack::forward ) ;
-    streamlog_out(DEBUG5) << "Initialized marlin_trk.\n";
 
     dEdxVec dEdxHitVec;
 
@@ -310,7 +306,6 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
       dd4hep::rec::Vector3D trackDir(trackDirX, trackDirY, trackDirZ);
 
       // Normal to the surface of hit
-      streamlog_out(DEBUG5) << "Looking for the Normal to the surface of hit.\n";
       unsigned long cellid = trackhits[ihit]->getCellID0();
       dd4hep::rec::SurfaceMap::const_iterator surface = surfMap->find(cellid);
       if (surface == surfMap->end()) {
@@ -319,7 +314,6 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
         exit(0);
       }
       dd4hep::rec::Vector3D surfaceNormal = surface->second->normal();
-      streamlog_out(DEBUG5) << "Found surface corresponding to track hit ID " << cellid << ".\n";
 
       double norm = sqrt(trackDir.dot(trackDir)*surfaceNormal.dot(surfaceNormal));
       if (norm < FLT_MIN) continue;

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -258,8 +258,8 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
     EVENT::TrackerHitVec trackhits = track->getTrackerHits();
 
     MarlinTrk::IMarlinTrack* marlin_trk = trkSystem->createTrack();
-    for( EVENT::TrackerHitVec::iterator it = trackhits.begin() ; it != trackhits.end() ; ++it ){
-      marlin_trk->addHit(*it);
+    for( auto it : trackhits ){
+      marlin_trk->addHit(it);
     }//end loop on hits
 
     const TrackStateImpl *trackState = dynamic_cast<const TrackStateImpl*>(track->getTrackState(TrackState::AtFirstHit));

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -388,11 +388,20 @@ double SiTracker_dEdxProcessor::dEdxGeneralTruncMean(dEdxVec hitVec, double &dEd
     const double truncLo, const double truncHi) {
 
   const unsigned n = hitVec.size();
-  if(n == 0) return 0;
-
-  sort(hitVec.begin(), hitVec.end(), dEdxOrder);
   const unsigned iStart = static_cast<unsigned>(floor(n*truncLo + 0.5));
   const unsigned iEnd = static_cast<unsigned>(floor(n*(1-truncHi) + 0.5));
+
+  if(iEnd-iStart == 0) {
+    dEdxError = 0;
+    return 0;
+  }
+  if(iEnd-iStart == 1) {
+    double track_dEdx = hitVec.at(iStart).Get_dE();
+    dEdxError = track_dEdx;
+    return track_dEdx;
+  }
+
+  sort(hitVec.begin(), hitVec.end(), dEdxOrder);
 
   double eDepSum = 0.;
   double thickness = 0.;

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -411,6 +411,8 @@ double SiTracker_dEdxProcessor::dEdxGeneralTruncMean(dEdxVec hitVec, double &dEd
     mu2dEdx += pow(hitVec.at(i).Get_dE(), 2) / hitVec.at(i).Get_dx();
   }
 
+  mu2dEdx /= thickness;
+
   double track_dEdx = eDepSum / thickness;
   dEdxError = sqrt((mu2dEdx - pow(track_dEdx, 2))/(iEnd-iStart));
   return track_dEdx;

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -275,10 +275,16 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
     }//end loop on hits
 
     streamlog_out(DEBUG5) << "Created marlin_trk.\n";
-    TrackStateImpl trackState( *(track->getTrackState(TrackState::AtFirstHit)) );
+    const TrackStateImpl *trackState = dynamic_cast<const TrackStateImpl*>(track->getTrackState(TrackState::AtFirstHit));
+    if (!trackState) {
+      streamlog_out(WARNING) << "Cannot get track state for track #" << i
+                             << " in event " << evt->getEventNumber() << std::endl;
+      streamlog_out(WARNING) << "Skipping track.\n";
+      continue;
+    }
     streamlog_out(DEBUG5) << "Got track state." << std::endl;
 
-    marlin_trk->initialise( trackState, _bField, MarlinTrk::IMarlinTrack::forward ) ;
+    marlin_trk->initialise( *trackState, _bField, MarlinTrk::IMarlinTrack::forward ) ;
     streamlog_out(DEBUG5) << "Initialized marlin_trk.\n";
 
     dEdxVec dEdxHitVec;

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -425,9 +425,8 @@ double SiTracker_dEdxProcessor::dEdxGeneralTruncMean(dEdxVec hitVec, double &dEd
     return 0;
   }
   if(iEnd-iStart == 1) {
-    double track_dEdx = hitVec.at(iStart).Get_dE();
-    dEdxError = track_dEdx;
-    return track_dEdx;
+    dEdxError = hitVec.at(iStart).Get_dEdx() ;
+    return hitVec.at(iStart).Get_dEdx() ;
   }
 
   sort(hitVec.begin(), hitVec.end(), dEdxOrder);
@@ -461,7 +460,14 @@ double SiTracker_dEdxProcessor::dEdxMean(dEdxVec hitVec, double &dEdxError) {
 double SiTracker_dEdxProcessor::dEdxMedian(dEdxVec hitVec, double &dEdxError) {
 
   const unsigned n = hitVec.size();
-  if(n == 0) return 0;
+  if(n == 0) {
+    dEdxError = 0;
+    return 0;
+  }
+  if(n == 1) {
+    dEdxError = hitVec.at(0).Get_dEdx();
+    return hitVec.at(0).Get_dEdx();
+  }
 
   sort(hitVec.begin(), hitVec.end(), dEdxOrder);
   double median=0.;
@@ -472,11 +478,9 @@ double SiTracker_dEdxProcessor::dEdxMedian(dEdxVec hitVec, double &dEdxError) {
     median = (hitVec.at(n/2-1).Get_dEdx() + hitVec.at(n/2).Get_dEdx()) / 2;
   }
 
-  double errMean = 0.;
-  dEdxMean(hitVec, errMean);
-  // Using ratio of the variance of the median to that of the mean
-  // from http://mathworld.wolfram.com/StatisticalMedian.html
-  dEdxError = sqrt(n * M_PI / 2 / (n-1)) * errMean;
+  // Substituting error of the mean for dEdxError here
+  // instead of bootstrapping the error of the median
+  dEdxMean(hitVec, dEdxError);
   return median;
 }
 
@@ -493,7 +497,14 @@ double SiTracker_dEdxProcessor::dEdxTruncMean(dEdxVec hitVec, double &dEdxError)
 double SiTracker_dEdxProcessor::dEdxHarmonic(dEdxVec hitVec, double &dEdxError) {
 
   const unsigned n = hitVec.size();
-  if(n == 0) return 0;
+  if(n == 0) {
+    dEdxError = 0;
+    return 0;
+  }
+  if(n == 1) {
+    dEdxError = hitVec.at(0).Get_dEdx();
+    return hitVec.at(0).Get_dEdx();
+  }
 
   // Calculation of the first and the second moment of
   // 1 / (dE/dx)
@@ -507,10 +518,10 @@ double SiTracker_dEdxProcessor::dEdxHarmonic(dEdxVec hitVec, double &dEdxError) 
 
   double mu2 = mu2sum / n;
   double mu1 = mu1sum / n;
-  double sigma = sqrt( mu2 - pow(mu1, 2) );
+  double sigma = sqrt( (mu2 - pow(mu1, 2)) / n );
 
   double dEdx = 1 / mu1;
-  dEdxError = sigma * pow(dEdx, 2) / sqrt(n) ;
+  dEdxError = sigma / pow(mu1, 2) ;
 
   return dEdx;
 }
@@ -520,7 +531,14 @@ double SiTracker_dEdxProcessor::dEdxHarmonic(dEdxVec hitVec, double &dEdxError) 
 double SiTracker_dEdxProcessor::dEdxHarmonic2(dEdxVec hitVec, double &dEdxError) {
 
   const unsigned n = hitVec.size();
-  if(n == 0) return 0;
+  if(n == 0) {
+    dEdxError = 0;
+    return 0;
+  }
+  if(n == 1) {
+    dEdxError = hitVec.at(0).Get_dEdx();
+    return hitVec.at(0).Get_dEdx();
+  }
 
   // Calculation of the first and the second moment of
   // 1 / (dE/dx)^2
@@ -534,10 +552,10 @@ double SiTracker_dEdxProcessor::dEdxHarmonic2(dEdxVec hitVec, double &dEdxError)
 
   double mu2 = mu2sum / n;
   double mu1 = mu1sum / n;
-  double sigma = sqrt( mu2 - pow(mu1, 2) );
+  double sigma = sqrt( (mu2 - pow(mu1, 2)) / n );
 
   double dEdx = 1 / sqrt(mu1);
-  dEdxError = sigma * pow(dEdx, 3) / 2 / sqrt(n) ;
+  dEdxError = sigma * pow(dEdx, 3) / 2 ;
 
   return dEdx;
 }
@@ -548,7 +566,14 @@ double SiTracker_dEdxProcessor::dEdxHarmonic2(dEdxVec hitVec, double &dEdxError)
 double SiTracker_dEdxProcessor::dEdxWgtHarmonic(dEdxVec hitVec, double &dEdxError) {
 
   const unsigned n = hitVec.size();
-  if(n == 0) return 0;
+  if(n == 0) {
+    dEdxError = 0;
+    return 0;
+  }
+  if(n == 1) {
+    dEdxError = hitVec.at(0).Get_dEdx();
+    return hitVec.at(0).Get_dEdx();
+  }
 
   // Calculation of the first and the second moment of
   // 1 / (dE/dx)
@@ -565,10 +590,10 @@ double SiTracker_dEdxProcessor::dEdxWgtHarmonic(dEdxVec hitVec, double &dEdxErro
 
   double mu2 = mu2sum / wgtsum;
   double mu1 = mu1sum / wgtsum;
-  double sigma = sqrt( mu2 - pow(mu1, 2) );
+  double sigma = sqrt( (mu2 - pow(mu1, 2)) / n );
 
   double dEdx = 1 / mu1;
-  dEdxError = sigma * pow(dEdx, 2) / sqrt(n) ;
+  dEdxError = sigma * pow(dEdx, 2) ;
 
   return dEdx;
 }
@@ -579,7 +604,14 @@ double SiTracker_dEdxProcessor::dEdxWgtHarmonic(dEdxVec hitVec, double &dEdxErro
 double SiTracker_dEdxProcessor::dEdxWgtHarmonic2(dEdxVec hitVec, double &dEdxError) {
 
   const unsigned n = hitVec.size();
-  if(n == 0) return 0;
+  if(n == 0) {
+    dEdxError = 0;
+    return 0;
+  }
+  if(n == 1) {
+    dEdxError = hitVec.at(0).Get_dEdx();
+    return hitVec.at(0).Get_dEdx();
+  }
 
   // Calculation of the first and the second moment of
   // 1 / (dE/dx)^2
@@ -596,10 +628,10 @@ double SiTracker_dEdxProcessor::dEdxWgtHarmonic2(dEdxVec hitVec, double &dEdxErr
 
   double mu2 = mu2sum / wgtsum;
   double mu1 = mu1sum / wgtsum;
-  double sigma = sqrt( mu2 - pow(mu1, 2) );
+  double sigma = sqrt( (mu2 - pow(mu1, 2)) / n );
 
   double dEdx = 1 / sqrt(mu1);
-  dEdxError = sigma * pow(dEdx, 3) / 2 / sqrt(n) ;
+  dEdxError = sigma * pow(dEdx, 3) / 2 ;
 
   return dEdx;
 }

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -271,7 +271,7 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
     return;
   }
 
-  layerFinder->ReportKnownDetectors();
+  //layerFinder->ReportHandledDetectors();
 
   addTime(1);
 

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -341,22 +341,14 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
       double effThickness = thickness / cosAngle;
 
       dEdxHitVec.push_back( dEdxPoint(trackhits[ihit]->getEDep(), effThickness) );
-      // At present there is no method to set dEdx for a EVENT::TrackerHit, IMPL::TrackerHitImpl or IMPL::TrackerHitPlaneImpl
-
-      // I am not sure whether the following is the intended use of the hit "type".
-      // The hit type value is being overwritten here, but it was apparently not used before.
-      // Todo: Why was I doing this at all?
-      /*try {
-        ((IMPL::TrackerHitImpl*)(trackhits[ihit]))->setType(detTypeFlag);
-      }
-      catch (std::exception &) {}*/
 
     }
     if(dEdxHitVec.size() == 0) continue;
 
     double dEdx, dEdxError;
     dEdx = dEdxEval(dEdxHitVec, dEdxError);
-    // This is read-only if track is read from existing lcio file!
+    // Todo: This is read-only if track is read from existing lcio file!
+    // Is there a way to process tracks that are read from the input file?
     track->setdEdx(dEdx);
     track->setdEdxError(dEdxError);
   }

--- a/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
+++ b/Analysis/SiPID/src/SiTracker_dEdxProcessor.cc
@@ -313,9 +313,7 @@ void SiTracker_dEdxProcessor::processEvent( LCEvent * evt ) {
       IMPL::TrackStateImpl ts;
       double chi2 = 0.;
       int ndf = 0;
-      // ToDo marlin_trk->propagate() consumes the bulk of the time
-      // of the processor. Can the processor run without it?
-      marlin_trk->propagate(hitpos, ts, chi2, ndf);
+      marlin_trk->extrapolate(hitpos, ts, chi2, ndf);
 
       addTime(3);
 

--- a/Analysis/SiPID/xml/AnaSidEdx.xml
+++ b/Analysis/SiPID/xml/AnaSidEdx.xml
@@ -30,7 +30,7 @@
     <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
     <parameter name="LinkCollectionName" type="string" lcioInType="LCRelation"> SiTracksMCTruthLink </parameter>
     <parameter name="RootFilename" type="string">ana.mu.root </parameter>
-    <parameter name="Verbosity" type="string">DEBUG </parameter>
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
   </processor>
 
 

--- a/Analysis/SiPID/xml/AnaSidEdx.xml
+++ b/Analysis/SiPID/xml/AnaSidEdx.xml
@@ -15,7 +15,7 @@
     <parameter name="LCIOInputFiles">
       reco.mu.slcio  </parameter>
     <!-- Limit the number of processed records (run+evt): -->
-    <parameter name="MaxRecordNumber" value="0" />
+    <parameter name="MaxRecordNumber" value="-1" />
     <parameter name="SkipNEvents" value="0" />
     <parameter name="SupressCheck" value="false" />  
     <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter>
@@ -27,10 +27,10 @@
 
   <!-- == Track dE/dx analysis parameters == -->
   <processor name="MyAnalyseSidEdxProcessor" type="AnalyseSidEdxProcessor">
-    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
-    <parameter name="LinkCollectionName" type="string" lcioInType="LCRelation">TrackMCTruthLink </parameter>
+    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
+    <parameter name="LinkCollectionName" type="string" lcioInType="LCRelation"> SiTracksMCTruthLink </parameter>
     <parameter name="RootFilename" type="string">ana.mu.root </parameter>
-    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+    <parameter name="Verbosity" type="string">DEBUG </parameter>
   </processor>
 
 

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -983,7 +983,7 @@
     <!--If Using Particle Gun Ignore Gen Stat-->
     <parameter name="UsingParticleGun" type="bool"> true </parameter>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+    <parameter name="Verbosity" type="string"> WARNING </parameter>
     <!--energy cut for daughters that are kept from KeepDaughtersPDG-->
     <parameter name="daughtersECutMeV" type="float"> 10 </parameter>
   </processor>

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -586,7 +586,7 @@
     <!-- compression of output file 0: false >0: true (default) -->
     <parameter name="Compress" type="int" value="1"/>
     <!-- filename without extension-->
-    <parameter name="FileName" type="string" value="histograms500GeV_ttbar"/>
+    <parameter name="FileName" type="string" value="aida_histograms"/>
     <!-- type of output file xml (default) or root ( only OpenScientist)-->
     <parameter name="FileType" type="string" value="root "/>
   </processor>
@@ -1311,7 +1311,7 @@
   <!-- == Track dE/dx parameters == -->
   <processor name="MySiTracker_dEdxProcessor" type="SiTracker_dEdxProcessor">
     <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
-    <parameter name="Verbosity" type="string">DEBUG5 </parameter>
+    <parameter name="Verbosity" type="string">MESSAGE </parameter>
     <parameter name="TrkHitCollections" type="StringVec">
       ITrackerHits
       ITrackerEndcapHits

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -593,7 +593,7 @@
 
 
   <processor name="EventNumber" type="Statusmonitor">
-    <parameter name="HowOften" type="int">1 </parameter>
+    <parameter name="HowOften" type="int">100 </parameter>
     <parameter name="Verbosity" type="string"> MESSAGE </parameter>
   </processor>
 

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -72,7 +72,7 @@
 
     <!-- ========== output  ========== -->
 
-    <group name="PfoSelector" />
+    <!-- group name="PfoSelector" /-->
 
     <processor name="Output_REC"/>
     <processor name="Output_DST"/>
@@ -88,7 +88,7 @@
     <parameter name="MaxRecordNumber" value="-1" />
     <parameter name="SkipNEvents" value="0" />
     <parameter name="SupressCheck" value="false" />
-    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING  </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter>
     <parameter name="RandomSeed" value="1234567890" />
   </global>
 

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -1311,7 +1311,7 @@
   <!-- == Track dE/dx parameters == -->
   <processor name="MySiTracker_dEdxProcessor" type="SiTracker_dEdxProcessor">
     <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
-    <parameter name="Verbosity" type="string">MESSAGE </parameter>
+    <parameter name="Verbosity" type="string">DEBUG5 </parameter>
     <parameter name="TrkHitCollections" type="StringVec">
       ITrackerHits
       ITrackerEndcapHits

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -1341,9 +1341,9 @@
           -->
     <!--parameter name="ElementMask" type="int"> 15 </parameter-->
     <!-- Type of estimator for dEdx.
-         Available estimators: mean, truncMean, harmonic, harmonic-2,
+         Available estimators: mean, median, truncMean, harmonic, harmonic-2,
          weighted-harmonic, weighted-harmonic-2
-         Default: mean.
+         Default: median.
           -->
     <parameter name="dEdxEstimator" type="string">harmonic-2 </parameter>
   </processor>

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="us-ascii"?>
+
+<!-- Steering file to run CLIC reconstruction with the dE/dx processor
+     for the silicon tracker -->
+
 <marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
   <execute>
 
@@ -1303,10 +1307,10 @@
     <parameter name="Verbosity" type="string">WARNING </parameter>
   </processor>
 
+
   <!-- == Track dE/dx parameters == -->
   <processor name="MySiTracker_dEdxProcessor" type="SiTracker_dEdxProcessor">
-    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
-    <parameter name="LinkCollectionName" type="string" lcioInType="LCRelation">TrackMCTruthLink </parameter>
+    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
     <parameter name="Verbosity" type="string">MESSAGE </parameter>
     <parameter name="TrkHitCollections" type="StringVec">
       ITrackerHits
@@ -1333,6 +1337,7 @@
          element that you want to use, where i is the order of the tracker
          element in LCDD.
          Default: use all elements.
+         Feature not ready.
           -->
     <!--parameter name="ElementMask" type="int"> 15 </parameter-->
     <!-- Type of estimator for dEdx.
@@ -1341,7 +1346,6 @@
          Default: mean.
           -->
     <parameter name="dEdxEstimator" type="string">harmonic-2 </parameter>
-
   </processor>
 
 

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -109,6 +109,8 @@
     <parameter name="Overlay" type="string">False </parameter>
     <!--Which option to use for tracking: Truth, ConformalPlusExtrapolator, Conformal-->
     <parameter name="Tracking" type="string">Truth </parameter>
+    <parameter name="Tracking" type="string">Truth </parameter>
+    <parameter name="Verbosity" type="string">WARNING </parameter>
   </processor>
 
   <group name="Overlay">
@@ -1331,7 +1333,7 @@
          negative values for thicknesses that should not be cheated
          Here we are cheating the thicknesses of the tracker barrel regions
          because they are defined per "layer" with 2 sensors. -->
-    <parameter name="SensorThicknessCheatValues" type="FloatVec"> 0.015 -1 0.015 -1 -1 -1 </parameter>
+    <parameter name="SensorThicknessCheatValues" type="FloatVec"> 0.05 0.05 0.1 0.1 0.1 0.1 </parameter>
     <!-- Type of estimator for dEdx.
          Available estimators: mean, median, truncMean, harmonic, harmonic-2,
          weighted-harmonic, weighted-harmonic-2

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -1332,14 +1332,6 @@
          Here we are cheating the thicknesses of the tracker barrel regions
          because they are defined per "layer" with 2 sensors. -->
     <parameter name="SensorThicknessCheatValues" type="FloatVec"> 0.015 -1 0.015 -1 -1 -1 </parameter>
-    <!-- Integer bitmask that specifies which tracker detector elements to use.
-         To obtain the integer value of the mask, add up 2^i for each tracker
-         element that you want to use, where i is the order of the tracker
-         element in LCDD.
-         Default: use all elements.
-         Feature not ready.
-          -->
-    <!--parameter name="ElementMask" type="int"> 15 </parameter-->
     <!-- Type of estimator for dEdx.
          Available estimators: mean, median, truncMean, harmonic, harmonic-2,
          weighted-harmonic, weighted-harmonic-2


### PR DESCRIPTION

BEGINRELEASENOTES

Updates of SiTracker_dEdxProcessor:
- Cleaned up unnecessary code.
- Added runtime protection against failure of TrackImpl::getTrackState().
- Replaced `MarlinTrk::IMarlinTrack::propagate()` which was making the processor ~1000X slower than necessary with `MarlinTrk::IMarlinTrack::extrapolate()`. 
- Removed unnecessary parameters.

Updates of AnalyseSidEdxProcessor:
- Added minor runtime protections.

ENDRELEASENOTES