### PR TITLE
Addition of new algorithms to TOFEstimator processor

### DIFF
--- a/TimeOfFlight/include/TOFEstimators.h
+++ b/TimeOfFlight/include/TOFEstimators.h
@@ -3,22 +3,36 @@
 
 #include "marlin/Processor.h"
 #include "lcio.h"
+
+//std stuff
+#include <iostream>
 #include <string>
 #include <vector>
+#include <random>
+#include <functional>
+#include <memory>
+using std::string, std::vector, std::endl;
+
 #include <gsl/gsl_rng.h>
+
+#include <EVENT/Track.h>
+#include <EVENT/Cluster.h>
+
+#include "DDRec/Vector3D.h"
+using dd4hep::rec::Vector3D;
 
 using namespace lcio ;
 using namespace marlin ;
 
-
-class TH2F ;
+#include "TH2F.h"
+// class TH2F ;
 
 /** Compute estimators for the time of flight from the CalorimeterHits in Clusters.
  *  The estimators are stored in a PID object with the name of the processor.
  *  The following parameters are stored:
  *   TOFFirstHit         -  first hit ( closest to calo entry point)
  *   TOFClosestHits      -  closest hit in every layer (<lMax)
- *   TOFClosestHitsError -  error of above 
+ *   TOFClosestHitsError -  error of above
  *   TOFFlightLength     -  trajectory length to reference point
  *   TOFLastTrkHit       -  (unsmeared) time of last tracker hit (in SET)
  *   TOFLastTrkHitFlightLength -  trajectory length to last trk hit
@@ -29,69 +43,65 @@ class TH2F ;
  *  TimeResolution  - assumed single hit resolution in ps
  *
  *  Only Ecal hits are considered.
- *  For charged particles the TrackState at the calorimeter is used as reference point and for the 
- *  extrapolation into the calorimeter. For neutral particles the position of the first hit (the one closest to the IP) 
+ *  For charged particles the TrackState at the calorimeter is used as reference point and for the
+ *  extrapolation into the calorimeter. For neutral particles the position of the first hit (the one closest to the IP)
  *  is used and a straight flight path from the IP is taken for the extrapolation.
  *  The hit time is corrected for the flight time from the reference assuming speed of light.
- *  
+ *
  *  See ../scripts/tofestimators.xml for example steering file.
  *
  * @author F.Gaede, DESY, April 2018
+ * @author B.Dudar, DESY, February 2021
  */
 
 class TOFEstimators : public Processor {
-  
- public:
-  
-  virtual Processor*  newProcessor() { return new TOFEstimators ; }
-  
-  TOFEstimators(const TOFEstimators&) = delete;
-  TOFEstimators& operator=(const TOFEstimators&) = delete;
+    public:
 
-  TOFEstimators() ;
-  
-  /** Called at the begin of the job before anything is read.
-   * Use to initialize the processor, e.g. book histograms.
-   */
-  virtual void init() ;
-  
-  /** Called for every run.
-   */
-  virtual void processRunHeader( LCRunHeader* run ) ;
-  
-  /** Called for every event - the working horse.
-   */
-  virtual void processEvent( LCEvent * evt ) ; 
-  
-  
-  virtual void check( LCEvent * evt ) ; 
-  
-  
-  /** Called after data processing for clean up.
-   */
-  virtual void end() ;
-  
-  
- protected:
+    virtual Processor*  newProcessor() { return new TOFEstimators ; }
 
-  /** Input collection name with ReconstructedParticles (PFOs).
-   */
-  std::string _colNamePFO{};
-  int   _maxLayerNum{} ;
-  float _resolution{} ;
-  
-  std::vector<std::string> _TOFNames {} ; 
+    TOFEstimators(const TOFEstimators&) = delete;
+    TOFEstimators& operator=(const TOFEstimators&) = delete;
 
-  int _nRun{};
-  int _nEvt{};
+    TOFEstimators() ;
 
-  gsl_rng* _rng = nullptr ;
+    /** Called at the begin of the job before anything is read.
+    * Use to initialize the processor, e.g. book histograms.
+    */
+    virtual void init() ;
 
-  std::vector<TH2F*> _h{};
+    /** Called for every event - the working horse.
+    */
+    virtual void processEvent(LCEvent* evt) ;
 
-} ;
+    virtual void check(LCEvent* evt) ;
+
+    /** Called after data processing for clean up.
+    */
+    virtual void end() ;
+
+    Vector3D getMomAtCalo(const Track*);
+    double getFlightLength(const Track*);
+    double getTOFClosest(const Track*, const Cluster*);
+    double getTOFFastest(const Track*, const Cluster*);
+    double getTOFCylFit(const Track*, const Cluster*);
+    double getTOFClosestFit(const Track*, const Cluster*);
+
+    protected:
+
+    /** Input collection name with ReconstructedParticles (PFOs).
+    */
+    string _colNamePFO{};
+
+    string _procVersion{};
+    int _maxLayerNum{};
+    float _resolution{};
+    vector<string> _TOFNames{};
+
+    gsl_rng* _rng = nullptr;
+    vector<TH2F*> _h{};
+
+    std::default_random_engine _generator{};
+    std::normal_distribution<double> _smearing{};
+};
 
 #endif
-
-
-

--- a/TimeOfFlight/include/TOFEstimators.h
+++ b/TimeOfFlight/include/TOFEstimators.h
@@ -11,7 +11,7 @@
 #include <random>
 #include <functional>
 #include <memory>
-using std::string, std::vector, std::endl;
+#include <limits>
 
 #include <gsl/gsl_rng.h>
 
@@ -19,13 +19,11 @@ using std::string, std::vector, std::endl;
 #include <EVENT/Cluster.h>
 
 #include "DDRec/Vector3D.h"
-using dd4hep::rec::Vector3D;
 
 using namespace lcio ;
 using namespace marlin ;
 
 #include "TH2F.h"
-// class TH2F ;
 
 /** Compute estimators for the time of flight from the CalorimeterHits in Clusters.
  *  The estimators are stored in a PID object with the name of the processor.
@@ -79,7 +77,7 @@ class TOFEstimators : public Processor {
     */
     virtual void end() ;
 
-    Vector3D getMomAtCalo(const Track*);
+    dd4hep::rec::Vector3D getMomAtCalo(const Track*);
     double getFlightLength(const Track*);
     double getTOFClosest(const Track*, const Cluster*);
     double getTOFFastest(const Track*, const Cluster*);
@@ -90,18 +88,21 @@ class TOFEstimators : public Processor {
 
     /** Input collection name with ReconstructedParticles (PFOs).
     */
-    string _colNamePFO{};
+    std::string _colNamePFO{};
 
-    string _procVersion{};
+    std::string _procVersion{};
     int _maxLayerNum{};
+    double _cylRadiusCut{};
     float _resolution{};
-    vector<string> _TOFNames{};
+    std::vector<std::string> _TOFNames{};
 
     gsl_rng* _rng = nullptr;
-    vector<TH2F*> _h{};
+    std::vector<TH2F*> _h{};
 
-    std::default_random_engine _generator{};
+    std::mt19937 _generator{};
     std::normal_distribution<double> _smearing{};
+
+    double _bField[3];
 };
 
 #endif

--- a/TimeOfFlight/include/TOFEstimators.h
+++ b/TimeOfFlight/include/TOFEstimators.h
@@ -25,29 +25,81 @@ using namespace marlin ;
 
 #include "TH2F.h"
 
