### PR TITLE
RealisticCaloDigi: new ROC integration

### DIFF
--- a/CaloDigi/Realistic/doc/Readme_ROCTiming.md
+++ b/CaloDigi/Realistic/doc/Readme_ROCTiming.md
@@ -1,0 +1,57 @@
+## New timing treatment in the `RealisticCaloDigi` processor (03.2021)
+
+### Possible integration methods: `Standard` VS `ROC`
+
+The RealisticCaloDigi processor includes two different timing treatment methods, also influencing the energy integration.
+
+- The `Standard` integration sums up the energy of Monte Carlo contributions (MCCs) of *SimCalorimeterHits* within a certain time window (`t_min` < t < `t_max`). The time stamp of the reconstructed hit is set to the earliest MCC time of the simulated hit and the energy is set to the sum of the MCC energies within the time window.
+- The `ROC` (ReadOut Chip) integration reflects a bit more how the electronics designed by the Omega group behaves. These chips include a fast shaper `t_fast` and a slow shaper `t_slow` value which are use in this algorithm to perform the energy integration and hit time estimate. Starting from the earliest MCC, the algorithm checks if the accumulated energy within `t_fast` passes the energy threshold. If not, it goes to the next MCC and performs the same check. If the threshold is reached, the hit time is set to the current MCC time and the energy is set to the accumulated MCC energy within `t_slow` from the current MCC. An absolute time cut is finally applied. If the hit time is in a certain time window (`t_min` < t < `t_max`), it is accepted, else discarded. If the hit is accepted, a random gaussian smearing is (optionally) applied to the hit time.
+
+### Processor parameters
+
+Here are listed the processor parameters acting on timing.
+
+General parameters:
+
+- `timingWindowMin`: The minimum hit time to accept a hit (t > `t_min`). Float, unit in `ns`, default is -10.
+- `timingWindowMax`: The maximum hit time to accept a hit (t < `t_max`). Float, unit in `ns`, default is 100.
+- `integrationMethod`: The energy integration and timing estimate method for digitization. Options are "Standard" (default) and "ROC".
+
+Parameters for the "Standard" method **only**:
+
+- `timingCorrectForPropagation`: Hit time correction `t_corr` for propagation computed as radial distance divided by `c`. Hit time becomes t - t_corr. Int, default is 0 (false).
+
+Parameters for the "ROC" method **only**:
+
+- `fastShaper`: The fast shaper integration time `t_fast`. Must be set in the steering file if the ROC method is chosen. Float, unit in `ns`, default is 0.
+- `slowShaper`: The slow shaper integration time `t_slow`. Must be set in the steering file if the ROC method is chosen. Float, unit in `ns`, default is 0.
+- `timingResolution`: Apply a random gaussian smearing `t_res` on the final hit time. The parameter value corresponds to the width of the gaussian function. Only applied if greater than 0. Float, unit in `ns`, default is 0 (no time smearing).
+
+The default behavior of the digitizer is then:
+
+- `integrationMethod`: "Standard"
+- `timingWindowMin`: -10 ns
+- `timingWindowMax`: 100 ns
+- `timingCorrectForPropagation`: false
+
+
+### Additional remarks on the ROC implementation
+
+#### Pull request
+The ROC implementation has been implementation through the `PR83` in the MarlinReco Github repository: https://github.com/iLCSoft/MarlinReco/pull/83. More detailed information, in particular the discussion with detector experts, can be found there.
+
+#### Current ROC parameter values for known technologies (03.2021)
+
+- AHCal:
+  - `fastShaper`: 15 ns
+  - `slowShaper`: 50 ns
+  - `timingResolution`: 700 ps
+- SiWEcal:
+  - `fastShaper`: 90 ns. First estimate
+  - `slowShaper`: 180 ns. First estimate
+  - `timingResolution`: 700 ps. First guess from AHCAL value, as the TDC is similar. Not a real estimate
+   
+   
+
+
+

--- a/CaloDigi/Realistic/include/RealisticCaloDigi.h
+++ b/CaloDigi/Realistic/include/RealisticCaloDigi.h
@@ -7,6 +7,8 @@
 #include "lcio.h"
 #include <string>
 #include <vector>
