### PR TITLE
Fix index out-of-range, compiler warnings, id of initial CNs, MCParti…

### DIFF
--- a/Analysis/TrueJet/include/TrueJet.h
+++ b/Analysis/TrueJet/include/TrueJet.h
@@ -43,6 +43,9 @@ class TrueJet : public Processor {
   
   
   TrueJet() ;
+
+  TrueJet& operator=(const TrueJet&) = delete ;
+  TrueJet(const TrueJet&) = delete ;  
   
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -135,7 +138,7 @@ private:
                         // or from a W from eg a top decay
     int elementon[26]{};  // I just invented that word (collective for quarks, leptons and elementary bosons) 
     int boson[26]{};
-    int fafp_boson[25]{};  // fafp of the boson creating this jet. 
+    int fafp_boson[26]{};  // fafp of the boson creating this jet. 
     int fafp[26]{};       // first fafp of the jet = either fafp_last (jet not from boson) or fafp_boson (jet from boson)
     int nfsr[26]{};
     int type[26]{};


### PR DESCRIPTION
…cle collection does not need to start with the beam-particles, nitty-gritty special cases



BEGINRELEASENOTES
- improved TrueJet processor:
     - Fixed crash due to index out-of-range
     - Remove all compiler warnings except local shadow (cheked to be OK)
     -  id of initial ColourNeutrals fixed (should be a boson (W,Z,H))
     - MCParticle collection does not need to start with the beam-particles, back-tracking now also
gracefully stops if the first entry is reached. This should allow for usage also for the DBD-250 samples, in which the initial beam-particles are missing in the MCParticle collections.
     - nitty-gritty special cases in history fixed.
     - Now also works for higgs-samples *except for h->gluon gluon*, which will need a completely different treatment fro back-track through the parton shower, as there is no quark-line to follow...



ENDRELEASENOTES