-/** Compute estimators for the time of flight from the CalorimeterHits in Clusters.
- *  The estimators are stored in a PID object with the name of the processor.
- *  The following parameters are stored:
- *   TOFFirstHit         -  first hit ( closest to calo entry point)
- *   TOFClosestHits      -  closest hit in every layer (<lMax)
- *   TOFClosestHitsError -  error of above
- *   TOFFlightLength     -  trajectory length to reference point
- *   TOFLastTrkHit       -  (unsmeared) time of last tracker hit (in SET)
- *   TOFLastTrkHitFlightLength -  trajectory length to last trk hit
- *
- *  processor parameters:
- *  MaxLayerNumber  - restrict the hits to the first MaxLayerNumbers
- *  ReconstructedParticleCollection - input collection
- *  TimeResolution  - assumed single hit resolution in ps
- *
- *  Only Ecal hits are considered.
+/**
+ * @section DESCRIPTION
+ * Compute time of flight (ToF) from the CalorimeterHits in the ECAL Cluster.
+ * The ToFs are stored in a PID object with the name of the processor attached
+ * to the PandoraPFOs.
+ * Steering parameters:
+ *  MaxLayerNumber  - Estimate ToF using only MaxLayerNumber first layers in the ECAL
+ *  ReconstructedParticleCollection - input collection (usually PandoraPFOs)
+ *  TimeResolution  - assumed single Calorimeter hit time resolution in ps
+ *  CylRadius - radius within which hits are accepted for the fit. Relevant only
+                for new TOFCylFit algorithm. Default 5 mm
+ *  ProcessorVersion - controls output of the processor between idr
+ *                (interim design report) and dev (current development) versions
+ * Output for ProcessorVersion = "idr"
+ *  The following parameters are stored with the IDR ProcessorVersion:
+ *   TOFFirstHit         -  ToF of the CalorimeterHit closest to track entry
+ *                          point to the ECAL corrected with the distance
+ *                          between cell center and entry point assuming
+ *                          speed of light propagation
+ *   TOFClosestHits      -  ToF estimated as the average of corrected
+ *                          CalorimeterHit times from hits that are closest to
+ *                          the linear prolongation of the trajectory line
+ *                          of the track in MaxLayerNumber first layers
+ *   TOFClosestHitsError -  error of the TOFClosestHits
+ *   TOFFlightLength     -  Track length of the helix between IP and ECAL entrance
+ *                          assuming IP at (0, 0, 0) and ECAL entry point is
+ *                          obtained from Kalman filter by extrapolation.
+ *                          Omega/lambda track parameters are taken from IP hit
+ *                          and assumed to be constant along the track.
+ *                          Results are reasonable for delta phi < 2pi
+ *                          meaning not more than one curl.
+ *   TOFLastTrkHit       -  (unsmeared) time of last tracker hit (in the SET)
+ *   TOFLastTrkHitFlightLength - track length similar to the TOFFlightLength
+ *                               but to the SET hit
+ * Notes:
  *  For charged particles the TrackState at the calorimeter is used as reference point and for the
  *  extrapolation into the calorimeter. For neutral particles the position of the first hit (the one closest to the IP)
  *  is used and a straight flight path from the IP is taken for the extrapolation.
  *  The hit time is corrected for the flight time from the reference assuming speed of light.
  *
+ * Output for ProcessorVersion = "dev"
+ *  The following parameters are stored with the IDR ProcessorVersion:
+ *   TOFClosest         -  ToF of the CalorimeterHit closest to track entry
+ *                          point to the ECAL corrected with the distance
+ *                          between cell center and entry point assuming
+ *                          speed of light propagation
+ *   TOFFastest         -  ToF of the CalorimeterHit arrived fastest corrected
+ *                          with the distance between cell center and entry
+ *                          point assuming speed of light propagation
+ *   TOFCylFit          -  ToF estimated from extrapolation from a fit of the
+ *                            hit times vs distance to to the track entry point
+ *                            to the ECAL at distance = 0
+ *   TOFClosestFit    -  ToF estimated with a fit as TOFCylFit but from hits
+ *                            that are closest to the linear prolongation of the
+ *                            trajectory line of the track in MaxLayerNumber first layers
+ *   FlightLength       -  Track length of the helix between IP and ECAL entrance
+ *                          assuming IP at (0, 0, 0) and ECAL entry point is
+ *                          obtained from Kalman filter by extrapolation.
+ *                          Omega/lambda track parameters are taken from the
+ *                            closest track hit to the ECAL and assumed to be
+ *                            constant along the track.
+ *                          Results are reasonable for delta phi < 2pi
+ *                          meaning not more than one curl.
+ *   MomAtCalo - momentum of the track estimated from the track curvature near
+ *                 ECAL entry point.
+ * Notes:
+ * FlightLength shows less bias in mass than TOFFlightLength
+ * MomAtCalo shows less bias in mass than taking momentum from IP as in IDR
+ * Every method in both idr and dev considers only Ecal hits.
+ * Methods work only for charged PFOs with ONE associated track and ONE associated cluster
+ * Therefore neutral PFOs and PFOs with multiple tracks/clusters are ignored
+ *
  *  See ../scripts/tofestimators.xml for example steering file.
  *
+ * @file
  * @author F.Gaede, DESY, April 2018
  * @author B.Dudar, DESY, February 2021
  */
@@ -71,29 +123,85 @@ class TOFEstimators : public Processor {
     */
     virtual void processEvent(LCEvent* evt) ;
 
+    /** Called after data processing to plot some histograms to debug.
+    */
     virtual void check(LCEvent* evt) ;
 
     /** Called after data processing for clean up.
     */
     virtual void end() ;
 
+    /** Called in dev version to write MomAtCalo parameter.
+    Can be used for more precise mass calculation
+    */
     dd4hep::rec::Vector3D getMomAtCalo(const Track*);
+
+    /** Track length of the helix between IP and ECAL entrance
+    * assuming IP at (0, 0, 0) and ECAL entry point is
+    * obtained from the Kalman filter by extrapolation.
+    * Omega/lambda track parameters are taken from the
+    * closest track hit to the ECAL and assumed to be
+    * constant along the track.
+    * Length is calculated by the formula that is reasonable only for delta phi < 2pi
+    * meaning only tracks with less than one curl.
+    */
     double getFlightLength(const Track*);
+
+    /**
+    *   TOFClosest         -  ToF of the CalorimeterHit closest to track entry
+    *                          point to the ECAL corrected with the distance
+    *                          between cell center and entry point assuming
+    *                          speed of light propagation
+    */
     double getTOFClosest(const Track*, const Cluster*);
+
+    /**
+    *   TOFFastest         -  ToF of the CalorimeterHit arrived fastest corrected
+    *                          with the distance between cell center and entry
+    *                          point assuming speed of light propagation
+    */
     double getTOFFastest(const Track*, const Cluster*);
+
+    /**
+    *   TOFCylFit          -  ToF estimated from extrapolation from a fit of the
+    *                            hit times vs distance to to the track entry point
+    *                            to the ECAL at distance = 0
+    */
     double getTOFCylFit(const Track*, const Cluster*);
+
+    /**
+    *   TOFClosestFit    -  ToF estimated with a fit as TOFCylFit but from hits
+    *                            that are closest to the linear prolongation of the
+    *                            trajectory line of the track in MaxLayerNumber first layers
+    */
     double getTOFClosestFit(const Track*, const Cluster*);
 
     protected:
 
     /** Input collection name with ReconstructedParticles (PFOs).
+        used for ReconstructedParticleCollection steering parameter. usually PandoraPFOs
     */
     std::string _colNamePFO{};
 
+    /** Input version idr (default) or dev (current development).
+    */
     std::string _procVersion{};
+
+    /** Select ECAL hits only from _maxLayerNum first layers of ECAL for ToF calculations
+    */
     int _maxLayerNum{};
+
+
+    /** Select hits for tofCylFit method from the cylinder limited by this radius
+    */
     double _cylRadiusCut{};
+
+    /** Single ECAL hit time resolution in ps
+    */
     float _resolution{};
+
+    /** vector of names of output PID object parameters which are written as output
+    */
     std::vector<std::string> _TOFNames{};
 
     gsl_rng* _rng = nullptr;
@@ -102,6 +210,8 @@ class TOFEstimators : public Processor {
     std::mt19937 _generator{};
     std::normal_distribution<double> _smearing{};
 
+    /** B field from the DD4HEP geometry processor for MomAtCalo calculations
+    */
     double _bField[3];
 };
 

--- a/TimeOfFlight/scripts/tofestimators.xml
+++ b/TimeOfFlight/scripts/tofestimators.xml
@@ -22,11 +22,11 @@
   <!--if condition="MyEventSelector"-->
   <processor name="InitDD4hep" />
    <processor name="MyAIDAProcessor"/>
-   <processor name="TOFEstimators0psOld"/>
-   <processor name="TOFEstimators0psNew"/>
+   <processor name="TOFEstimators0psIDR"/>
+   <processor name="TOFEstimators0psDEV"/>
    <!-- <processor name="TOFEstimators10ps"/>
    <processor name="TOFEstimators50ps"/> -->
-   <XXXprocessor name="MyLCIOOutputProcessor"/>
+   <processor name="MyLCIOOutputProcessor"/>
   <!--/if-->
  </execute>
 
@@ -36,7 +36,7 @@
   <parameter name="MaxRecordNumber" value="5001" />
   <parameter name="SkipNEvents" value="0" />
   <parameter name="SupressCheck" value="false" />
-  <parameter name="AllowToModifyEvent" value="false" />
+  <parameter name="AllowToModifyEvent" value="true" />
   <parameter name="GearXMLFile"></parameter>
   <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE DEBUG  </parameter>
   <parameter name="RandomSeed" value="1234567890" />
@@ -57,7 +57,7 @@
 </processor>
 
 
- <processor name="TOFEstimators0psOld" type="TOFEstimators">
+ <processor name="TOFEstimators0psIDR" type="TOFEstimators">
      <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
       <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
       <parameter name="MaxLayerNumber" type="int">10 </parameter>
@@ -69,14 +69,14 @@
       <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
 
       <!--Assumed time resolution per hit in ps-->
-      <parameter name="ProcessorVersion" type="string">old</parameter>
+      <parameter name="ProcessorVersion" type="string">idr</parameter>
 </processor>
 
 
-<processor name="TOFEstimators0psNew" type="TOFEstimators">
+<processor name="TOFEstimators0psDEV" type="TOFEstimators">
      <parameter name="MaxLayerNumber" type="int">10 </parameter>
      <parameter name="TimeResolution" type="float">0 </parameter>
-     <parameter name="ProcessorVersion" type="string">new</parameter>
+     <parameter name="ProcessorVersion" type="string">dev</parameter>
 </processor>
 
  <processor name="TOFEstimators10ps" type="TOFEstimators">

--- a/TimeOfFlight/scripts/tofestimators.xml
+++ b/TimeOfFlight/scripts/tofestimators.xml
@@ -36,7 +36,7 @@
   <parameter name="MaxRecordNumber" value="5001" />
   <parameter name="SkipNEvents" value="0" />
   <parameter name="SupressCheck" value="false" />
-  <parameter name="AllowToModifyEvent" value="true" />
+  <parameter name="AllowToModifyEvent" value="false" />
   <parameter name="GearXMLFile"></parameter>
   <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE DEBUG  </parameter>
   <parameter name="RandomSeed" value="1234567890" />

--- a/TimeOfFlight/scripts/tofestimators.xml
+++ b/TimeOfFlight/scripts/tofestimators.xml
@@ -13,90 +13,87 @@
 
 <marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
  <constants>
-  <!-- define constants here - use in steering file as ${ConstantName} --> 
+  <!-- define constants here - use in steering file as ${ConstantName} -->
   <constant name="DetectorModel" value="ILD_l5_o1_v02" />
  </constants>
 
  <execute>
-  <!--processor name="MyEventSelector"/--> 
-  <!--if condition="MyEventSelector"-->    
+  <!--processor name="MyEventSelector"/-->
+  <!--if condition="MyEventSelector"-->
+  <processor name="InitDD4hep" />
    <processor name="MyAIDAProcessor"/>
-   <processor name="TOFEstimators0ps"/>  
-   <processor name="TOFEstimators10ps"/>  
-   <processor name="TOFEstimators50ps"/>  
-   <XXXprocessor name="MyLCIOOutputProcessor"/>  
-  <!--/if-->                                 
+   <processor name="TOFEstimators0psOld"/>
+   <processor name="TOFEstimators0psNew"/>
+   <!-- <processor name="TOFEstimators10ps"/>
+   <processor name="TOFEstimators50ps"/> -->
+   <XXXprocessor name="MyLCIOOutputProcessor"/>
+  <!--/if-->
  </execute>
 
  <global>
   <parameter name="LCIOInputFiles"> simjob.slcio </parameter>
-  <!-- limit the number of processed records (run+evt): -->  
-  <parameter name="MaxRecordNumber" value="5001" />  
-  <parameter name="SkipNEvents" value="0" />  
-  <parameter name="SupressCheck" value="false" />  
-  <parameter name="AllowToModifyEvent" value="false" />  
-  <parameter name="GearXMLFile"></parameter>  
-  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE DEBUG  </parameter> 
+  <!-- limit the number of processed records (run+evt): -->
+  <parameter name="MaxRecordNumber" value="5001" />
+  <parameter name="SkipNEvents" value="0" />
+  <parameter name="SupressCheck" value="false" />
+  <parameter name="AllowToModifyEvent" value="false" />
+  <parameter name="GearXMLFile"></parameter>
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE DEBUG  </parameter>
   <parameter name="RandomSeed" value="1234567890" />
-  <!-- optionally limit the collections that are read from the input file: -->  
+  <!-- optionally limit the collections that are read from the input file: -->
   <!--parameter name="LCIOReadCollectionNames">MCParticle PandoraPFOs</parameter-->
  </global>
 
  <processor name="MyAIDAProcessor" type="AIDAProcessor">
- <!--Processor that handles AIDA files. Creates on directory per processor.  Processors only need to create and fill the histograms, clouds and tuples. Needs to be the first ActiveProcessor-->
-  <!-- compression of output file 0: false >0: true (default) -->
-  <parameter name="Compress" type="int">1 </parameter>
-  <!-- filename without extension-->
-  <parameter name="FileName" type="string">tof_estimators </parameter>
-  <!-- type of output file root (default) or xml )-->
-  <parameter name="FileType" type="string">root </parameter>
-  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-  <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    <!--Processor that handles AIDA files. Creates on directory per processor.  Processors only need to create and fill the histograms, clouds and tuples. Needs to be the first ActiveProcessor-->
+    <!-- compression of output file 0: false >0: true (default) -->
+    <parameter name="Compress" type="int">1 </parameter>
+    <!-- filename without extension-->
+    <parameter name="FileName" type="string">tof_estimators </parameter>
+    <!-- type of output file root (default) or xml )-->
+    <parameter name="FileType" type="string">root </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
 </processor>
 
 
