### PR TITLE
Default-compile ErrorFlow processor in MarlinReco

### DIFF
--- a/Analysis/ErrorFlow/include/ErrorFlow.h
+++ b/Analysis/ErrorFlow/include/ErrorFlow.h
@@ -99,56 +99,56 @@ class ErrorFlow : public Processor
 
 	  /** Input collection name.
 	  */
-	  std::string p_inputJetCollection;
-	  std::string p_outputJetCollection;
-	  std::string p_inputMCTruth;
+	  std::string p_inputJetCollection {};
+	  std::string p_outputJetCollection {};
+	  std::string p_inputMCTruth {};
 
 	  // Semi-leptonic correction
-	  bool p_semiLepCorrection;                 /* Add semi-leptonic energy resolution to the covariance matrix */
-      double p_semiLepSigmaCorrFactor;          /* A correction factor to be multiplied by total lepton energy to get semi-leptonic uncertainty */
+	  bool p_semiLepCorrection {};                 /* Add semi-leptonic energy resolution to the covariance matrix */
+      double p_semiLepSigmaCorrFactor {};          /* A correction factor to be multiplied by total lepton energy to get semi-leptonic uncertainty */
 
 	  // Confusion scale factor
-	  double p_scaleConf;                        /* A factor to use to scale confusion term */
+	  double p_scaleConf {};                        /* A factor to use to scale confusion term */
 	  
 	  // Calorimeter resolution parameters
-	  double p_aECAL;                      /* Stochastic term coefficient in ECAL resolution */
-	  double p_cECAL;                      /* Constant term coefficinet in ECAL resolution */
-	  double p_aHCAL;                      /* Stochastic term coefficient in HCAL resolution */
-	  double p_cHCAL;                      /* Constant term coefficient in HCAL resolution */
+	  double p_aECAL {};                      /* Stochastic term coefficient in ECAL resolution */
+	  double p_cECAL {};                      /* Constant term coefficinet in ECAL resolution */
+	  double p_aHCAL {};                      /* Stochastic term coefficient in HCAL resolution */
+	  double p_cHCAL {};                      /* Constant term coefficient in HCAL resolution */
 
 	  // Confusion scale factor
-	  bool p_storeTree;                        /* Enable/disable storing in a ROOT tree */
+	  bool p_storeTree {};                        /* Enable/disable storing in a ROOT tree */
 
 	  // Counters for PFOs
-      int numChargedPFOs;                       /* Number of charged PFOs in a jet */
-	  int numPhotons;                           /* Number of photons in a jet */
-      int numNeutralPFOs;                       /* Number of charged PFOs in a jet */
+      int numChargedPFOs {};                       /* Number of charged PFOs in a jet */
+	  int numPhotons {};                           /* Number of photons in a jet */
+      int numNeutralPFOs {};                       /* Number of charged PFOs in a jet */
 
 	  // Energy of PFOs
-      double eChargedPFOs;                      /* Total energy of charged PFOs in a jet  */
-	  double ePhotons;                          /* Total energy of photons in a jet  */
-      double eNeutralPFOs;                      /* Total energy of neutral PFOs in a jet  */
-	  double eJetTotal;                         /* Sum of energy of all PFOs */
-      double eLeptonsTotal;                     /* Sum of energy of all leptons in a jet */
+      double eChargedPFOs {};                      /* Total energy of charged PFOs in a jet  */
+	  double ePhotons {};                          /* Total energy of photons in a jet  */
+      double eNeutralPFOs {};                      /* Total energy of neutral PFOs in a jet  */
+	  double eJetTotal {};                         /* Sum of energy of all PFOs */
+      double eLeptonsTotal {};                     /* Sum of energy of all leptons in a jet */
 
 	  // Resolution
