### PR TITLE
fix bug in TrueJet_Parser::final_cn, replace math.h by cmath in Use_T…

### DIFF
--- a/Analysis/TrueJet_Parser/examples/Use_TrueJet/src/Use_TrueJet.cc
+++ b/Analysis/TrueJet_Parser/examples/Use_TrueJet/src/Use_TrueJet.cc
@@ -1,7 +1,6 @@
 #include "Use_TrueJet.h"
 #include <stdlib.h>
-#include <math.h>
-//#include <cmath>
+#include <cmath>
 #include <iostream>
 #include <iomanip>
 

--- a/Analysis/TrueJet_Parser/src/TrueJet_Parser.cc
+++ b/Analysis/TrueJet_Parser/src/TrueJet_Parser.cc
@@ -296,7 +296,7 @@ int TrueJet_Parser::final_cn( int ijet ) {
    LCObjectVec fcnvec = relfcn->getRelatedToObjects( jets->at(ijet) );
    int fcn ;
    if (fcnvec.size() > 0 ) {
-     fcn=fcnvec[0]->ext<IcnIndex>();
+     fcn=fcnvec[0]->ext<FcnIndex>();
    } else {
      fcn = -1 ;
    }


### PR DESCRIPTION
…rueJet

r2 | berggren | 2019-01-11 18:12:26 +0100 (Fr, 11 Jan 2019) | 2 lines



BEGINRELEASENOTES
- fix bug in TrueJet_Parser::final_cn, replace math.h by cmath in Use_TrueJet

ENDRELEASENOTES