- <processor name="TOFEstimators0ps" type="TOFEstimators">
- <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
-  <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
-  <parameter name="MaxLayerNumber" type="int">10 </parameter>
-  <!--Name of the ReconstructedParticle collection-->
-  <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
-  <!--Assumed time resolution per hit in ps-->
-  <parameter name="TimeResolution" type="float">0 </parameter>
-  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-  <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+ <processor name="TOFEstimators0psOld" type="TOFEstimators">
+     <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
+      <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
+      <parameter name="MaxLayerNumber" type="int">10 </parameter>
+      <!--Name of the ReconstructedParticle collection-->
+      <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+      <!--Assumed time resolution per hit in ps-->
+      <parameter name="TimeResolution" type="float">0 </parameter>
+      <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+      <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+
+      <!--Assumed time resolution per hit in ps-->
+      <parameter name="ProcessorVersion" type="string">old</parameter>
 </processor>
+
+
+<processor name="TOFEstimators0psNew" type="TOFEstimators">
+     <parameter name="MaxLayerNumber" type="int">10 </parameter>
+     <parameter name="TimeResolution" type="float">0 </parameter>
+     <parameter name="ProcessorVersion" type="string">new</parameter>
+</processor>
+
  <processor name="TOFEstimators10ps" type="TOFEstimators">
- <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
-  <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
-  <parameter name="MaxLayerNumber" type="int">10 </parameter>
-  <!--Name of the ReconstructedParticle collection-->
-  <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
-  <!--Assumed time resolution per hit in ps-->
-  <parameter name="TimeResolution" type="float">10. </parameter>
-  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-  <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    <parameter name="MaxLayerNumber" type="int">10 </parameter>
+    <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <parameter name="TimeResolution" type="float">10. </parameter>
 </processor>
+
  <processor name="TOFEstimators50ps" type="TOFEstimators">
- <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
-  <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
-  <parameter name="MaxLayerNumber" type="int">10 </parameter>
-  <!--Name of the ReconstructedParticle collection-->
-  <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
-  <!--Assumed time resolution per hit in ps-->
-  <parameter name="TimeResolution" type="float">50 </parameter>
-  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-  <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    <parameter name="MaxLayerNumber" type="int">10 </parameter>
+    <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <parameter name="TimeResolution" type="float">50 </parameter>
 </processor>
 
  <processor name="MyTOFPlots" type="TOFPlots">
- <!--TOFPlots creates plots related to potential time of flight measurements with the calorimter-->
-  <!--Name of the MCParticle collection-->
-  <parameter name="MCPCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
-  <!--Name of the ReconstructedParticle collection-->
-  <parameter name="PFOCollectionName" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
-  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-  <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+    <parameter name="MCPCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
+    <parameter name="PFOCollectionName" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
 </processor>
 
 
@@ -120,6 +117,13 @@
   <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
 </processor>
 
+
+<processor name="InitDD4hep" type="InitializeDD4hep">
+    <!--InitializeDD4hep reads a compact xml file and initializes the DD4hep::LCDD object-->
+    <parameter name="DD4hepXMLFile" type="string">
+        /cvmfs/ilc.desy.de/sw/x86_64_gcc82_centos7/v02-02/lcgeo/v00-16-06/ILD/compact/${DetectorModel}/${DetectorModel}.xml
+    </parameter>
+</processor>
 
 
 </marlin>

--- a/TimeOfFlight/src/TOFEstimators.cc
+++ b/TimeOfFlight/src/TOFEstimators.cc
@@ -21,7 +21,7 @@ using EVENT::LCCollection, EVENT::ReconstructedParticle;
 
 #include "TGraphErrors.h"
 #include "TF1.h"
-#include "TMath.h"
+#include "CLHEP/Units/PhysicalConstants.h"
 
 #include "HelixClass.h"
 #include "marlinutil/CalorimeterHitType.h"
@@ -46,10 +46,6 @@ using EVENT::LCCollection, EVENT::ReconstructedParticle;
 using namespace lcio ;
 using namespace marlin ;
 using namespace TOFUtils ;
-
-// Speed of light in mm/ns = 299.79246
-#define SPEED_OF_LIGHT TMath::C()/1.e6
-
 
 TOFEstimators aTOFEstimators ;
 
@@ -531,7 +527,7 @@ double TOFEstimators::getTOFClosest(const Track* track, const Cluster* cluster){
         }
     }
     hitTime += _smearing(_generator);
-    return hitTime - dToImpactMin / SPEED_OF_LIGHT;
+    return hitTime - dToImpactMin / CLHEP::c_light;
 }
 
 
@@ -554,7 +550,7 @@ double TOFEstimators::getTOFFastest(const Track* track, const Cluster* cluster){
             hitTimeMin = hitTime;
         }
     }
-    return hitTimeMin - dToImpactMin / SPEED_OF_LIGHT;
+    return hitTimeMin - dToImpactMin / CLHEP::c_light;
 }
 
 

--- a/TimeOfFlight/src/TOFEstimators.cc
+++ b/TimeOfFlight/src/TOFEstimators.cc
@@ -97,7 +97,9 @@ void TOFEstimators::init() {
         const auto& detector = dd4hep::Detector::getInstance();
         detector.field().magneticField({0., 0., 0.}, _bField);
     }
-    else { throw std::string("Invalid ProcessorVersion parameter passed!!!\n Viable options are: idr (default), dev"); }
+    else { 
+        throw EVENT::Exception(std::string("Invalid ProcessorVersion parameter passed: \'") + _procVersion + std::string("\'\n Viable options are idr (default), dev"); 
+    }
 }
 
 

--- a/TimeOfFlight/src/TOFEstimators.cc
+++ b/TimeOfFlight/src/TOFEstimators.cc
@@ -98,7 +98,7 @@ void TOFEstimators::init() {
         detector.field().magneticField({0., 0., 0.}, _bField);
     }
     else { 
-        throw EVENT::Exception(std::string("Invalid ProcessorVersion parameter passed: \'") + _procVersion + std::string("\'\n Viable options are idr (default), dev"); 
+        throw EVENT::Exception(std::string("Invalid ProcessorVersion parameter passed: \'") + _procVersion + std::string("\'\n Viable options are idr (default), dev")); 
     }
 }
 

--- a/TimeOfFlight/src/TOFEstimators.cc
+++ b/TimeOfFlight/src/TOFEstimators.cc
@@ -1,11 +1,8 @@
 #include "TOFEstimators.h"
 #include "TOFUtils.h"
 
-#include <iostream>
 #include <cmath>
-#include <functional>
 #include <algorithm>
-
 
 #include <lcio.h>
 #include <EVENT/LCCollection.h>
@@ -15,7 +12,20 @@
 #include <UTIL/Operators.h>
 #include <UTIL/PIDHandler.h>
 