+#include <functional>
+#include <optional>
 
 using namespace lcio ;
 using namespace marlin ;
@@ -17,6 +19,7 @@ using namespace marlin ;
     this is virtual class, technology-blind
     technology-specific classes can inherit from this one
     D. Jeans 02/2016, rewrite of parts of ILDCaloDigi, DDCaloDigi
+    R. Ete 11/2020, rewrite of charge integration and extension of timing treatment
  */
 
 class RealisticCaloDigi : virtual public Processor {
@@ -37,9 +40,17 @@ class RealisticCaloDigi : virtual public Processor {
   
   // energy scales we know about
   enum { MIP, GEVDEP, NPE };
+  // integration result types
+  using integr_res = std::pair<float,float>;
+  using integr_res_opt = std::optional<integr_res>;
+  using integr_function = std::function<integr_res_opt(const EVENT::SimCalorimeterHit*)>;
 
   virtual float EnergyDigi(float energy, int id0, int id1);
-  virtual std::vector < std::pair < float , float > > timingCuts( const SimCalorimeterHit * hit );
+  virtual integr_res_opt Integrate( const SimCalorimeterHit * hit ) const;
+  
+  integr_res_opt StandardIntegration( const SimCalorimeterHit * hit ) const ;
+  integr_res_opt ROCIntegration( const SimCalorimeterHit * hit ) const ;
+  float SmearTime(float time) const;
 
   // virtual methods to be be overloaded in tech-specific derived classes
   virtual int   getMyUnit()=0;
@@ -55,7 +66,7 @@ class RealisticCaloDigi : virtual public Processor {
 
   // parameters for digitization effects
 
-
+  std::string _integration_method{}; // timing calculation method
   float _threshold_value{};         // hit energy threshold
   std::string _threshold_unit{};    // hit energy threshold unit
 
@@ -63,6 +74,9 @@ class RealisticCaloDigi : virtual public Processor {
   int   _time_correctForPropagation{}; // correct times for propagation?
   float _time_windowMin{};          // defn of timing window
   float _time_windowMax{};
+  float _fast_shaper{};             // fast shaper value. unit in ns
+  float _slow_shaper{};             // slow shaper value. unit in ns
+  float _time_resol{};              // time resolution (unit ns)
 
   float _calib_mip{};               // MIP calibration factor (most probable energy deposit by MIP in active material of one layer)
 
@@ -90,6 +104,7 @@ class RealisticCaloDigi : virtual public Processor {
 
   std::map < std::pair <int, int> , float > _cell_miscalibs{};
   std::map < std::pair <int, int> , bool  > _cell_dead{};
+  integr_function _integr_function{};
 
 } ;
 

--- a/CaloDigi/Realistic/include/RealisticCaloDigi.h
+++ b/CaloDigi/Realistic/include/RealisticCaloDigi.h
@@ -53,9 +53,9 @@ class RealisticCaloDigi : virtual public Processor {
   float SmearTime(float time) const;
 
   // virtual methods to be be overloaded in tech-specific derived classes
-  virtual int   getMyUnit()=0;
-  virtual float digitiseDetectorEnergy(float energy) = 0 ;
-  virtual float convertEnergy( float energy, int inScale ) = 0; // convert energy from input to output scale
+  virtual int   getMyUnit() const = 0 ;
+  virtual float digitiseDetectorEnergy(float energy) const = 0 ;
+  virtual float convertEnergy( float energy, int inScale ) const = 0; // convert energy from input to output scale
 
   // general parameters
 

--- a/CaloDigi/Realistic/include/RealisticCaloDigiScinPpd.h
+++ b/CaloDigi/Realistic/include/RealisticCaloDigiScinPpd.h
@@ -18,9 +18,9 @@ class RealisticCaloDigiScinPpd : public RealisticCaloDigi {
   RealisticCaloDigiScinPpd() ;
 
  protected:
-  int getMyUnit() {return NPE;}
-  float digitiseDetectorEnergy(float energy); // apply scin+PPD specific effects
-  float convertEnergy( float energy, int inputUnit ); // convert energy from input to output scale
+  int getMyUnit() const {return NPE;}
+  float digitiseDetectorEnergy(float energy) const ; // apply scin+PPD specific effects
+  float convertEnergy( float energy, int inputUnit ) const; // convert energy from input to output scale
 
   float _PPD_pe_per_mip{};         // # photoelectrons/MIP for PPD
   int   _PPD_n_pixels{};           // # pixels in PPD

--- a/CaloDigi/Realistic/include/RealisticCaloDigiSilicon.h
+++ b/CaloDigi/Realistic/include/RealisticCaloDigiSilicon.h
@@ -18,9 +18,9 @@ class RealisticCaloDigiSilicon : public RealisticCaloDigi {
   RealisticCaloDigiSilicon() ;
 
  protected:
-  int getMyUnit() {return MIP;}
-  float convertEnergy( float energy, int inputUnit ); // convert energy from input to output (MIP) scale 
-  float digitiseDetectorEnergy(float energy);         // apply silicon-specific realistic digitisation
+  int getMyUnit() const {return MIP;}
+  float convertEnergy( float energy, int inputUnit )const; // convert energy from input to output (MIP) scale 
+  float digitiseDetectorEnergy(float energy)const;         // apply silicon-specific realistic digitisation
   float _ehEnergy{};                                    // energy to create e-h pair in silicon
 } ;
 

--- a/CaloDigi/Realistic/src/RealisticCaloDigi.cc
+++ b/CaloDigi/Realistic/src/RealisticCaloDigi.cc
@@ -484,10 +484,14 @@ RealisticCaloDigi::integr_res_opt RealisticCaloDigi::ROCIntegration( const SimCa
       break;
     }
   }
+  // check hit time 
+  const float thresholdTime = mcconts[thresholdIndex].time;
+  if( not (thresholdTime>_time_windowMin && thresholdTime<_time_windowMax) ) {
+    return std::nullopt;
+  }
   // If we've found a hit above the threshold, accumulate the energy until
   // until the maximum time given by the slow shaper
   if(passThreshold) {
-    const float thresholdTime = mcconts[thresholdIndex].time;
     float energySum = 0.f ; 
     for(unsigned int i=thresholdIndex ; i<ncontrib ; ++i) {
       if( mcconts[i].time < thresholdTime + _slow_shaper) {

--- a/CaloDigi/Realistic/src/RealisticCaloDigi.cc
+++ b/CaloDigi/Realistic/src/RealisticCaloDigi.cc
@@ -299,9 +299,9 @@ void RealisticCaloDigi::processEvent( LCEvent * evt ) {
           newhit->setCellID1( simhit->getCellID1() );
           newhit->setTime( time );
           newhit->setPosition( simhit->getPosition() );
-    	    newhit->setEnergy( energyDig );
-    	    int layer = idDecoder(simhit)[_cellIDLayerString];
-    	    newhit->setType( CHT( cht_type, cht_id, cht_lay, layer ) );
+	        newhit->setEnergy( energyDig );
+	        int layer = idDecoder(simhit)[_cellIDLayerString];
+	        newhit->setType( CHT( cht_type, cht_id, cht_lay, layer ) );
           newhit->setRawHit( simhit );
           newcol->addElement( newhit ); // add hit to output collection
 
@@ -435,11 +435,11 @@ RealisticCaloDigi::integr_res_opt RealisticCaloDigi::StandardIntegration( const 
 	       earliestTime = relativetime; //use earliest hit time for simpletimingcut
       }
     }
-  }      
+  }
   if(earliestTime > _time_windowMin && earliestTime < _time_windowMax){ //accept this hit
     return integr_res{SmearTime(earliestTime), energySum};
   }
-  return integr_res{0, hit->getEnergy()};
+  return std::nullopt;
 }
 
 //------------------------------------------------------------------------------
@@ -495,7 +495,7 @@ RealisticCaloDigi::integr_res_opt RealisticCaloDigi::ROCIntegration( const SimCa
       }
     }
     hitTime = SmearTime(hitTime);
-    return integr_res{thresholdTime, energySum};
+    return integr_res{hitTime, energySum};
   }
   // else no hit dude !
   else {

--- a/CaloDigi/Realistic/src/RealisticCaloDigiScinPpd.cc
+++ b/CaloDigi/Realistic/src/RealisticCaloDigiScinPpd.cc
@@ -47,7 +47,7 @@ RealisticCaloDigiScinPpd::RealisticCaloDigiScinPpd() : RealisticCaloDigi::Proces
 }
 
 
-float RealisticCaloDigiScinPpd::convertEnergy( float energy, int inUnit ) { // convert energy from input to output scale (NPE)
+float RealisticCaloDigiScinPpd::convertEnergy( float energy, int inUnit ) const { // convert energy from input to output scale (NPE)
   if      ( inUnit==NPE ) return energy;
   else if ( inUnit==MIP ) return _PPD_pe_per_mip*energy;
   else if ( inUnit==GEVDEP ) return _PPD_pe_per_mip*energy/_calib_mip;
@@ -55,7 +55,7 @@ float RealisticCaloDigiScinPpd::convertEnergy( float energy, int inUnit ) { // c
   assert (0);
 }
 
-float RealisticCaloDigiScinPpd::digitiseDetectorEnergy(float energy) {
+float RealisticCaloDigiScinPpd::digitiseDetectorEnergy(float energy) const {
   // input energy in deposited GeV
   // output in npe
   float npe = energy*_PPD_pe_per_mip/_calib_mip; // convert to pe scale

--- a/CaloDigi/Realistic/src/RealisticCaloDigiSilicon.cc
+++ b/CaloDigi/Realistic/src/RealisticCaloDigiSilicon.cc
@@ -26,7 +26,7 @@ RealisticCaloDigiSilicon::RealisticCaloDigiSilicon() : RealisticCaloDigi::Proces
                              (float)3.6);
 }
 
-float RealisticCaloDigiSilicon::convertEnergy( float energy, int inUnit ) { // convert energy from input to output scale (MIP)
+float RealisticCaloDigiSilicon::convertEnergy( float energy, int inUnit ) const { // convert energy from input to output scale (MIP)
   // converts input energy to MIP scale
   if      ( inUnit==MIP ) return energy;
   else if ( inUnit==GEVDEP ) return energy/_calib_mip;
@@ -35,7 +35,7 @@ float RealisticCaloDigiSilicon::convertEnergy( float energy, int inUnit ) { // c
 }
 
 
-float RealisticCaloDigiSilicon::digitiseDetectorEnergy(float energy) {
+float RealisticCaloDigiSilicon::digitiseDetectorEnergy(float energy) const {
   // applies extra digitisation to silicon hits
   //  input energy in deposited GeV
   //  output is MIP scale


### PR DESCRIPTION
BEGINRELEASENOTES
- RealisticCaloDigi: Added new option for energy/charge and time integration
  - deal with slow/fast shaper of ROC chips and time estimate
  - new processor parameters:
     - **integrationMethod**: "Standard" for old implementation (default) or "ROC" emulating the behavior of ROC chip.
     - **fastShaper**: fast shaper time, unit in ns. Only for ROC method
     - **slowShaper**: slow shaper time, unit in ns. Only for ROC method
     - **timingResolution**: optional time resolution gaussian smearing to apply, unit . Only apply is > 0. Default is 0 (no smearing)

ENDRELEASENOTES

Fixes #41 

Parameter values for ROC implementation:
- AHCAL
   - **fastShaper** = 15 ns
   - **slowShaper** =  50 ns
   - **timingResolution** = 700 ps
- SiWECal
   - **fastShaper** = 90 ns (first estimate)
   - **slowShaper** =  180 ns (first estimate)
   - **timingResolution** = 700 ps (first guess from AHCAL value and the fact that the TDC is similar. Not a real estimate)

TODO:
- [x] Add details in release notes
- [x] Validate changes in the code for previous version (identical distributions)
- [x] Determine whether the ROC implementation works for the SiWECal electronics
- [x] Determine parameters for all technologies
- [x] Make plots:
    - rec time distribution
    - rec energy distribution
- [x] Document timing treatment in a Readme.md