### PR TITLE
Add option to include full CovMat of neutrals

### DIFF
--- a/Analysis/ErrorFlow/include/ErrorFlow.h
+++ b/Analysis/ErrorFlow/include/ErrorFlow.h
@@ -118,6 +118,7 @@ class ErrorFlow : public Processor
 
 	  // Confusion scale factor
 	  bool p_storeTree {};                        /* Enable/disable storing in a ROOT tree */
+	  bool p_useFullCovMatNeut {};                /* Enable/disable using full CovMat for neutral PFOs */
 
 	  // Counters for PFOs
       int numChargedPFOs {};                       /* Number of charged PFOs in a jet */


### PR DESCRIPTION
BEGINRELEASENOTES
- An option is added to include full CovMat of neutral PFOs in jet error
ENDRELEASENOTES