-#include "DDRec/Vector3D.h"
+#include "EVENT/LCCollection.h"
+#include "EVENT/ReconstructedParticle.h"
+using EVENT::LCCollection, EVENT::ReconstructedParticle;
+
+#include "DD4hep/Detector.h"
+using dd4hep::Detector;
+#include "DD4hep/DD4hepUnits.h"
+
+#include "TGraphErrors.h"
+#include "TF1.h"
+
+#include "HelixClass.h"
+#include "marlinutil/CalorimeterHitType.h"
+#include <UTIL/PIDHandler.h>
 
 // ----- include for verbosity dependend logging ---------
 #include "marlin/VerbosityLevels.h"
@@ -33,442 +43,578 @@
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 
-//---- ROOT -----
-#include "TH2F.h"
-
 using namespace lcio ;
 using namespace marlin ;
 using namespace TOFUtils ;
 
+#define SPEED_OF_LIGHT 299.792458
+
+
 TOFEstimators aTOFEstimators ;
 
 
-
 TOFEstimators::TOFEstimators() : Processor("TOFEstimators") {
+    _description = "TOFEstimators compute some estimators for the time of flight from calorimeter hits" ;
 
-  // modify processor description
-  _description = "TOFEstimators compute some estimators for the time of flight from calorimeter hits" ;
-
-  // register steering parameters: name, description, class-variable, default value
-  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-			   "ReconstructedParticleCollection" , 
-			   "Name of the ReconstructedParticle collection"  ,
-			   _colNamePFO ,
-			   std::string("PandoraPFOs")
-    );
-
-
-    registerProcessorParameter("MaxLayerNumber",
-			     "Use only calorimeter hits up to MaxLayerNumber in TOF estimators",
-			     _maxLayerNum,
-			     int(100) );
-
-
-  registerProcessorParameter("TimeResolution",
-			     "Assumed time resolution per hit in ps",
-			     _resolution,
-			     float(0.) );
-
+    // register steering parameters: name, description, class-variable, default value
+    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE, "ReconstructedParticleCollection", "Name of the ReconstructedParticle collection", _colNamePFO , string("PandoraPFOs") );
+    registerProcessorParameter( "MaxLayerNumber", "Use only calorimeter hits up to MaxLayerNumber in TOF estimators", _maxLayerNum, int(100) );
+    registerProcessorParameter( "TimeResolution", "Assumed time resolution per hit in ps", _resolution, float(0.) );
+    registerProcessorParameter( "ProcessorVersion", "Legacy or new TOFEstimator", _procVersion, string("old") );
 }
 
 
