### PR TITLE
change relation direction: reco -> sim; add info to relation collecti…

### DIFF
--- a/CaloDigi/Realistic/include/RealisticCaloDigi.h
+++ b/CaloDigi/Realistic/include/RealisticCaloDigi.h
@@ -24,6 +24,9 @@ class RealisticCaloDigi : virtual public Processor {
  public:
 
   RealisticCaloDigi( ) ;
+  RealisticCaloDigi ( const RealisticCaloDigi& ) = delete;
+  RealisticCaloDigi& operator=(const RealisticCaloDigi&) = delete;
+
   virtual void init() ;
   virtual void processRunHeader( LCRunHeader* run ) ;
   virtual void processEvent( LCEvent * evt ) ; 
@@ -81,6 +84,7 @@ class RealisticCaloDigi : virtual public Processor {
   int _threshold_iunit{};
 
   LCFlagImpl _flag{};
+  LCFlagImpl _flag_rel{};
 
   float _event_correl_miscalib{};
 

--- a/CaloDigi/Realistic/include/RealisticCaloReco.h
+++ b/CaloDigi/Realistic/include/RealisticCaloReco.h
@@ -34,11 +34,15 @@ class RealisticCaloReco : virtual public Processor {
   
  public:
   RealisticCaloReco() ;
+  RealisticCaloReco ( const RealisticCaloReco& ) = delete;
+  RealisticCaloReco& operator=(const RealisticCaloReco&) = delete;
+
   virtual void init() ;
   virtual void processRunHeader( LCRunHeader* run ) ;
   virtual void processEvent( LCEvent * evt ) ; 
   virtual void check( LCEvent * evt ) ; 
   virtual void end() ;
+
 
  protected:
 
@@ -57,6 +61,8 @@ class RealisticCaloReco : virtual public Processor {
 
   // internal variables
   LCFlagImpl _flag{};
+  LCFlagImpl _flag_rel{};
+
   CellIDDecoder<CalorimeterHit> * _idDecoder{};
 
 } ;


### PR DESCRIPTION
…on; fix compiler warnings

BEGINRELEASENOTES
- Change order of hit relations: now from reco/digi -> sim [to be consistent with past practice and all other processors]
- Add to/from type info to the relation collections
- Fix warnings from the compiler
ENDRELEASENOTES