### PR TITLE
SimpleFcalDigi fix (cellID1)

### DIFF
--- a/CaloDigi/LDCCaloDigi/src/SimpleFCalDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/SimpleFCalDigi.cc
@@ -139,6 +139,7 @@ void SimpleFCalDigi::processEvent( LCEvent * evt ) {
   LCFlagImpl flag;
 
   flag.setBit(LCIO::CHBIT_LONG);
+  flag.setBit(LCIO::CHBIT_ID1);
 
   lcalcol->setFlag(flag.getFlag());
 


### PR DESCRIPTION

BEGINRELEASENOTES
- SimpleFcalDigi processor:
    - Missing cellid 1 flag in fcal output collection, causing issues in the BeamCal reconstruction

ENDRELEASENOTES