-
-void TOFEstimators::init() { 
-
-  streamlog_out(DEBUG) << "   init called  " << std::endl ;
-
-  // usually a good idea to
-  printParameters() ;
-
-  _nRun = 0 ;
-  _nEvt = 0 ;
-
-  // initialize gsl random generator
-  _rng = gsl_rng_alloc(gsl_rng_ranlxs2);
-
-  Global::EVENTSEEDER->registerProcessor(this);
-
-
-  _TOFNames = { "TOFFirstHit",
-		"TOFClosestHits", "TOFClosestHitsError",
-		"TOFFlightLength",  "TOFLastTrkHit" ,
-		"TOFLastTrkHitFlightLength" } ;
-
-}
-
-
-void TOFEstimators::processRunHeader( LCRunHeader* ) {
-
-  _nRun++ ;
-} 
-
-
-
-void TOFEstimators::processEvent( LCEvent * evt ) { 
-
-
-  // use the global Marlin random seed for this processor
-  gsl_rng_set( _rng, Global::EVENTSEEDER->getSeed(this) ) ;   
-
-  streamlog_out(DEBUG ) << "seed set to " << Global::EVENTSEEDER->getSeed(this) << std::endl;
-
-  streamlog_out(DEBUG2) << "   process event: " << evt->getEventNumber() 
-			<< "   in run:  " << evt->getRunNumber() << std::endl ;
-
-
-  // get the PFO collection from the event if it exists
-  LCCollection* colPFO = nullptr ;
-    
-  try{
-    colPFO = evt->getCollection( _colNamePFO ) ;
-  }
-  catch(lcio::Exception){
-    streamlog_out( DEBUG6 ) << " collection " << _colNamePFO
-			    << " not found in event - nothing to do ... " << std::endl ;
-  }
-
-  if( colPFO->getTypeName() != LCIO::RECONSTRUCTEDPARTICLE ) {
-
-    streamlog_out( ERROR ) << " collection " << _colNamePFO
-			   << " not of type LCIO::RECONSTRUCTEDPARTICLE " << std::endl ;
-
-    colPFO = nullptr ;
-  }
-    
-  if( colPFO != nullptr ){
-    
-
-
-    PIDHandler pidh( colPFO );
-    int algoID = pidh.addAlgorithm( name()  , _TOFNames);
-
-
-    int nPFO = colPFO->getNumberOfElements()  ;
-    
-    
-    for(int i=0; i< nPFO ; ++i){ 
-
-      ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>(  colPFO->getElementAt( i ) ) ;
-
-      bool isCharged = false ;
-
-      if(  pfo->getClusters().size() != 1 ){
-	
-	streamlog_out( DEBUG1 ) << " ignore particle w/ cluster number other than one:  " <<  *pfo << std::endl ; 
-	continue ;
-      }
-
-      if( std::fabs( pfo->getCharge() ) < 0.1  && pfo->getTracks().size() == 0  ) {
-	
-	isCharged = false ;
-      }
-      
-      else if ( std::fabs( pfo->getCharge() ) > 0.1  && pfo->getTracks().size() == 1  ) {
-	
-	isCharged = true ;
-	
-      } else {
-	
-	streamlog_out( DEBUG1 ) << " ignore particle w/ track number other than zero or one:  " <<  *pfo << std::endl ; 
-	continue ;
-      }
-
-      streamlog_out( DEBUG1 ) << " --- compute TOF estimators for particle : " << *pfo << std::endl ;
-
-
-      
-      // =======  use only Ecal hits  (requires the CalorimeterHitType to be set in the digitizer )
-      //          with time information ( > 1 ps) and layer <= max layer
-
-      int maxLayerNum = _maxLayerNum ;
-      std::function<bool(CalorimeterHit*)> selectHits =  [maxLayerNum](CalorimeterHit* h){
-
-	return ( isEcal( h )            &&
-		 h->getTime() > 1.e-3   &&
-		 layer( h ) <=  maxLayerNum  ) ;
-      } ;
-
-      // -------------------------------------------------------------------------------------------
-
-      Cluster* clu = pfo->getClusters()[0] ;
-      const CalorimeterHitVec& cluhv = clu->getCalorimeterHits() ;
-      
-      // create vectors of extended handle objects for relevant calorimeter hits
-      // one w/ unique_ptr for memory handling
-      
-      CaloHitUPtrVec uniqueVec ;
-      uniqueVec.reserve( cluhv.size()  ) ;
-      
-      CaloHitDataVec caloHitVec ;
-      caloHitVec.reserve( cluhv.size()  ) ;
-      //-------------------------------------------------------------------------------
-      
-      CaloHitLayerMap layerMap ;
-
-      for( auto* clh : cluhv ){
-	
-	if( selectHits( clh ) ){
-
-	  uniqueVec.push_back(  std::unique_ptr<CaloHitData>( new CaloHitData( clh) )  ) ; 
-
-	  CaloHitData* ch = uniqueVec.back().get() ;
-
-	  caloHitVec.push_back( ch ) ;
-
-	  ch->layer = layer( ch->lcioHit ) ;
-	  ch->timeResolution = _resolution ; 
-
-	  ch->smearedTime  = ( _resolution > 0. ?
-			       ch->lcioHit->getTime() + gsl_ran_gaussian( _rng, _resolution / 1000. ) : // convert ps to ns 
-			       ch->lcioHit->getTime() ) ;
-
-	  ch->distanceFromIP = dd4hep::rec::Vector3D( clh->getPosition() ).r() ; 
-
-
-	  layerMap[ ch->layer ].push_back( ch ) ;
-	}
-      }
-      
-      
-      if( layerMap.empty() ) {
-
-	streamlog_out( DEBUG1 ) << " --- not suitable Ecal hits found for particle " << std::endl ;
-	continue ;
-      }
-
-      // streamlog_out( DEBUG ) << " --- map with hits per layer : " << std::endl ;
-      // for( auto m : layerMap ){
-      // 	streamlog_out( DEBUG ) << "  ----- layer " << m.first << " : " << std::endl ;
-      // 	for( auto ch : m.second )
-      // 	  streamlog_out( DEBUG ) << "            " << caloTypeStr( ch->lcioHit ) << std::endl ; 		
-      // }
-      
-      
-      // --- define reference point: track state at calo for charged - hit closest to IP for neutral
-      //     and direction of straight line - either from IP or from track state at calo
-
-      dd4hep::rec::Vector3D refPoint ;
-      dd4hep::rec::Vector3D unitDir ;
-      float flightLength = 0. ;
-
-      TrackerHit* lastTrackerHit = nullptr ;
-      float flightLengthTrkHit = 0. ;
-
-      if( isCharged ){
-
-	Track* trk =  pfo->getTracks()[0] ;
-	const TrackState* tscalo = trk->getTrackState( TrackState::AtCalorimeter ) ; 	
-	
-	refPoint = tscalo->getReferencePoint() ;
-		
-	float tanL = tscalo->getTanLambda() ;
-	float theta = std::atan( 1. / tanL ) ;
-
-	unitDir = dd4hep::rec::Vector3D( 1. ,  tscalo->getPhi() , theta , dd4hep::rec::Vector3D::spherical ) ;
-
-	flightLength = computeFlightLength( trk ) ;
-	
-
-	// also store time and flight length of last tracker hit
-	const TrackState* tsIP = trk->getTrackState( TrackState::AtIP ) ; 	
- 	const TrackState* tslh = trk->getTrackState( TrackState::AtLastHit ) ; 	
-
-	lastTrackerHit = trk->getTrackerHits().back() ;
-
-	flightLengthTrkHit = computeFlightLength( tsIP , tslh ) ;
-	
-
-#if 1
-	if( lastTrackerHit->getTime() > 1e-3 ) {
-	  dd4hep::rec::Vector3D rpLH = tslh->getReferencePoint() ;
-	  dd4hep::rec::Vector3D lhp = lastTrackerHit->getPosition()  ;
-	  streamlog_out( DEBUG3 ) << " *************** referenece point calo     : " << refPoint << std::endl ;
-	  streamlog_out( DEBUG3 ) << " *************** referenece point last hit : " << rpLH << std::endl ;
-	  streamlog_out( DEBUG3 ) << " *************** poistion         last hit : " << lhp << std::endl ;
-	  streamlog_out( DEBUG3 ) << "   distance hit-trkstate: " << (rpLH - lhp ).r() << " --  distance  calo/last hit ref points : " << (refPoint-rpLH).r() << std::endl ;
-	  streamlog_out( DEBUG3 ) << "   flight lengths:  " << flightLength << "  - " << flightLengthTrkHit << "  -- diff " << flightLength - flightLengthTrkHit <<
-	    " time diff: " << (flightLength - flightLengthTrkHit) / 299.8 << std::endl ;  
-	  streamlog_out( DEBUG3 ) << " track state : " << *tslh << std::endl ;
-	  streamlog_out( DEBUG3 ) << " last hit : " << *lastTrackerHit << std::endl ;
-	}
-#endif
-
-
-      } else {  // neutral particle
-
-	CaloHitDataVec chv =  layerMap.begin()->second ; // only look in first layer w/ hits   
-
-	CaloHitData* closestHit =
-	  *std::min_element( chv.begin() , chv.end () ,
-			    [](CaloHitData* c0, CaloHitData* c1 ){ return c0->distanceFromIP < c1->distanceFromIP  ; }
-	    ) ; 
-	  
-	refPoint = closestHit->lcioHit->getPosition() ;
-
-	flightLength = refPoint.r() ;
-
-
-	dd4hep::rec::Vector3D cluPos = clu->getPosition() ;
-
-	unitDir = cluPos.unit() ;
-	
-      } 
-      
-      streamlog_out( DEBUG2 ) << " ----- use reference point for TOF : " << refPoint << std::endl ;
-
-      streamlog_out( DEBUG ) << " -----  calorimeter hits considered for estimators : " << std::endl ;
-
-
-      // ------  loop again over hits and fill missing data
-
-      for( auto ch : caloHitVec ){
-
-	CalorimeterHit* calohit = ch->lcioHit ; 
-
-	dd4hep::rec::Vector3D pos = ch->lcioHit->getPosition() ;
-
-	ch->distanceFromReferencePoint = ( pos - refPoint ).r()   ; 
-
-	ch->distancefromStraightline = computeDistanceFromLine( calohit, refPoint, unitDir ) ;
-	  
-	streamlog_out( DEBUG ) <<  "     ----- " << caloTypeStr( calohit )
-			       <<  " --  " <<  ch->toString()   <<   std::endl ;
-      }
-
-      // ---- now get hits that are closest to the extrapolated line
-      CaloHitDataVec tofHits = findHitsClosestToLine( layerMap ) ;
-
-
-      streamlog_out( DEBUG )   <<  " ***** hits used for the TOF estimator : " << std::endl ;
-      for( auto ch : tofHits ){
-	streamlog_out( DEBUG ) <<  "     ----- " << ch->toString() << std::endl ;
-      }
-      
-      auto t_dt     = computeTOFEstimator( tofHits ) ;
-      
-      const static float c_mm_per_ns = 299.792458 ;
-
-      float tof_fh = tofHits[0]->smearedTime - tofHits[0]->distanceFromReferencePoint / c_mm_per_ns ; 
-
-      streamlog_out( DEBUG2 ) << "  #### tof ( first ) : " <<  tof_fh << " +/- " << 0 << std::endl ; 
-      streamlog_out( DEBUG2 ) << "  #### tof ( straight line ) : " << t_dt.first << " +/- " << t_dt.second << std::endl ; 
-
-
-      float trkHitTime = ( lastTrackerHit ?   lastTrackerHit->getTime()   : 0.  ) ;
-
-
-      FloatVec TOF_params = { tof_fh, 
-			      t_dt.first, t_dt.second,
-			      flightLength , trkHitTime , flightLengthTrkHit } ;
-
-      pidh.setParticleID( pfo , 0, 0 , 0.0 , algoID, TOF_params );
- 
-													      
-   //=========================================================================================
-    
+void TOFEstimators::init() {
+    Global::EVENTSEEDER->registerProcessor(this);
+    if ( _procVersion == "old" ){
+        // initialize gsl random generator
+        _rng = gsl_rng_alloc(gsl_rng_ranlxs2);
+        _TOFNames = {"TOFFirstHit", "TOFClosestHits", "TOFClosestHitsError", "TOFFlightLength",  "TOFLastTrkHit" , "TOFLastTrkHitFlightLength"};
     }
-
-  }
-
-  _nEvt ++ ;
-
+    else if (_procVersion == "new"){
+        _smearing.param( std::normal_distribution<double>::param_type(0., _resolution/1000.) );
+        _TOFNames = {"TOFClosest", "TOFFastest", "TOFCylFit", "TOFClosestFit", "FlightLength", "MomAtCalo"};
+    }
+    else { throw string("Invalid ProcessorVersion parameter passed!!!\n Viable options are: old (default), new"); }
 }
 
+
+void TOFEstimators::processEvent( LCEvent * evt ) {
+
+    if ( _procVersion == "old" ){
+        // use the global Marlin random seed for this processor
+        gsl_rng_set( _rng, Global::EVENTSEEDER->getSeed(this) ) ;
+
+        streamlog_out(DEBUG ) << "seed set to " << Global::EVENTSEEDER->getSeed(this) << endl;
+
+        streamlog_out(DEBUG2) << "   process event: " << evt->getEventNumber()
+        		<< "   in run:  " << evt->getRunNumber() << endl ;
+
+
+        // get the PFO collection from the event if it exists
+        LCCollection* colPFO = nullptr ;
+
+        try{
+        colPFO = evt->getCollection( _colNamePFO ) ;
+        }
+        catch(lcio::Exception&){
+        streamlog_out( DEBUG6 ) << " collection " << _colNamePFO
+        		    << " not found in event - nothing to do ... " << endl ;
+        }
+
+        if( colPFO->getTypeName() != LCIO::RECONSTRUCTEDPARTICLE ) {
+
+        streamlog_out( ERROR ) << " collection " << _colNamePFO
+        		   << " not of type LCIO::RECONSTRUCTEDPARTICLE " << endl ;
+
+        colPFO = nullptr ;
+        }
+
+        if( colPFO != nullptr ){
+
+
+
+        PIDHandler pidh( colPFO );
+        int algoID = pidh.addAlgorithm( name()  , _TOFNames);
+
+
+        int nPFO = colPFO->getNumberOfElements()  ;
+
+
+        for(int i=0; i< nPFO ; ++i){
+
+          ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>(  colPFO->getElementAt( i ) ) ;
+
+          bool isCharged = false ;
+
+          if(  pfo->getClusters().size() != 1 ){
+
+        streamlog_out( DEBUG1 ) << " ignore particle w/ cluster number other than one:  " <<  *pfo << endl ;
+        continue ;
+          }
+
+          if( fabs( pfo->getCharge() ) < 0.1  && pfo->getTracks().size() == 0  ) {
+
+        isCharged = false ;
+          }
+
+          else if ( fabs( pfo->getCharge() ) > 0.1  && pfo->getTracks().size() == 1  ) {
+
+        isCharged = true ;
+
+          } else {
+
+        streamlog_out( DEBUG1 ) << " ignore particle w/ track number other than zero or one:  " <<  *pfo << endl ;
+        continue ;
+          }
+
+          streamlog_out( DEBUG1 ) << " --- compute TOF estimators for particle : " << *pfo << endl ;
+
+
+
+          // =======  use only Ecal hits  (requires the CalorimeterHitType to be set in the digitizer )
+          //          with time information ( > 1 ps) and layer <= max layer
+
+          int maxLayerNum = _maxLayerNum ;
+          std::function<bool(CalorimeterHit*)> selectHits =  [maxLayerNum](CalorimeterHit* h){
+
+        return ( isEcal( h )            &&
+        	 h->getTime() > 1.e-3   &&
+        	 layer( h ) <=  maxLayerNum  ) ;
+          } ;
+
+          // -------------------------------------------------------------------------------------------
+
+          Cluster* clu = pfo->getClusters()[0] ;
+          const CalorimeterHitVec& cluhv = clu->getCalorimeterHits() ;
+
+          // create vectors of extended handle objects for relevant calorimeter hits
+          // one w/ unique_ptr for memory handling
+
+          CaloHitUPtrVec uniqueVec ;
+          uniqueVec.reserve( cluhv.size()  ) ;
+
+          CaloHitDataVec caloHitVec ;
+          caloHitVec.reserve( cluhv.size()  ) ;
+          //-------------------------------------------------------------------------------
+
+          CaloHitLayerMap layerMap ;
+
+          for( auto* clh : cluhv ){
+
+        if( selectHits( clh ) ){
+
+          uniqueVec.push_back(  std::unique_ptr<CaloHitData>( new CaloHitData( clh) )  ) ;
+
+          CaloHitData* ch = uniqueVec.back().get() ;
+
+          caloHitVec.push_back( ch ) ;
+
+          ch->layer = layer( ch->lcioHit ) ;
+          ch->timeResolution = _resolution ;
+
+          ch->smearedTime  = ( _resolution > 0. ?
+        		       ch->lcioHit->getTime() + gsl_ran_gaussian( _rng, _resolution / 1000. ) : // convert ps to ns
+        		       ch->lcioHit->getTime() ) ;
+
+          ch->distanceFromIP = dd4hep::rec::Vector3D( clh->getPosition() ).r() ;
+
+
+          layerMap[ ch->layer ].push_back( ch ) ;
+        }
+          }
+
+
+          if( layerMap.empty() ) {
+
+        streamlog_out( DEBUG1 ) << " --- not suitable Ecal hits found for particle " << endl ;
+        continue ;
+          }
+
+          // streamlog_out( DEBUG ) << " --- map with hits per layer : " << endl ;
+          // for( auto m : layerMap ){
+          // 	streamlog_out( DEBUG ) << "  ----- layer " << m.first << " : " << endl ;
+          // 	for( auto ch : m.second )
+          // 	  streamlog_out( DEBUG ) << "            " << caloTypeStr( ch->lcioHit ) << endl ;
+          // }
+
+
+          // --- define reference point: track state at calo for charged - hit closest to IP for neutral
+          //     and direction of straight line - either from IP or from track state at calo
+
+          dd4hep::rec::Vector3D refPoint ;
+          dd4hep::rec::Vector3D unitDir ;
+          float flightLength = 0. ;
+
+          TrackerHit* lastTrackerHit = nullptr ;
+          float flightLengthTrkHit = 0. ;
+
+          if( isCharged ){
+
+        Track* trk =  pfo->getTracks()[0] ;
+        const TrackState* tscalo = trk->getTrackState( TrackState::AtCalorimeter ) ;
+
+        refPoint = tscalo->getReferencePoint() ;
+
+        float tanL = tscalo->getTanLambda() ;
+        float theta = atan( 1. / tanL ) ;
+
+        unitDir = dd4hep::rec::Vector3D( 1. ,  tscalo->getPhi() , theta , dd4hep::rec::Vector3D::spherical ) ;
+
+        flightLength = computeFlightLength( trk ) ;
+
+
+        // also store time and flight length of last tracker hit
+        const TrackState* tsIP = trk->getTrackState( TrackState::AtIP ) ;
+        	const TrackState* tslh = trk->getTrackState( TrackState::AtLastHit ) ;
+
+        lastTrackerHit = trk->getTrackerHits().back() ;
+
+        flightLengthTrkHit = computeFlightLength( tsIP , tslh ) ;
+
+
+        #if 1
+        if( lastTrackerHit->getTime() > 1e-3 ) {
+          dd4hep::rec::Vector3D rpLH = tslh->getReferencePoint() ;
+          dd4hep::rec::Vector3D lhp = lastTrackerHit->getPosition()  ;
+          streamlog_out( DEBUG3 ) << " *************** referenece point calo     : " << refPoint << endl ;
+          streamlog_out( DEBUG3 ) << " *************** referenece point last hit : " << rpLH << endl ;
+          streamlog_out( DEBUG3 ) << " *************** poistion         last hit : " << lhp << endl ;
+          streamlog_out( DEBUG3 ) << "   distance hit-trkstate: " << (rpLH - lhp ).r() << " --  distance  calo/last hit ref points : " << (refPoint-rpLH).r() << endl ;
+          streamlog_out( DEBUG3 ) << "   flight lengths:  " << flightLength << "  - " << flightLengthTrkHit << "  -- diff " << flightLength - flightLengthTrkHit <<
+            " time diff: " << (flightLength - flightLengthTrkHit) / 299.8 << endl ;
+          streamlog_out( DEBUG3 ) << " track state : " << *tslh << endl ;
+          streamlog_out( DEBUG3 ) << " last hit : " << *lastTrackerHit << endl ;
+        }
+        #endif
+
+
+          } else {  // neutral particle
+
+        CaloHitDataVec chv =  layerMap.begin()->second ; // only look in first layer w/ hits
+
+        CaloHitData* closestHit =
+          *min_element( chv.begin() , chv.end () ,
+        		    [](CaloHitData* c0, CaloHitData* c1 ){ return c0->distanceFromIP < c1->distanceFromIP  ; }
+            ) ;
+
+        refPoint = closestHit->lcioHit->getPosition() ;
+
+        flightLength = refPoint.r() ;
+
+
+        dd4hep::rec::Vector3D cluPos = clu->getPosition() ;
+
+        unitDir = cluPos.unit() ;
+
+          }
+
+          streamlog_out( DEBUG2 ) << " ----- use reference point for TOF : " << refPoint << endl ;
+
+          streamlog_out( DEBUG ) << " -----  calorimeter hits considered for estimators : " << endl ;
+
+
+          // ------  loop again over hits and fill missing data
+
+          for( auto ch : caloHitVec ){
+
+        CalorimeterHit* calohit = ch->lcioHit ;
+
+        dd4hep::rec::Vector3D pos = ch->lcioHit->getPosition() ;
+
+        ch->distanceFromReferencePoint = ( pos - refPoint ).r()   ;
+
+        ch->distancefromStraightline = computeDistanceFromLine( calohit, refPoint, unitDir ) ;
+
+        streamlog_out( DEBUG ) <<  "     ----- " << caloTypeStr( calohit )
+        		       <<  " --  " <<  ch->toString()   <<   endl ;
+          }
+
+          // ---- now get hits that are closest to the extrapolated line
+          CaloHitDataVec tofHits = findHitsClosestToLine( layerMap ) ;
+
+
+          streamlog_out( DEBUG )   <<  " ***** hits used for the TOF estimator : " << endl ;
+          for( auto ch : tofHits ){
+        streamlog_out( DEBUG ) <<  "     ----- " << ch->toString() << endl ;
+          }
+
+          auto t_dt     = computeTOFEstimator( tofHits ) ;
+
+          const static float c_mm_per_ns = 299.792458 ;
+
+          float tof_fh = tofHits[0]->smearedTime - tofHits[0]->distanceFromReferencePoint / c_mm_per_ns ;
+
+          streamlog_out( DEBUG2 ) << "  #### tof ( first ) : " <<  tof_fh << " +/- " << 0 << endl ;
+          streamlog_out( DEBUG2 ) << "  #### tof ( straight line ) : " << t_dt.first << " +/- " << t_dt.second << endl ;
+
+
+          float trkHitTime = ( lastTrackerHit ?   lastTrackerHit->getTime()   : 0.  ) ;
+
+
+          FloatVec TOF_params = { tof_fh,
+        		      t_dt.first, t_dt.second,
+        		      flightLength , trkHitTime , flightLengthTrkHit } ;
+
+          pidh.setParticleID( pfo , 0, 0 , 0.0 , algoID, TOF_params );
+
+
+        //=========================================================================================
+
+        }
+
+        }
+    }
+    else if (_procVersion == "new"){
+        _generator.seed( Global::EVENTSEEDER->getSeed(this) );
+
+        LCCollection* colPFO = evt->getCollection(_colNamePFO);
+        PIDHandler handler( colPFO );
+        int algoID = handler.addAlgorithm( name() , _TOFNames);
+
+        for (int i=0; i<colPFO->getNumberOfElements(); ++i){
+            ReconstructedParticle* pfo = dynamic_cast <ReconstructedParticle*> ( colPFO->getElementAt(i) );
+            int nClusters = pfo->getClusters().size();
+            int nTracks = pfo->getTracks().size();
+
+            // Only simple cases of PFOs
+            if( nClusters != 1 || nTracks != 1) continue;
+
+            const Track* track = pfo->getTracks()[0];
+            const Cluster* cluster = pfo->getClusters()[0];
+
+            float momAtCalo = getMomAtCalo(track).r();
+            float flightLength = getFlightLength(track);
+            float tofClosest = getTOFClosest(track, cluster);
+            float tofFastest = getTOFFastest(track, cluster);
+            float tofCylFit = getTOFCylFit(track, cluster);
+            float tofClosestFit = getTOFClosestFit(track, cluster);
+
+            const vector <float> results{tofClosest, tofFastest, tofCylFit, tofClosestFit, flightLength, momAtCalo};
+            handler.setParticleID(pfo , 0, 0, 0., algoID, results);
+        }
+    }
+}
 
 
 void TOFEstimators::check( LCEvent *evt) {
-
-  streamlog_out( DEBUG ) << " --- check called ! " << std::endl ; 
-
-
-  // create some histograms with beta vs momentum for charged particles
-  
-  if( isFirstEvent() ){
-
-    // this creates a directory for this processor ....
-    AIDAProcessor::histogramFactory( this ) ;
-
-    _h.resize(5) ;
-    int nBins = 100 ;
-    _h[0] = new TH2F( "hbetaFirstHitsChrg", "beta vs momentum - first hit - charged",    nBins, .1 , 10., nBins, 0.93 , 1.03 ) ; 
-    _h[1] = new TH2F( "hbetaCloseHitsChrg", "beta vs momentum - closest hits - charged", nBins, .1 , 10., nBins, 0.93 , 1.03 ) ; 
-
-    _h[2] = new TH2F( "hbetaFirstHitsNeut", "beta vs momentum - first hit - neutral",    nBins, .1 , 10., nBins, 0.93 , 1.03 ) ; 
-    _h[3] = new TH2F( "hbetaCloseHitsNeut", "beta vs momentum - closest hits - neutral", nBins, .1 , 10., nBins, 0.93 , 1.03 ) ; 
-
-    _h[4] = new TH2F( "hbetaLastTrkHit",    "beta vs momentum - last tracker hit", nBins, .1 , 10., nBins, 0.93 , 1.03 ) ; 
+    if( _procVersion == "old"){
+      streamlog_out( DEBUG ) << " --- check called ! " << endl ;
 
 
-  }
+      // create some histograms with beta vs momentum for charged particles
 
-  // get the PFO collection from the event if it exists
-  LCCollection* colPFO = nullptr ;
-  try{ colPFO = evt->getCollection( _colNamePFO ) ; } catch(lcio::Exception){}
+      if( isFirstEvent() ){
 
-  if( colPFO != nullptr ){
-  
-    PIDHandler pidh( colPFO );
-    int algoID       = pidh.getAlgorithmID( name() );
-    int tof_firsthit = pidh.getParameterIndex(algoID,"TOFFirstHit") ;
-    int tof_closest  = pidh.getParameterIndex(algoID,"TOFClosestHits") ;
-    int tof_length   = pidh.getParameterIndex(algoID,"TOFFlightLength") ;
-    int tof_trkhit   = pidh.getParameterIndex(algoID,"TOFLastTrkHit") ;
-    int tof_trk_len  = pidh.getParameterIndex(algoID,"TOFLastTrkHitFlightLength") ;
-    
-    int nPFO = colPFO->getNumberOfElements()  ;
+        // this creates a directory for this processor ....
+        AIDAProcessor::histogramFactory( this ) ;
 
-    for( int i=0 ; i< nPFO ; ++i){
+        _h.resize(5) ;
+        int nBins = 100 ;
+        _h[0] = new TH2F( "hbetaFirstHitsChrg", "beta vs momentum - first hit - charged",    nBins, .1 , 10., nBins, 0.93 , 1.03 ) ;
+        _h[1] = new TH2F( "hbetaCloseHitsChrg", "beta vs momentum - closest hits - charged", nBins, .1 , 10., nBins, 0.93 , 1.03 ) ;
 
-      ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>(  colPFO->getElementAt( i ) ) ;
+        _h[2] = new TH2F( "hbetaFirstHitsNeut", "beta vs momentum - first hit - neutral",    nBins, .1 , 10., nBins, 0.93 , 1.03 ) ;
+        _h[3] = new TH2F( "hbetaCloseHitsNeut", "beta vs momentum - closest hits - neutral", nBins, .1 , 10., nBins, 0.93 , 1.03 ) ;
 
-      const ParticleID& tofPID = pidh.getParticleID( pfo , algoID ) ;
-      
-      const FloatVec& tofParams = tofPID.getParameters() ;
-
-      streamlog_out( DEBUG ) << " ****  found TOF parameters for pfo w/ size " << tofParams.size() << std::endl ;
-
-      if( !tofParams.empty() ){
-
-	const double* mom = pfo->getMomentum() ;
-	double momentum = sqrt( mom[0] * mom[0] +  mom[1] * mom[1] +  mom[2] * mom[2] ) ;
-
-	double length  =  tofParams[ tof_length  ] ; 
-
-	double beta_fh = ( length / tofParams[ tof_firsthit] ) / 299.8 ;
-	double beta_ch = ( length / tofParams[ tof_closest ] ) / 299.8 ;
+        _h[4] = new TH2F( "hbetaLastTrkHit",    "beta vs momentum - last tracker hit", nBins, .1 , 10., nBins, 0.93 , 1.03 ) ;
 
 
-	if( std::abs( pfo->getCharge() )  > 0.5 ) { 
-	  _h[0]->Fill( momentum , beta_fh );
-	  _h[1]->Fill( momentum , beta_ch );
-	} else {
-	  _h[2]->Fill( momentum , beta_fh );
-	  _h[3]->Fill( momentum , beta_ch );
-	}
+      }
 
-	if( tofParams[ tof_trk_len  ] > 1.e-3 ){ // if TOF from last tracker hit has been set
+      // get the PFO collection from the event if it exists
+      LCCollection* colPFO = nullptr ;
+      try{ colPFO = evt->getCollection( _colNamePFO ) ; } catch(lcio::Exception&){}
 
-	  double beta    = ( tofParams[ tof_trk_len  ] / tofParams[ tof_trkhit  ] ) / 299.8 ;
+      if( colPFO != nullptr ){
 
-	  _h[4]->Fill( momentum , beta );
-	}
+        PIDHandler pidh( colPFO );
+        int algoID       = pidh.getAlgorithmID( name() );
+        int tof_firsthit = pidh.getParameterIndex(algoID,"TOFFirstHit") ;
+        int tof_closest  = pidh.getParameterIndex(algoID,"TOFClosestHits") ;
+        int tof_length   = pidh.getParameterIndex(algoID,"TOFFlightLength") ;
+        int tof_trkhit   = pidh.getParameterIndex(algoID,"TOFLastTrkHit") ;
+        int tof_trk_len  = pidh.getParameterIndex(algoID,"TOFLastTrkHitFlightLength") ;
 
-      } 
+        int nPFO = colPFO->getNumberOfElements()  ;
+
+        for( int i=0 ; i< nPFO ; ++i){
+
+          ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>(  colPFO->getElementAt( i ) ) ;
+
+          const ParticleID& tofPID = pidh.getParticleID( pfo , algoID ) ;
+
+          const FloatVec& tofParams = tofPID.getParameters() ;
+
+          streamlog_out( DEBUG ) << " ****  found TOF parameters for pfo w/ size " << tofParams.size() << endl ;
+
+          if( !tofParams.empty() ){
+
+    	const double* mom = pfo->getMomentum() ;
+    	double momentum = sqrt( mom[0] * mom[0] +  mom[1] * mom[1] +  mom[2] * mom[2] ) ;
+
+    	double length  =  tofParams[ tof_length  ] ;
+
+    	double beta_fh = ( length / tofParams[ tof_firsthit] ) / 299.8 ;
+    	double beta_ch = ( length / tofParams[ tof_closest ] ) / 299.8 ;
+
+
+    	if( abs( pfo->getCharge() )  > 0.5 ) {
+    	  _h[0]->Fill( momentum , beta_fh );
+    	  _h[1]->Fill( momentum , beta_ch );
+    	} else {
+    	  _h[2]->Fill( momentum , beta_fh );
+    	  _h[3]->Fill( momentum , beta_ch );
+    	}
+
+    	if( tofParams[ tof_trk_len  ] > 1.e-3 ){ // if TOF from last tracker hit has been set
+
+    	  double beta    = ( tofParams[ tof_trk_len  ] / tofParams[ tof_trkhit  ] ) / 299.8 ;
+
+    	  _h[4]->Fill( momentum , beta );
+    	}
+
+          }
+        }
+      }
     }
-  }
-  
-}
-
-void TOFEstimators::end(){ 
-
-  gsl_rng_free( _rng );
-
-  streamlog_out(MESSAGE) << "TOFEstimators::end()  " << name() 
-			 << " processed " << _nEvt << " events in " << _nRun << " runs "
-			 << std::endl ;
-
 }
 
 
-//*******************************************************************************************************
+void TOFEstimators::end(){ if( _procVersion == "old") gsl_rng_free( _rng ); }
 
+
+Vector3D TOFEstimators::getMomAtCalo(const Track* track){
+    const TrackState* ts = track->getTrackState(TrackState::AtCalorimeter);
+    double phi = ts->getPhi();
+    double d0 = ts->getD0();
+    double z0 = ts->getZ0();
+    double omega = ts->getOmega();
+    double tanL = ts->getTanLambda();
+
+    const Detector& detector = Detector::getInstance();
+    double bField[3];
+    detector.field().magneticField({0., 0., 0.}, bField);
+
+    HelixClass helix;
+    helix.Initialize_Canonical(phi, d0, z0, omega, tanL, bField[2]/dd4hep::tesla);
+    return helix.getMomentum();
+}
+
+
+double TOFEstimators::getFlightLength(const Track* track){
+    const TrackState* ts = track->getTrackState(TrackState::AtIP);
+    double phiIP = ts->getPhi();
+    ts = track->getTrackState(TrackState::AtCalorimeter);
+    double phiCalo = ts->getPhi();
+    double omegaCalo = ts->getOmega();
+    double tanLCalo = ts->getTanLambda();
+
+    return abs((phiIP - phiCalo)/omegaCalo)*sqrt(1. + tanLCalo*tanLCalo);
+}
+
+
+double TOFEstimators::getTOFClosest(const Track* track, const Cluster* cluster){
+    const TrackState* ts = track->getTrackState(TrackState::AtCalorimeter);
+    Vector3D trackAtCaloPos = ts->getReferencePoint();
+
+    double dToImpactMin = 99999.;
+    double hitTime = 0.;
+    for (auto&& hit : cluster->getCalorimeterHits() ){
+        CHT hitType( hit->getType() );
+        bool isEcal = (hitType.caloID() == CHT::ecal);
+        if (!isEcal) continue;
+
+        Vector3D hitPos = hit->getPosition() ;
+        double dToImpact = (hitPos - trackAtCaloPos).r();
+
+        if(dToImpact < dToImpactMin){
+            dToImpactMin = dToImpact;
+            hitTime = hit->getTime();
+        }
+    }
+    hitTime += _smearing(_generator);
+    return hitTime - dToImpactMin / SPEED_OF_LIGHT;
+}
+
+
+double TOFEstimators::getTOFFastest(const Track* track, const Cluster* cluster){
+    const TrackState* ts = track->getTrackState(TrackState::AtCalorimeter);
+    Vector3D trackAtCaloPos = ts->getReferencePoint();
+
+    double dToImpactMin = 0.;
+    double hitTimeMin = 99999.;
+    for (auto&& hit : cluster->getCalorimeterHits() ){
+        CHT hitType( hit->getType() );
+        bool isEcal = (hitType.caloID() == CHT::ecal);
+        if (!isEcal) continue;
+
+        Vector3D hitPos = hit->getPosition();
+        double dToImpact = (hitPos - trackAtCaloPos).r();
+        double hitTime = hit->getTime() + _smearing(_generator);
+        if(hitTime < hitTimeMin){
+            dToImpactMin = dToImpact;
+            hitTimeMin = hitTime;
+        }
+    }
+    return hitTimeMin - dToImpactMin / SPEED_OF_LIGHT;
+}
+
+
+double TOFEstimators::getTOFCylFit(const Track* track, const Cluster* cluster){
+    const TrackState* ts = track->getTrackState(TrackState::AtCalorimeter);
+    Vector3D trackAtCaloPos = ts->getReferencePoint();
+    Vector3D trackAtCaloMom = getMomAtCalo(track);
+
+    vector <double> x, xErr, y, yErr;
+
+    for (auto&& hit : cluster->getCalorimeterHits() ){
+        CHT hitType( hit->getType() );
+        bool isEcal = (hitType.caloID() == CHT::ecal);
+        int layer = hitType.layer();
+        if (!isEcal || layer >= _maxLayerNum) continue;
+
+        Vector3D hitPos = hit->getPosition();
+        double dToLine = (hitPos - trackAtCaloPos).cross(trackAtCaloMom.unit()).r();
+        // take only hits from 5 mm cylinders. 5 mm value was ibtain optimizing on photons
+        if (dToLine > 5.) continue;
+
+        x.push_back( (hitPos - trackAtCaloPos).r() );
+        y.push_back( hit->getTime() + _smearing(_generator) );
+        xErr.push_back(0.);
+        yErr.push_back( 0.1 );
+    }
+
+    if (x.size() <= 1) return 0.;
+
+    TGraphErrors gr(x.size(), &x[0], &y[0], &xErr[0], &yErr[0]);
+    gr.Fit("pol1", "Q");
+
+    return gr.GetFunction("pol1")->GetParameter(0);
+}
+
+
+double TOFEstimators::getTOFClosestFit(const Track* track, const Cluster* cluster){
+    const TrackState* ts = track->getTrackState(TrackState::AtCalorimeter);
+    Vector3D trackAtCaloPos = ts->getReferencePoint();
+    Vector3D trackAtCaloMom = getMomAtCalo(track);
+
+    std::map<int, double> dToImpact;
+    std::map<int, double> hitTime;
+    std::map<int, double> dToLineMin;
+    for(int i=0; i<_maxLayerNum; ++i) dToImpact[i] = 0.;
+    for(int i=0; i<_maxLayerNum; ++i) hitTime[i] = 0.;
+    for(int i=0; i<_maxLayerNum; ++i) dToLineMin[i] = 99999.;
+
+    for (auto&& hit : cluster->getCalorimeterHits() ){
+        CHT hitType( hit->getType() );
+        bool isEcal = (hitType.caloID() == CHT::ecal);
+        int layer = hitType.layer();
+        if (!isEcal || layer >= _maxLayerNum) continue;
+
+        Vector3D hitPos = hit->getPosition();
+        double dToLine = (hitPos - trackAtCaloPos).cross(trackAtCaloMom.unit()).r();
+        if( dToLine < dToLineMin[layer] ){
+            dToLineMin[layer] = dToLine;
+            dToImpact[layer] = (hitPos - trackAtCaloPos).r();
+            hitTime[layer] = hit->getTime();
+        }
+    }
+
+    vector <double> x, xErr, y, yErr;
+
+    for(int i=0; i<_maxLayerNum; ++i){
+        if (hitTime[i] <= 0.) continue;
+        x.push_back(dToImpact[i]);
+        y.push_back( hitTime[i] + _smearing(_generator) );
+        xErr.push_back(0.);
+        yErr.push_back(0.1);
+    }
+
+    if (x.size() <= 1) return 0.;
+
+    TGraphErrors gr(x.size(), &x[0], &y[0], &xErr[0], &yErr[0]);
+    gr.Fit("pol1", "Q");
+
+    return gr.GetFunction("pol1")->GetParameter(0);
+}

--- a/TimeOfFlight/src/TOFEstimators.cc
+++ b/TimeOfFlight/src/TOFEstimators.cc
@@ -279,7 +279,7 @@ void TOFEstimators::processEvent( LCEvent * evt ) {
           streamlog_out( DEBUG3 ) << " *************** poistion         last hit : " << lhp << std::endl ;
           streamlog_out( DEBUG3 ) << "   distance hit-trkstate: " << (rpLH - lhp ).r() << " --  distance  calo/last hit ref points : " << (refPoint-rpLH).r() << std::endl ;
           streamlog_out( DEBUG3 ) << "   flight lengths:  " << flightLength << "  - " << flightLengthTrkHit << "  -- diff " << flightLength - flightLengthTrkHit <<
-            " time diff: " << (flightLength - flightLengthTrkHit) / 299.8 << std::endl ;
+            " time diff: " << (flightLength - flightLengthTrkHit) / CLHEP::c_light << std::endl ;
           streamlog_out( DEBUG3 ) << " track state : " << *tslh << std::endl ;
           streamlog_out( DEBUG3 ) << " last hit : " << *lastTrackerHit << std::endl ;
         }
@@ -338,9 +338,7 @@ void TOFEstimators::processEvent( LCEvent * evt ) {
 
           auto t_dt     = computeTOFEstimator( tofHits ) ;
 
-          const static float c_mm_per_ns = 299.792458 ;
-
-          float tof_fh = tofHits[0]->smearedTime - tofHits[0]->distanceFromReferencePoint / c_mm_per_ns ;
+          float tof_fh = tofHits[0]->smearedTime - tofHits[0]->distanceFromReferencePoint / CLHEP::c_light ;
 
           streamlog_out( DEBUG2 ) << "  #### tof ( first ) : " <<  tof_fh << " +/- " << 0 << std::endl ;
           streamlog_out( DEBUG2 ) << "  #### tof ( straight line ) : " << t_dt.first << " +/- " << t_dt.second << std::endl ;
@@ -452,8 +450,8 @@ void TOFEstimators::check( LCEvent *evt) {
 
     	double length  =  tofParams[ tof_length  ] ;
 
-    	double beta_fh = ( length / tofParams[ tof_firsthit] ) / 299.8 ;
-    	double beta_ch = ( length / tofParams[ tof_closest ] ) / 299.8 ;
+    	double beta_fh = ( length / tofParams[ tof_firsthit] ) / CLHEP::c_light ;
+    	double beta_ch = ( length / tofParams[ tof_closest ] ) / CLHEP::c_light ;
 
 
     	if( abs( pfo->getCharge() )  > 0.5 ) {
@@ -466,7 +464,7 @@ void TOFEstimators::check( LCEvent *evt) {
 
     	if( tofParams[ tof_trk_len  ] > 1.e-3 ){ // if TOF from last tracker hit has been set
 
-    	  double beta    = ( tofParams[ tof_trk_len  ] / tofParams[ tof_trkhit  ] ) / 299.8 ;
+    	  double beta    = ( tofParams[ tof_trk_len  ] / tofParams[ tof_trkhit  ] ) / CLHEP::c_light ;
 
     	  _h[4]->Fill( momentum , beta );
     	}


### PR DESCRIPTION
BEGINRELEASENOTES

- TOFEstimators processor: adding new algorithms to calculate the ToF, track length and momentum.
  - New output parameters:
    - TOFClosest --- based on the closest ECAL hit
    - TOFFastest --- based on the fastest ECAL hit
    - TOFCylFit --- extrapolated time from the ECAL hits within a cylinder of a shower core
    - TOFClosestFit --- extrapolated time from the ECAL hits closest to the linear continuation of the track inside the ECAL
    - FlightLength --- the helix track length based on the track parameters from the TrackState at the ECAL
    - MomAtCal --- the momentum based on the track parameters from the TrackState at the ECAL
  - New steering parameters:
    - ProcessorVersion --- changes output between the idr version (before this patch) and the dev (after this patch). Default: idr
    - CylRadius --- the radius within which to select hits for the TOFCylFit method. Default: 5 mm

ENDRELEASENOTES

### Important notes
Currently new algorithms work only with simple cases of PFO, meaning: **only one cluster** and **only one track** associated with PFO. Other PFOs are ignored.

Flight length calculation are done using the assumption of less than 2*pi change in the phi angle. Meaning that the **flight length** gives the **wrong** results for the tracks with **more than one helix curls**.

Thus, the new algorithms are still optimized to work in the barrel part only. **Performance** of the TOF estimators in the **endcap** is currently **unknown**.

### What's new
We added new TOF estimators that show a better performance in terms of less bias in the measurement of pions, kaons and protons masses.

### Steering parameter
New steering parameter `ProcessorVersion` has been added with the possible values: `"idr"` (default) and `"dev"`.
The previous behavior is set by default for the backwards compatibility.

### Output
In the new version the output parameters are modified to:
`{"TOFClosest", "TOFFastest", "TOFCylFit", "TOFClosestFit", "FlightLength", "MomAtCalo"}`

- TOF* --- are TimeOfFlight estimated by different algorithms (see bellow).
- FlightLength --- is a track length of a particle from IP (assuming (0, 0, 0)) to ECAL surface
- MomAtCalo --- Track momentum at ECAL surface.

Using these parameters the mass of a particle can be calculated.

### TOF estimators
The four estimators are available in the new version:
- TOFClosest --- time of the ECAL hit closest to the extrapolated track position at the ECAL surface with correction for distance between impact point and center of ECAL cell assuming speed of light propagation.
- TOFFastest --- time of the ECAL hit with the smallest time with correction for distance between impact point and center of ECAL cell assuming speed of light propagation.
- TOFCylFit --- time estimated with a linear fit of the ECAL hits times in the 5mm cylinder with the main axis parallel to track direction at the ECAL surface vs distance to the impact point of each hit. Then TOF is the bias parameter of a linear fit.
- TOFClosestFit --- time estimated with a linear fit of the ECAL hits times which are closest to the track line estimated at the ECAL surface (one closest hit per layer) vs distance to the impact point of each hit. Then TOF is the bias parameter of a linear fit.