-      double absDetResSquared;                  /* Total absolute detector resolution */
-      double relConfCharged;                    /* Relative confusion term for charged PFOs */
-      double relConfPhotons;                    /* Relative confusion term for photons */
-      double relConfNeutral;                    /* Relative confusion term for neutral PFOs */
-	  double relConfSquared;                    /* Total relative confusion squared  */
-	  double absConfSquared;                    /* Total absolute confusion squared  */
-      double absSemiLepResSquared;              /* Total absolute semi-leptonic resolution  */
+      double absDetResSquared {};                  /* Total absolute detector resolution */
+      double relConfCharged {};                    /* Relative confusion term for charged PFOs */
+      double relConfPhotons {};                    /* Relative confusion term for photons */
+      double relConfNeutral {};                    /* Relative confusion term for neutral PFOs */
+	  double relConfSquared {};                    /* Total relative confusion squared  */
+	  double absConfSquared {};                    /* Total absolute confusion squared  */
+      double absSemiLepResSquared {};              /* Total absolute semi-leptonic resolution  */
 
-	  int p_nRun;
-	  int p_nEvt;
+	  int p_nRun {};
+	  int p_nEvt {};
 
    private:
 	  /* ====================  METHODS       ======================================= */
 
 	  /* ====================  DATA MEMBERS  ======================================= */
-	  TTree* tree;
-	  ReconstructedParticleVec::size_type nPFOs;
+	  std::shared_ptr<TTree> tree {};
+	  ReconstructedParticleVec::size_type nPFOs {};
 
 }; /* -----  end of class ErrorFlow  ----- */
 

--- a/Analysis/ErrorFlow/src/ErrorFlow.cc
+++ b/Analysis/ErrorFlow/src/ErrorFlow.cc
@@ -136,7 +136,7 @@ void ErrorFlow::init() {
 
 	// Create a ROOT file if enabled in the steering file
 	if ( p_storeTree ) {
-	   tree = new TTree("ErrorFlow", "Number of photons, charged and neutral hadrons in a jet");
+	   tree = std::make_shared<TTree>("ErrorFlow", "Number of photons, charged and neutral hadrons in a jet");
 	   // PFO count branches
 	   tree->Branch( "numPhotons" , &numPhotons, "numPhotons/I");
 	   tree->Branch( "numChargedPFOs" , &numChargedPFOs, "numChargedPFOs/I");
@@ -169,7 +169,7 @@ void ErrorFlow::init() {
  *  Description:  
  * =====================================================================================
  */
-void ErrorFlow::processRunHeader( LCRunHeader* run ) { 
+void ErrorFlow::processRunHeader( LCRunHeader* /*run*/ ) { 
 
     p_nRun++ ;
 
@@ -499,7 +499,7 @@ double ErrorFlow::getTotalMomentum ( const double * t_threeMomentum )
  *  Description:  
  * =====================================================================================
  */
-void ErrorFlow::check( LCEvent * evt ) { 
+void ErrorFlow::check( LCEvent * /*evt*/ ) { 
     // nothing to check here - could be used to fill checkplots in reconstruction processor
 } /* -----  end of function ErrorFlow::check  ----- */
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ ADD_MARLINRECO_PKG( ./Analysis/CLICPfoSelector )
 ADD_MARLINRECO_PKG( ./Analysis/EventShapes )
 ADD_MARLINRECO_PKG( ./Analysis/TJjetsPFOAnalysisProcessor )
 ADD_MARLINRECO_PKG( ./Analysis/GammaGammaHadronRemoval )
+ADD_MARLINRECO_PKG( ./Analysis/ErrorFlow )
 
 ADD_MARLINRECO_PKG( ./Calibration/AbsCalibration )
 ADD_MARLINRECO_PKG( ./CaloDigi/LDCCaloDigi )


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove compiler warnings for ErrorFlow processor (default initialization in header, using shared_ptr instead of raw pointer).
- Add ErrorFlow processor to list of processors to be compiled by default in MarlinReco.

ENDRELEASENOTES