### PR TITLE
SiPID: fresh update

### DIFF
--- a/Analysis/SiPID/include/AnalyseSidEdxProcessor.h
+++ b/Analysis/SiPID/include/AnalyseSidEdxProcessor.h
@@ -36,6 +36,9 @@ class AnalyseSidEdxProcessor : public Processor {
   virtual Processor*  newProcessor() { return new AnalyseSidEdxProcessor ; }
 
   AnalyseSidEdxProcessor() ;
+  AnalyseSidEdxProcessor(const AnalyseSidEdxProcessor&) = delete ;
+
+  AnalyseSidEdxProcessor& operator=(const AnalyseSidEdxProcessor&) = delete ;
 
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.

--- a/Analysis/SiPID/src/LayerFinder.cc
+++ b/Analysis/SiPID/src/LayerFinder.cc
@@ -10,79 +10,54 @@
 #include <LayerFinder.h>
 #include "DD4hep/DD4hepUnits.h"
 
-/******************************************
- * Implementation of base class LayerResolver
- * ************************************** */
+/***************************************************
+ * Implementation of base class LayerResolverBase
+ * *********************************************** */
 
-LayerResolver::LayerResolver(const LayerResolver &lt) :
-  ThicknessSensitive( lt.CheatsSensThickness() ? &LayerResolver::SensitiveThicknessCheat : NULL ),
-  sensThickCheatVal(lt.SensitiveThicknessCheat(0)),
-  detTypeFlag(lt.GetDetTypeFlag()),
-  collectionName(lt.GetCollectionName()),
-  collection(lt.collection),
-  decoder(lt.decoder)
-{}
-
-LayerResolver::LayerResolver(const int _detTypeFlag,
-              const std::string _collectionName, double _sensThickCheatVal) :
-  ThicknessSensitive( _sensThickCheatVal>0. ? &LayerResolver::SensitiveThicknessCheat : NULL ),
+LayerResolverBase::LayerResolverBase(const int _detTypeFlag,
+    const std::string _collectionName, const std::string _detectorName, double _sensThickCheatVal) :
+  ThicknessSensitive( _sensThickCheatVal>0. ? &LayerResolverBase::SensitiveThicknessCheat : NULL ),
   sensThickCheatVal(_sensThickCheatVal),
   detTypeFlag(_detTypeFlag),
   collectionName(_collectionName),
+  detectorName(_detectorName),
   collection(NULL),
   decoder(NULL)
 {}
 
-LayerResolver::LayerResolver() :
-  ThicknessSensitive(NULL),
-  sensThickCheatVal(0),
-  detTypeFlag(0),
-  collectionName(""),
-  collection(NULL),
-  decoder(NULL)
-{}
-
-
-LayerResolver::~LayerResolver() {
+LayerResolverBase::~LayerResolverBase() {
   if(decoder) delete decoder;
   decoder=NULL;
 }
 
-const LayerResolver& LayerResolver::operator =(const LayerResolver& lr) {
-  this->detTypeFlag = lr.detTypeFlag;
-  this->collectionName = lr.collectionName;
-  this->decoder = lr.decoder;
-  return *this;
-}
-
-std::string LayerResolver::GetCollectionType() const {
+std::string LayerResolverBase::GetCollectionType() const {
   if (collection) return collection->getTypeName();
   else return "NONE";
 }
 
-std::string LayerResolver::GetCollectionEncoding() const {
+std::string LayerResolverBase::GetCollectionEncoding() const {
   if (collection)
     return collection->getParameters().getStringVal( lcio::LCIO::CellIDEncoding );
   else return "EMPTY";
 }
 
 // Event-by-event:
-int LayerResolver::GetNumberOfHits() const {
+int LayerResolverBase::GetNumberOfHits() const {
   if (collection) return collection->getNumberOfElements();
   else return -1;
 }
 
-TrackerHitPlane* LayerResolver::GetHit(int i) const {
+TrackerHitPlane* LayerResolverBase::GetHit(int i) const {
   if (collection) return dynamic_cast<TrackerHitPlane*>(collection->getElementAt(i));
   else return NULL;
 }
 
-int LayerResolver::SetCollection(EVENT::LCEvent *evt) {
+int LayerResolverBase::SetCollection(EVENT::LCEvent *evt) {
 
-  delete decoder;
+  if (decoder) delete decoder;
   decoder = NULL;
 
-  streamlog_out(DEBUG) << "LayerResolver::SetCollection: Looking for collection "
+  streamlog_out(DEBUG5) << "LayerResolver::SetCollection: Looking for collection "
       << collectionName << ".\n";
   try {
     collection = evt->getCollection(collectionName);
@@ -96,100 +71,36 @@ int LayerResolver::SetCollection(EVENT::LCEvent *evt) {
 
   decoder = new CellIDDecoder<TrackerHitPlane>(collection);
 
-  streamlog_out(DEBUG) << "Found collection of type " << collection->getTypeName()
-                       << " with encoding "
-                       << collection->getParameters().getStringVal( lcio::LCIO::CellIDEncoding ) << "\n";
+  streamlog_out(DEBUG5) << "Found collection of type \'" << collection->getTypeName()
+                       << "\' with encoding \'"
+                       << collection->getParameters().getStringVal( lcio::LCIO::CellIDEncoding ) << "\'\n";
   return 0;
 }
 
 
 
 /******************************************
- * Implementation of class PetalResolver
+ * Implementation of class LayerResolver
  * ************************************** */
 
-PetalResolver::PetalResolver(const PetalResolver &lt) :
-  LayerResolver(lt),
-  layering(lt.GetLayering())
-{
-  if(ThicknessSensitive == NULL) ThicknessSensitive = (LayerResolverFn)(&PetalResolver::SensitiveThicknessRead);
-}
-
-PetalResolver::PetalResolver(const int _detTypeFlag,
-          dd4hep::rec::ZDiskPetalsData *_layering,
+template <class T>
+LayerResolver<T>::LayerResolver(const int _detTypeFlag,
+          T *_layering,
           const std::string _collectionName,
+          const std::string _detectorName,
           double _sensThickCheatVal) :
-  LayerResolver(_detTypeFlag, _collectionName, _sensThickCheatVal),
+  LayerResolverBase(_detTypeFlag, _collectionName, _detectorName, _sensThickCheatVal),
   layering(_layering)
 {
-  if(_sensThickCheatVal < 0) ThicknessSensitive = (LayerResolverFn)(&PetalResolver::SensitiveThicknessRead);
+  if(_sensThickCheatVal < 0) ThicknessSensitive = (LayerResolverFn)(&LayerResolver<T>::SensitiveThicknessRead);
 }
 
-PetalResolver::PetalResolver() :
-  LayerResolver(),
-  layering(NULL)
-{}
 
-const PetalResolver& PetalResolver::operator=(const PetalResolver& pr)
-  {
-  this->detTypeFlag = pr.detTypeFlag;
-  this->collectionName = pr.collectionName;
-  this->decoder = pr.decoder;
-  this->layering = pr.layering;
-  return *this;
-}
-
-double PetalResolver::SensitiveThicknessRead(int nLayer) const {
+template <class T>
+double LayerResolver<T>::SensitiveThicknessRead(int nLayer) const {
   return layering->layers.at(nLayer).thicknessSensitive;
 }
 
-
-
-
-/******************************************
- * Implementation of class PlaneResolver
- * ************************************** */
-
-PlaneResolver::PlaneResolver(const PlaneResolver &lt) :
-  LayerResolver(lt),
-  layering(lt.GetLayering())
-{
-  if(!lt.CheatsSensThickness()) ThicknessSensitive = (LayerResolverFn)(&PlaneResolver::SensitiveThicknessRead);
-}
-
-PlaneResolver::PlaneResolver(const int _detTypeFlag,
-                             dd4hep::rec::ZPlanarData *_layering,
-                             const std::string _collectionName,
-                             double _sensThickCheatVal):
-  LayerResolver(_detTypeFlag, _collectionName, _sensThickCheatVal),
-  layering(_layering)
-{
-  if(_sensThickCheatVal < 0) ThicknessSensitive = (LayerResolverFn)(&PlaneResolver::SensitiveThicknessRead);
-}
-
-PlaneResolver::PlaneResolver() :
-  LayerResolver(),
-  layering(NULL)
-{}
-
-
-const PlaneResolver& PlaneResolver::operator=(const PlaneResolver& pr)
-  {
-  this->detTypeFlag = pr.detTypeFlag;
-  this->collectionName = pr.collectionName;
-  this->decoder = pr.decoder;
-  this->layering = pr.layering;
-  return *this;
-}
-
-double PlaneResolver::SensitiveThicknessRead(int nLayer) const {
-  return layering->layers.at(nLayer).thicknessSensitive;
-}
-
-
-LayerFinder::LayerFinder() :
-knownDetectors()
-{}
 
 
 /******************************************
@@ -197,104 +108,83 @@ knownDetectors()
  * ************************************** */
 
 LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& theDetector,
-                          FloatVec sensThickCheatVals, int elementMask) :
-  knownDetectors()
+                          FloatVec sensThickCheatVals) :
+  layerResolvers()
 {
 
   const std::vector< dd4hep::DetElement > &detElements = theDetector.detectors("tracker", true);
 
   if(_collectionNames.size() != detElements.size()) {
-    streamlog_out(WARNING) << "There are " <<  detElements.size() << " tracker detector elements in "
+    streamlog_out(ERROR) << "There are " <<  detElements.size() << " tracker detector elements in "
         "the geometry and " << _collectionNames.size() << " tracker hit collection names have been "
             "set in the parameters.\n";
+    exit(0);
   }
 
   streamlog_out(MESSAGE) << "Tracker has " << detElements.size() << " elements:\n";
 
   for(unsigned i=0; i<detElements.size(); i++) {
 
-    streamlog_out(MESSAGE) << "Detector element #" << i << " of type " << detElements.at(i).type();
-    streamlog_out(MESSAGE) << ", named " << detElements.at(i).name() << "\n";
+    streamlog_out(MESSAGE) << "Detector element #" << i << " of type \'" << detElements.at(i).type();
+    streamlog_out(MESSAGE) << "\', named \'" << detElements.at(i).name() << "\'\n";
     streamlog_out(MESSAGE) << " ... expects collection name " << _collectionNames[i] << "\n";
     streamlog_out(MESSAGE) << " ... has type flags " << detElements.at(i).typeFlag() << "\n";
 
-    if(! (elementMask & 1 << i) ) {
-      streamlog_out(MESSAGE) << "Turned OFF in the element mask (see ElementMask parameter).\n";
-      continue;
-    }
+    int tf = detElements.at(i).typeFlag();
 
-    int tf = 0;
-
-    void *layering_tmp = NULL;
+    LayerResolverBase *sr = NULL;
 
     try {
       streamlog_out(DEBUG) << "Trying ZPlanarData.\n";
-      layering_tmp = detElements.at(i).extension<dd4hep::rec::ZPlanarData>() ;
-      tf = dd4hep::DetType::BARREL;
+      dd4hep::rec::ZPlanarData* layering = detElements.at(i).extension<dd4hep::rec::ZPlanarData>() ;
+      sr = new PlaneResolver(tf, layering, _collectionNames[i], detElements.at(i).name(), sensThickCheatVals.at(i));
     }
     catch ( std::exception &e) {
       streamlog_out(DEBUG) << "Caught exception " << e.what() << std::endl;
       try {
             streamlog_out(DEBUG) << "Trying ZDiskPetalsData.\n";
-            layering_tmp = detElements.at(i).extension<dd4hep::rec::ZDiskPetalsData>() ;
-            tf = dd4hep::DetType::ENDCAP;
+            dd4hep::rec::ZDiskPetalsData *layering = detElements.at(i).extension<dd4hep::rec::ZDiskPetalsData>() ;
+            sr = new PetalResolver(tf, layering, _collectionNames[i], detElements.at(i).name(), sensThickCheatVals.at(i));
           }
       catch ( std::exception &e1) {
         streamlog_out(DEBUG) << "Caught exception " << e1.what() << std::endl;
       }
     }
 
-    if (tf & dd4hep::DetType::BARREL) {
-
-      dd4hep::rec::ZPlanarData *layering = static_cast<dd4hep::rec::ZPlanarData*>(layering_tmp);
-      streamlog_out(MESSAGE) << " ... has " << layering->layers.size() << " layers with thicknesses: ";
-
-      for(unsigned iLayer = 0; iLayer < layering->layers.size(); iLayer++) {
-
-        double sensThick = layering->layers.at(i).thicknessSensitive/dd4hep::mm;
-        streamlog_out(MESSAGE) << sensThick << " mm, ";
-
-        if(sensThick < 1.e-6 && sensThickCheatVals.at(i) < 0.) {
-          streamlog_out(ERROR) << "Detector element #" << i << ", named " << detElements.at(i).name()
-              << " has sensitive thickness " << sensThick << " mm in layer " << iLayer
-              << " and cheat value has not been set.\n";
-          exit(0);
-        }
-      }
-
-      streamlog_out(MESSAGE) << "\n";
-      knownDetectors.push_back(new PlaneResolver(tf, layering, _collectionNames[i], sensThickCheatVals.at(i)));
-
+    if (!sr) {
+      streamlog_out(ERROR) << "Could not find a semiconductor layering extension in the detector element! Aborting.";
+      exit(0);
     }
-    else if (tf & dd4hep::DetType::ENDCAP) {
 
-      dd4hep::rec::ZDiskPetalsData *layering = static_cast<dd4hep::rec::ZDiskPetalsData*>(layering_tmp);
-      streamlog_out(MESSAGE) << " ... has " << layering->layers.size() << " layers with thicknesses: ";
+    streamlog_out(MESSAGE) << "Detector element has " << sr->GetNumberOfLayers() << " layers with thicknesses: ";
 
-      for(unsigned iLayer = 0; iLayer < layering->layers.size(); iLayer++) {
+    for(unsigned iLayer = 0; iLayer < sr->GetNumberOfLayers(); iLayer++) {
 
-        double sensThick = layering->layers.at(i).thicknessSensitive/dd4hep::mm;
-        streamlog_out(MESSAGE) << sensThick << " mm, ";
+      double sensThick = sr->SensitiveThickness(iLayer)/dd4hep::mm;
+      streamlog_out(MESSAGE) << sensThick << " mm, ";
 
-        if(sensThick < 1.e-6 && sensThickCheatVals.at(i) < 0.) {
-          streamlog_out(ERROR) << "Detector element #" << i << ", named " << detElements.at(i).name()
-              << " has sensitive thickness " << sensThick << " mm in layer " << iLayer
-              << " and cheat value has not been set.\n";
-          exit(0);
-        }
+      if(sensThick < 1.e-6 && sensThickCheatVals.at(i) < 0.) {
+        streamlog_out(ERROR) << "Detector element #" << i << ", named \'" << detElements.at(i).name()
+            << "\' has sensitive thickness " << sensThick << " mm in layer " << iLayer
+            << " and cheat value has not been set.\n";
+        exit(0);
       }
 
       streamlog_out(MESSAGE) << "\n";
-      knownDetectors.push_back(new PetalResolver(tf, layering, _collectionNames[i], sensThickCheatVals.at(i)));
+    }
+
+    ResolverMapIter it = layerResolvers.find(detElements.at(i).id());
+    if (it == layerResolvers.end()) {
+      layerResolvers[detElements.at(i).id()] = sr;
     }
     else {
-      streamlog_out(WARNING) << "Detector element #" << i << " of type " << detElements.at(i).type();
-      streamlog_out(WARNING) << ", named " << detElements.at(i).name() << " has neither an extension"
-          " of type ZPlanarData nor of type ZDiskPetalsData and will not be added!\n";
-      streamlog_out(WARNING) << "dd4hep::DetType::BARREL = " << dd4hep::DetType::BARREL << "\n";
-      streamlog_out(WARNING) << "dd4hep::DetType::ENDCAP = " << dd4hep::DetType::ENDCAP << "\n";
-      streamlog_out(WARNING) << "Our type = " << tf << "\n";
+      streamlog_out(ERROR) << "Detector element \'" << detElements.at(i).name()
+          << "\' has ID = " << detElements.at(i).id()
+          << " which is already taken by the detector element \'"
+          << it->second->GetDetectorName() << "\'! Aborting.\n";
+      exit(0);
     }
+
 
     if(sensThickCheatVals.at(i) > 0.) {
       streamlog_out(MESSAGE) << " ... Replacing this detector sensitive thicknesses with value "
@@ -306,87 +196,76 @@ LayerFinder::LayerFinder(EVENT::StringVec _collectionNames, dd4hep::Detector& th
 }
 
 
-
 int LayerFinder::ReadCollections(EVENT::LCEvent *evt) {
 
-  int nFound=0;
+  for(auto collit : layerResolvers) {
 
-  streamlog_out(DEBUG5) << "CollectionFinder::ReadCollections. Event #" << evt->getEventNumber()
-      << ". Number of collections to look for: " << knownDetectors.size() << "\n";
-
-  for(std::vector<LayerResolver*>::iterator collit=knownDetectors.begin(); collit!=knownDetectors.end(); collit++) {
-
-    if ((*collit)->SetCollection(evt) == 0) nFound++;
+    collit.second->SetCollection(evt);
 
   } // End loop over known detectors
-  return nFound;
 
+  return 0;
 }
 
 
-double LayerFinder::SensitiveThickness(TrackerHitPlane* thit, int &tf) {
+double LayerFinder::SensitiveThickness(TrackerHitPlane* thit) {
 
-  streamlog_out(DEBUG5) << "CollectionFinder::SensitiveThickness() for hit ID = " << thit->getCellID0() << ".\n";
+  streamlog_out(DEBUG5) << "LayerFinder::SensitiveThickness() for hit ID = " << thit->getCellID0() << ".\n";
 
-  for(std::vector<LayerResolver*>::iterator cit=knownDetectors.begin(); cit!=knownDetectors.end(); cit++) {
+  // Decode system ID where the hit is located.
+  int systemID = FindSystem(thit);
 
-    streamlog_out(DEBUG5) << " ... Looking in collection " << (*cit)->GetCollectionName() ;
-    streamlog_out(DEBUG5) << " of type "
-                         << (*cit)->GetCollectionType() << " with " << (*cit)->GetNumberOfHits() << " hits.\n";
-
-    for(int i=0; i<(*cit)->GetNumberOfHits(); i++) {
-
-      if( thit == (*cit)->GetHit(i) ) {
-
-        streamlog_out(DEBUG5) << " ... Found matching hit " << (*cit)->GetHit(i)->getCellID0()
-                                 << " with energy " << (*cit)->GetHit(i)->getEDep()
-                                 << " in collection " << (*cit)->GetCollectionName() << ".\n";
-
-        int nLayer = (*cit)->Decode(thit);
-        tf = (*cit)->GetDetTypeFlag();
-        int nLayers = (*cit)->GetNumberOfLayers();
-
-        streamlog_out(DEBUG5) << " ... Layer number is " << nLayer << ".\n";
-        streamlog_out(DEBUG5) << " ... Number of layers is " << nLayers << ".\n";
-        if(nLayer >= nLayers) {
-          streamlog_out(ERROR) << "CollectionFinder::SensitiveThickness() -- Layer number out of range!\n";
-          return 1.;
-        }
-
-
-        if (tf & dd4hep::DetType::BARREL) {
-          double t = dynamic_cast<PlaneResolver*>(*cit)->SensitiveThickness(nLayer);
-          streamlog_out(DEBUG5) << " ... Thickness is " << t/dd4hep::mm << " mm.\n";
-          return t;
-        }
-        if (tf & dd4hep::DetType::ENDCAP) {
-          double t = dynamic_cast<PetalResolver*>(*cit)->SensitiveThickness(nLayer);
-          streamlog_out(DEBUG5) << " ... Thickness is " << t/dd4hep::mm << " mm.\n";
-          return t;
-        }
-        streamlog_out(WARNING) << " ... Detector type flag not found!!!\n";
-
-        // We found it so we can stop searching
-        break;
-      }
-    }
+  // Check if the system is registered for handling by the processor
+  ResolverMapIter resolver = layerResolvers.find(systemID);
+  if (resolver == layerResolvers.end()) {
+    streamlog_out(WARNING) << "Hit is located in the system with ID " << systemID
+        << " which is not handled by the processor.\n";
+    return -1.;
   }
-  return -1.;
+
+  streamlog_out(DEBUG5) << "Hit is located in subdetector \'" << resolver->second->GetDetectorName()
+      << "\' with system ID " << systemID << "\n";
+
+  double t = resolver->second->SensitiveThickness(thit);
+
+  streamlog_out(DEBUG5) << " ... Thickness is " << t/dd4hep::mm << " mm.\n";
+  return t;
 }
 
 
-void LayerFinder::ReportKnownDetectors() {
+void LayerFinder::ReportHandledDetectors() {
 
 
-  streamlog_out(DEBUG5) << "LayerFinder knows the following detectors:\n";
-  for(std::vector<LayerResolver*>::iterator dit=knownDetectors.begin(); dit!=knownDetectors.end(); dit++) {
+  streamlog_out(DEBUG5) << "LayerFinder handles the following detectors:\n";
+  for(auto dit : layerResolvers) {
     std::string dettype;
-    if      ((*dit)->GetDetTypeFlag() & dd4hep::DetType::BARREL) dettype = "BARREL";
-    else if ((*dit)->GetDetTypeFlag() & dd4hep::DetType::ENDCAP) dettype = "ENDCAP";
-    streamlog_out(DEBUG5) << "Detector of type " << dettype;
-    streamlog_out(DEBUG5) << " associated with collection name " << (*dit)->GetCollectionName() << "\n";
-    streamlog_out(DEBUG5) << "Currently looking at collection of type " << (*dit)->GetCollectionType();
-    streamlog_out(DEBUG5) << " with encoding " << (*dit)->GetCollectionEncoding() << "\n";
+    if      (dit.second->GetDetTypeFlag() & dd4hep::DetType::BARREL) dettype = "BARREL";
+    else if (dit.second->GetDetTypeFlag() & dd4hep::DetType::ENDCAP) dettype = "ENDCAP";
+    streamlog_out(DEBUG5) << "Detector \'" << dit.second->GetDetectorName() << "\' of type \'" << dettype;
+    streamlog_out(DEBUG5) << "\' associated with collection name \'" << dit.second->GetCollectionName() << "\'.\n";
+    streamlog_out(DEBUG5) << "Currently looking at collection of type \'" << dit.second->GetCollectionType();
+    streamlog_out(DEBUG5) << "\' with encoding \'" << dit.second->GetCollectionEncoding() << "\'\n";
   }
 }
 
+
+int LayerFinder::FindSystem(TrackerHitPlane* thit) const {
+
+  for( auto cit : layerResolvers) {
+
+    for(int i=0; i<cit.second->GetNumberOfHits(); i++) {
+
+      if( thit == cit.second->GetHit(i) ) {
+
+        streamlog_out(DEBUG5) << " ... Found matching hit " << cit.second->GetHit(i)->getCellID0()
+                                 << " with energy " << cit.second->GetHit(i)->getEDep()
+                                 << " in collection " << cit.second->GetCollectionName() << ".\n";
+
+        return cit.second->DecodeSystem(thit);
+      }
+    } // Loop over hits
+  } // Loop over collections
+
+  return -1;
+
+}

--- a/Analysis/SiPID/xml/AnaSidEdx.xml
+++ b/Analysis/SiPID/xml/AnaSidEdx.xml
@@ -15,7 +15,7 @@
     <parameter name="LCIOInputFiles">
       reco.mu.slcio  </parameter>
     <!-- Limit the number of processed records (run+evt): -->
-    <parameter name="MaxRecordNumber" value="0" />
+    <parameter name="MaxRecordNumber" value="-1" />
     <parameter name="SkipNEvents" value="0" />
     <parameter name="SupressCheck" value="false" />  
     <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter>
@@ -27,8 +27,8 @@
 
   <!-- == Track dE/dx analysis parameters == -->
   <processor name="MyAnalyseSidEdxProcessor" type="AnalyseSidEdxProcessor">
-    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
-    <parameter name="LinkCollectionName" type="string" lcioInType="LCRelation">TrackMCTruthLink </parameter>
+    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
+    <parameter name="LinkCollectionName" type="string" lcioInType="LCRelation"> SiTracksMCTruthLink </parameter>
     <parameter name="RootFilename" type="string">ana.mu.root </parameter>
     <parameter name="Verbosity" type="string">MESSAGE </parameter>
   </processor>

--- a/Analysis/SiPID/xml/SiTrack_dEdx.xml
+++ b/Analysis/SiPID/xml/SiTrack_dEdx.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="us-ascii"?>
+
+<!-- Steering file to run CLIC reconstruction with the dE/dx processor
+     for the silicon tracker -->
+
 <marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
   <execute>
 
@@ -68,7 +72,7 @@
 
     <!-- ========== output  ========== -->
 
-    <group name="PfoSelector" />
+    <!-- group name="PfoSelector" /-->
 
     <processor name="Output_REC"/>
     <processor name="Output_DST"/>
@@ -84,7 +88,7 @@
     <parameter name="MaxRecordNumber" value="-1" />
     <parameter name="SkipNEvents" value="0" />
     <parameter name="SupressCheck" value="false" />
-    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING  </parameter>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter>
     <parameter name="RandomSeed" value="1234567890" />
   </global>
 
@@ -105,6 +109,8 @@
     <parameter name="Overlay" type="string">False </parameter>
     <!--Which option to use for tracking: Truth, ConformalPlusExtrapolator, Conformal-->
     <parameter name="Tracking" type="string">Truth </parameter>
+    <parameter name="Tracking" type="string">Truth </parameter>
+    <parameter name="Verbosity" type="string">WARNING </parameter>
   </processor>
 
   <group name="Overlay">
@@ -582,14 +588,14 @@
     <!-- compression of output file 0: false >0: true (default) -->
     <parameter name="Compress" type="int" value="1"/>
     <!-- filename without extension-->
-    <parameter name="FileName" type="string" value="histograms500GeV_ttbar"/>
+    <parameter name="FileName" type="string" value="aida_histograms"/>
     <!-- type of output file xml (default) or root ( only OpenScientist)-->
     <parameter name="FileType" type="string" value="root "/>
   </processor>
 
 
   <processor name="EventNumber" type="Statusmonitor">
-    <parameter name="HowOften" type="int">1 </parameter>
+    <parameter name="HowOften" type="int">100 </parameter>
     <parameter name="Verbosity" type="string"> MESSAGE </parameter>
   </processor>
 
@@ -979,7 +985,7 @@
     <!--If Using Particle Gun Ignore Gen Stat-->
     <parameter name="UsingParticleGun" type="bool"> true </parameter>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+    <parameter name="Verbosity" type="string"> WARNING </parameter>
     <!--energy cut for daughters that are kept from KeepDaughtersPDG-->
     <parameter name="daughtersECutMeV" type="float"> 10 </parameter>
   </processor>
@@ -1303,10 +1309,10 @@
     <parameter name="Verbosity" type="string">WARNING </parameter>
   </processor>
 
+
   <!-- == Track dE/dx parameters == -->
   <processor name="MySiTracker_dEdxProcessor" type="SiTracker_dEdxProcessor">
-    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
-    <parameter name="LinkCollectionName" type="string" lcioInType="LCRelation">TrackMCTruthLink </parameter>
+    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
     <parameter name="Verbosity" type="string">MESSAGE </parameter>
     <parameter name="TrkHitCollections" type="StringVec">
       ITrackerHits
@@ -1327,21 +1333,13 @@
          negative values for thicknesses that should not be cheated
          Here we are cheating the thicknesses of the tracker barrel regions
          because they are defined per "layer" with 2 sensors. -->
-    <parameter name="SensorThicknessCheatValues" type="FloatVec"> 0.015 -1 0.015 -1 -1 -1 </parameter>
-    <!-- Integer bitmask that specifies which tracker detector elements to use.
-         To obtain the integer value of the mask, add up 2^i for each tracker
-         element that you want to use, where i is the order of the tracker
-         element in LCDD.
-         Default: use all elements.
-          -->
-    <!--parameter name="ElementMask" type="int"> 15 </parameter-->
+    <parameter name="SensorThicknessCheatValues" type="FloatVec"> 0.05 0.05 0.1 0.1 0.1 0.1 </parameter>
     <!-- Type of estimator for dEdx.
-         Available estimators: mean, truncMean, harmonic, harmonic-2,
+         Available estimators: mean, median, truncMean, harmonic, harmonic-2,
          weighted-harmonic, weighted-harmonic-2
-         Default: mean.
+         Default: median.
           -->
     <parameter name="dEdxEstimator" type="string">harmonic-2 </parameter>
-
   </processor>
 
 


### PR DESCRIPTION

BEGINRELEASENOTES

Updates of SiTracker_dEdxProcessor:

- Cleaned up unnecessary code.
- Added runtime protection against failure of `TrackImpl::getTrackState()`.
- Replaced `MarlinTrk::IMarlinTrack::propagate()` which was making the processor ~1000X slower than necessary with `MarlinTrk::IMarlinTrack::extrapolate()`.
- Removed unnecessary parameters.

Updates of AnalyseSidEdxProcessor:

-   Added minor runtime protections.

ENDRELEASENOTES