### PR TITLE
Full true jet update

### DIFF
--- a/Analysis/TrueJet/README.md
+++ b/Analysis/TrueJet/README.md
@@ -1,0 +1,294 @@
+#  TrueJet: A Marlin processor to group particles into jets, using true information.
+
+Author:
+
+  Mikael Berggren <mikael.berggren@desy.de>
+
+## Brief description:
+
+  Use this Marlin processor to create collections and navigators
+to find jets actually coming from separate initial systems.
+Both true, seen, and true-of-seen jet-energies are accessible.
+The correct total energy can be calculated. Correct di-jet
+pairings giving W or Z are provided. Jet-flavour is indicated.
+Inner brems-strahlung and gluon induced jets are flagged.
+Particles from overlaid gamma-gamma to hadrons are identified
+The only exception is that currently _initial_ gluon-jets (from H->g g)
+cannot be treated.
+
+
+To use the the output from the processor in further analysis,
+it is suggested to use the helper-class TrueJet_Parser.
+
+The only processor-parameters used are collection names for output and
+input (mcparticles(skimmed), pfos , and the mc-reco link.
+The latter two are gracefully ignored if absent, as is the case
+if the input LCIO file is the output from the event generator.
+There is also one boolean flag to switch between Whizard1 and
+and Whizard2 format of the MCParticle (i.e. between mc2020 and IDR DSTs).
+The defaults should work when running on mc2020 DSTs,
+so normally no parameters are needed to be specified. For IDR DSTs,
+and for generator-output LCIO files, the name of the MCParticle
+collection needs to be adjusted, and for IDR DSTs, the flag Whizard1
+must be set to `true`.
+
+See the examples folder for suggested steering-files. Play with the
+Verbosity level. Put to MESSAGE or WARNING to make it almost shut up.
+
+## Detailed Description:
+
+  The processor uses the MCParticle collection, and the
+RecoMCTruthLink navigator as input. It recreates the Pythia event
+record from the MCParticles, corrects in-consistencies (both those 
+already present in  the input file and those created by
+simulation). It identifies the _initial_ and _final_ colour-neutral
+systems, meaning those at the beginning and end of the parton-shower,
+respectively. It identifies the decay-products of these systems and
+the particles giving rise to them. In each such system, the final
+products are assigned to one of two jets, by looking at the angle to
+either of the two particles creating the colour-neutral system.
+All decay-products - also those created in simulation - of the
+primary hadrons are assigned to the same jet as their ancestor.
+The jet-identity is also propagated backwards through the parton-
+shower, until either the initial, hard particles from the matrix-
+element are reached, or it is found that the particles came from
+a radiated gluon or IVB. In the process, inner-bremsstrahlung photons
+are also found, and added to the jet of the particle that radiated
+them.
+
+The  _final_ colour-neutral systems always give rise to two jets.
+This is also true if the colour-neutral system is a "cluster"
+i.e. a bound state of initial quarks (normally the  colour-neutral 
+system is a "string" i.e.. a system of two quarks and a chain of gluons).
+Usually, a "cluster" materialises to a single hadron, so one of the
+two jets will be _empty_ . However, both jets will be present earlier
+in the parton-shower.
+
+The _initial_ colour-neutral system  might make more than two jets, 
+due to gluon radiation. In the this case, TrueJet keeps track of 
+which jets ultimately came from a given _initial_ colour-neutral system. 
+The _initial_  colour-neutral system is the one that is expected to come 
+from a single IVB-fermion-antifermion vertex in the initial hard process.
+
+The same logic also works for leptons: They, too, are grouped together
+two-by-two into groups associated with the same initial boson.
+
+ISR photons are assigned to separate (un-grouped) jets, as are photons
+explicitly present in the hard interaction, i.e. the final state in the
+Whizard process definition. This includes gammas from H->gammagamma or
+H->Zgamma.
+
+All post-parton shower MCParticles that were not assigned to
+any jet by this process are from overlaid gamma-gamma->hadrons
+events, or beam-strahlung pairs, and are grouped together into one single jet.
+
+For further explanations of the method , see the commented listing in 
+the examples folder and  [this talk](http://agenda.linearcollider.org/getFile.py/access?contribId=0&resId=0&materialId=slides&confId=6526).
+(note that some collection-names have changed wrt. that talk).
+
+**Process-parameters**:
+
+<u>Input collection names</u>
+
+
+|   parameter name         |          type         |            default |
+|-----                     |-------                | ------- |
+|  MCParticleCollection    | MCParticle            |   MCParticles |
+|  RecoParticleCollection  | ReconstructedParticle |  PandoraPFOs |
+|  RecoMCTruthLink         | LCRelation            |  RecoMCTruthLink |
+
+<u>Output collection names</u>
+
+
+|   parameter name         |          type         |            default |
+|-----                     |-------                | ------- |
+|  TrueJets                | ReconstructedParticle  | TrueJets  |
+|  FinalColourNeutrals     | ReconstructedParticle  | FinalColourNeutrals |
+|  InitialColourNeutrals   | ReconstructedParticle  | InitialColourNeutrals |
+| | | |
+|  TrueJetPFOLink          | LCRelation             | TrueJetPFOLink |
+|  TrueJetMCParticleLink   | LCRelation             | TrueJetMCParticleLink |
+|  FinalElementonLink      | LCRelation             | FinalElementonLink |
+|  InitialElementonLink    | LCRelation             | InitialElementonLink |
+|  FinalColourNeutralLink  | LCRelation             | FinalColourNeutralLink |
+|  InitialColourNeutralLink| LCRelation             | InitialColourNeutralLink |
+
+
+** Marlin steering sections **:
+
+```
+
+ <execute>
+           .
+           .
+           .
+  <processor name="mytruejet"/>
+           .
+           .
+           .
+ (optionally:)
+  <processor name="DSTOutput"/>
+ </execute>
+           .
+           .
+           .
+<processor name="mytruejet" type="TrueJet">
+ ... (add process parameters if for some strange reason the default collection names are not OK)
+</processor>
+```
+
+If DSTOutput called: need to add the TrueJet outputs to the parameters of 
+processor name="DSTOutput", by adding
+
+
+-       TrueJets
+-       FinalColourNeutrals
+-       InitialColourNeutrals
+-       TrueJetPFOLink 
+-       TrueJetMCParticleLink 
+-       FinalElementonLink 
+-       InitialElementonLink 
+-       FinalColourNeutralLink 
+-       InitialColourNeutralLink
+
+to the   <parameter name="KeepCollectionNames" type="StringVec"> 
+section of the DSTOutput processor parameters. If full functionality
+of TrueJet_Parser is wanted, at least
+
+-       MCParticles
+-       RecoMCTruthLink
+-       MCTruthRecoLink
+
+should also be in the list, but they would be in any useful DST-output anyhow....
+
+** Contents of the output collections **:
+
+  <u>TrueJets (ReconstructedParticle):</u>
+
+   `getEnergy, getMass, getMomentum, getCharge` returns those quantities, calculated from the values
+    of all PFOs connected to the true jet.
+    
+   `getParticles` returns the list of all PFOs in the jet.
+   `getParticleIDs()[0]->getType` returns the jet type as:
+   
+       1  : jet from string
+       2  : jet is lepton
+       3  : jet from cluster
+       4  : jet is ISR
+       5  : jet is overlay
+       6  : jet is a photon from the matrix-element
+       
+
+
+if the jet came from a quark from gluon-splitting, [(jet radiating the gluon)+1]*100 is added to the type.
+`getParticleIDs()[0]->getPDG()` returns the jet flavour as the PDG of the elementon (quark/lepton/photon) it
+is associated to.
+
+No other information is filled.
+
+<u>  FinalColourNeutrals (ReconstructedParticle):</u>
+
+`getEnergy`, `getMass`, `getMomentum`,  returns those quantities, as given by the values
+of the string, or the particle produced by the cluster, or as the sum of the two
+leptons from the initial boson, or as the sum of true energies of all stable particles
+(for jet type 1,3,2,5), or simply as the true value of each photon (type 4 or 6)
+`getParticles` returns the TrueJets connected to the system (always two, except for ISR)
+
+   `getParticleIDs()[0]->getType` returns the  Colour Neutral type as:
+   
+       1  : c.n. is string
+       2  : c.n. is lepton-pair
+       3  : c.n. is cluster
+       4  : c.n. is single ISR
+       6  : c.n. is single photon from the M.E.
+
+`getParticleIDs()[1:2]->getType` is the same as the type of jet 1:2 emerging from the
+Colour Neutral system.
+
+   `getParticleIDs()[0:2]->getPDG` returns the  Colour Neutral PDG as:
+   
+       0 : PDG of the system itself (92=string, 91=cluster, 22=photon (ISR or ME), any lepton PDG=lepton pair)
+       1 : PDG of first elementon (quark, lepton or photon)
+       2 : PDG of second elementon (quark or  lepton)
+
+No other information is filled.
+
+<u>  InitialColourNeutrals (ReconstructedParticle):</u>
+
+`getEnergy`, `getMass`, `getMomentum`, returns those quantities, as given by the values
+of the CMcluster, or the particle produced by the boson, in case there was no CMcluster
+(sometimes happens for quarks, almost always for leptons)
+`getParticles` returns the _TrueJets_ connected to the system (at least two, possibly more
+if there was hard gluon radiation or (top) quark-decay during the parton shower)
+
+   `getParticleIDs()[0]->getType` returns the Colour Neutral type as:
+   
+       1,3  : c.n. is hadronic
+       2    : c.n. lepton-pair
+       
+`getParticleIDs()[1:n]->getType` is the same as the type of jet 1:n emerging from the
+ Colour Neutral system.
+   
+   `getParticleIDs()[0:n]->getPDG` returns the  Colour Neutral PDG as:
+
+       0   : PDG of the boson (23=Z, 24=W, 25=H ... )
+       1:n : PDG of elementon (quark, lepton) 1:n
+
+Note that the PDG of the boson is the _last_ boson in the case of a chain, specifically for
+H->WW*, ZZ* or Zgamma, the boson is *not* the Higgs, but rather the W, Z or gamma. In H->ffbar, on
+the other hand, the boson *is* the Higgs.
+
+No other information is filled.
+ 
+** Navigators: **
+
+|   Name                      |  Object   |  Related objects |
+| ----------                  | --------- | --------- |
+|  TrueJetPFOLink             | TrueJet-> | all PFO of jet |
+|  TrueJetMCParticleLink      | TrueJet-> | all MCParticles of jet |
+|  FinalElementonLink         | TrueJet-> | the MCParticle that is the Final elementon (quark/lepton/photon) of the jet  |
+|  InitialElementonLink       | TrueJet-> | the MCParticle that is the Initial elementon (quark/lepton/photon) of the jet  |
+|  FinalColourNeutralLink     | TrueJet-> | FinalColourNeutrals of the jet |
+|  InitialColourNeutralLink   | TrueJet-> | InitialColourNeutrals of the jet |
+
+
+To make this clear: If `reltjmcp` is created by
+
+```
+    tjmcplcol  = evt->getCollection(  _trueJetMCParticleLink );
+    reltjmcp = new LCRelationNavigator( tjmcplcol );
+```
+
+then
+
+
+`reltjmcp->getRelated`*To*`Objects( aTrueJet )`
+                     
+
+returns the list of mcparticles in jet aTrueJet, while
+
+
+`reltjmcp->getRelated`*From*`Objects( anMCparticle )`
+
+returns the jet an MCParticle belongs to (It is in principle a list, but off course
+it only contains one element!)
+
+Differently put, the order of the elements in the table is the same as the order of
+the arguments of the addRelation method of an `LCRelationNavigator`.
+
+Except for _TrueJetMCParticle_, the weight of the relation has no particular meaning.
+In _TrueJetMCParticle_ the meaning of the weight (as from `www =  reltjmcp->getRelated`*To*`Weights(  aTrueJet )` )
+is:
+
+      1   : stable particle from generator, or decayed particle where the sum of 4-mom of the daughters is 
+            different from the 4-mom of the particle (which indicates that the detector simulation has modified
+	    the particle before decay)  
+     -1   : generator inner brems photon.
+
+      11  : generator decayed particle.
+      0   : created in simulation, or generator particle where the parent has been modified before decay,
+            so that the 4-mom is inconsistent.
+
+Hence, adding all MCP:s related with any jets of types 1,2,3 or 6 with `|weight| == 1` gives the total
+4-mom of the hard reaction. Also adding jets of type 4 adds the ISR to the sum and finally
+including type 5 jets also include the overlay events.

--- a/Analysis/TrueJet/examples/truejet_run_ana_onthefly.xml
+++ b/Analysis/TrueJet/examples/truejet_run_ana_onthefly.xml
@@ -18,14 +18,13 @@
  <global>
 
 <parameter name="LCIOInputFiles">
-/afs/desy.de/group/flc/pool/analysis/rv01-16-p05_500.sv01-14-01-p00.mILD_o1_v05.E500-TDR_ws.I250006.P4f_ww_h.eL.pR-00001-DST.slcio
+inputdst
 </parameter>
   <!-- limit the number of processed records (run+evt): -->  
-  <parameter name="MaxRecordNumber" value="10" />  
-  <parameter name="SkipNEvents" value="" />  
+  <parameter name="MaxRecordNumber" value="1000" />  
+  <parameter name="SkipNEvents" value="0" />  
   <parameter name="SupressCheck" value="false" />  
-  <parameter name="GearXMLFile"> gear_ild.xml </parameter>  
-  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG5 </parameter> 
+  <!-- parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">DEBUG4</parameter--> 
  </global>
 
  <processor name="MyAIDAProcessor" type="AIDAProcessor">
@@ -42,7 +41,12 @@
 
 
  <processor name="mytruejet" type="TrueJet">
- <!-- These are the defaults, probably exactly what you need.
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">
+DEBUG9
+  </parameter> 
+
+
+<!-- These are the defaults, probably exactly what you need.
   <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle">MCParticlesSkimmed</parameter>
   <parameter name="RecoParticleCollection" type="string"  lcioInType="ReconstructedParticle">PandoraPFOs</parameter>
   <parameter name="RecoMCTruthLinkName" type="string" lcioInType="LCRelation"> RecoMCTruthLink </parameter>
@@ -57,13 +61,25 @@
   <parameter name="InitialElementonLink" type="string" lcioOutType="LCRelation">InitialElementonLink</parameter>
   <parameter name="InitialColourNeutralLink" type="string" lcioOutType="LCRelation">InitialColourNeutralLink</parameter>
   <parameter name="InitialColourNeutralLink" type="string" lcioOutType="LCRelation">InitialColourNeutralLink</parameter>
+   <parameter name="Whizard1" type="bool">0</parameter>
   -->
+
+<!-- these two might need to be switched on depending on input (IDR samples require both, input generator
+     samples require the first one) -->
+
+<!--
+  <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle">MCParticle</parameter>
+ -->
+<!--
+   <parameter name="Whizard1" type="bool">1</parameter>  
+-->
 
 
 </processor>
 
 
 <processor name="myuse_truejet" type="Use_TrueJet">
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">DEBUG5</parameter> 
  <!-- Using the defaults above, only your "own" parameters are needed 
   <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle">MCParticlesSkimmed</parameter>
   <parameter name="RecoParticleCollection" type="string"  lcioInType="ReconstructedParticle">PandoraPFOs</parameter>

--- a/Analysis/TrueJet/include/TrueJet.h
+++ b/Analysis/TrueJet/include/TrueJet.h
@@ -78,7 +78,7 @@ class TrueJet : public Processor {
   std::string  _MCParticleColllectionName{};
   std::string _recoParticleCollectionName{};
   std::string _recoMCTruthLink{};
- /**  ouput collection names */
+ /**  ouput collection names. The corresponding collections are filled from the internal data structues at the end of processEvent */
   std::string _trueJetCollectionName{};
   std::string _finalColourNeutralCollectionName{};
   std::string _initialColourNeutralCollectionName{};
@@ -95,70 +95,117 @@ class TrueJet : public Processor {
 private:
 
   void getPyjets(LCCollection* mcpcol);
-
+  void stdhep_reader_bug_workaround( int line94 );
   void true_lepton();
   void cluster();
   void string();
   void assign_jet(int jet1,int jet2,int this_fafp);
   void first_parton(int this_partic,int this_jet,int& first_partic,int& last_94_parent,int& nfsr,int& info,int& info2);
   int flavour(int k2) ;
-  void fix94() ;
   void isr() ;
+  void photon();
   void grouping() ;
-  void fix_top();
   LCEvent * evt{};
-  MCParticleVec  mcp_pyjets{};
 
-    int jet[4001]{};
-    int companion[4001]{};
-    double p[4001][6]{};
-    int k[4001][7]{};
-    int nlund{};
-    int i_jet{};
+                             // The information in the MCParticleCollection, recast into "pyjets"
+                             // format. This is the structure the processor works with internally.
+                             // Note that line-numbering starts at 1, not 0
+
+                             // getting from one to the other:
+                             //  mcp_pyjets[k_py]=mcp  gets the MCParticle corresponding to a pythia-line
+                             //  i_py= mcp->ext<MCPpyjet>()  gets the pythia-line of an MCParticle.
+
+    double p[4001][6]{};     // p,E and M - direct copy from the MCParticle  
+    int k[4001][9]{};        // status, pid, and history information:
+                             //  1:status , 2:pdg, 3:(first) mother, 4&5 first and last daugther,
+                             //  6: last mother, 7&8; colour&anti-colour code
+
+                             // history codes (3,4,5,6) refers to the line (first index) of p and k.
+                             // The  first and last daugther codes always indicate a consecutive
+                             // set of lines with the same mother, while between the first and last mother
+                             // lines, there can be lines *not* having the daughter in question, so
+                             // a loop-n-check between thes two is always needed!
+
+                             // status codes: 0:created in simulation, 1: stable, 11:decaying, 
+                             //   21:documentation. Any of these +30: particle is overlay
+
+                             // pdg: either the particle pdg code, or one of Pythia's internal
+                             // codes: 91; cluster, i.e. a hadron created *during* the parton-shower
+                             //  92: string, i.e. the object that is the parent of all hadrons at the
+                             //  end of the parton-shower. It's direct parent is a group of lines,
+                             //  starting and ending with quarks, with a number of colour-conected
+                             //  gluons inbetween. 94: a many-to-many object used to allow to redistribute
+                             //  four-momentum between it's components (total 4-mom conserved)
+
+                             // Note than k is *not* a direct copy of the information in the MCParticle.
+                             // In particular, many idiosyncarcies are corrected for - mostly concerning
+                             // 94 objects. Also the (inaptly named) colour-code is sometimes also used
+                             // for leptons, to indicate how these should be grouped, in case the generator
+                             // information contains hints of this.
+
+    int nlund{};             //  number of entries in this event
+    MCParticleVec  mcp_pyjets{};  // Cross-reference
+
+                             //  final results of the processor at particle level:
+
+    int jet[4001]{};         //  Jet number of the particle 
+    int companion[4001]{};   //  Associated jet (i.e. the jet that creates a colour-neutral
+                             //  object together with the jet this particle belongs to)
+
+    int current_jet{};
     int first_line{};
 
+                             //  final results of the processor at jet level:
     // TYPE jets_summary_t
-    int njet{};
-    int n_djb{};
-    int n_dje{};
-    int nstr{};  // *2
-    int n_hard_lepton{};
-    int nboson{};
-    int nclu{};  // *2
-    int nisr{};
-    int n_mixed{};
-    int n_jetless{};
-    int n_2jet_clu{};
-    int n_0_E_jets{};
-    int n_beam_jet{};
+    int njet{};         // number of jets found
+    int n_djb{};        // number of initial di-jets (=colour neutrals)
+    int n_dje{};        // number of final di-jets (=colour neutrals), If there are no gluon-splitting in the P.S.
+                        // n_djb = n_dje.
+    int nstr{};         // number of strings   
+    int n_hard_lepton{};// number of hard (ME) leptons
+    int nboson{};       // number of bosons (normally gluons) yielding ffbar pairs *during* the P.S.
+    int nclu{};         // number of "clusters", i.e. hadrons created *during* the P.S. They have two quark parents,
+                        // so even if there is only one hadron created (usually, but not always the case), there will be
+                        // an empty jet.
+    int nisr{};         // number of ISRs
+    int nphot{};        // number of M.E. photons (not counting ISR)
+    int n_mixed{};      // number of "mixed" jets - jets with final particles from different true jets. should be 0
+    int n_jetless{};    // number of jets with no assigned identy. should be 0
+    int n_2jet_clu{};   // number of clusters actually giving two non empty jets (see above)
+    int n_0_E_jets{};   // number of empty (zero energy) jets - typically from clusters (see above)
+    int n_beam_jet{};   // number of beam (overlay) jets. Either 1 or 0 (is there was no overlay at all in the event)
 
-    // TYPE jet_t
+
+    // TYPE jet_t         //    Index in the following is the jet-number, and when the variable refers to a particle,
+                          //    the line in pyjets is implied
+
     int fafp_last[26]{};  // fafp = fermion-antifermion pair. _last is the last created = the first if there was no gluon splitting
-                        // or from a W from eg a top decay
+                          // or from a W from eg a top decay
     int elementon[26]{};  // I just invented that word (collective for quarks, leptons and elementary bosons) 
-    int boson[26]{};
-    int fafp_boson[26]{};  // fafp of the boson creating this jet. 
+                          // The elemeton is the particle directly before the final hadrons or leptons
+                          // for hadrons, it would be the two last-generation quarks, for leptons usually simply the
+                          // initial leptons.
+    int boson[26]{};      // boson (gluons) inside the P.S. giving qqbars
+    int fafp_boson[26]{}; // fafp of the boson creating this jet. 
     int fafp[26]{};       // first fafp of the jet = either fafp_last (jet not from boson) or fafp_boson (jet from boson)
-    int nfsr[26]{};
-    int type[26]{};
+    int nfsr[26]{};       // number of FSR photons
+    int type[26]{};       // type of the jet: 1:string, 2:lepton, 3:cluster, 4:ISR, 5:overlay, 6:ME photon
     int group[26][26]{};  // group this jet belongs to. 
-    int dijet_begining[26]{}; // the initial di-jet of the jet. the fafp:s of all jets in this group is the initial fafp ie. ie the boson
-                             // kids (colour singlet!)
-    int dijet_end[26]{};       // idem for the final di-jet (could be the same as the initial, or could be gluon/W induced)
-    // pjet(5) =
-    double tmom[26][3]{};
-    double tE[26]{};
+    int dijet_begining[26]{}; // the initial di-jet of the jet. the fafp:s of all jets in this group is the initial fafp ie. 
+                              // ie the fermion anti-fermion pair the boson directly decayed to. A colour singlet.
+    int dijet_end[26]{};      // idem for the final di-jet (could be the same as the initial, or could be gluon/W induced)
+    double tmom[26][3]{}; // true momentum
+    double tE[26]{};      // true energy.
 
     //TYPE dijet_t (begin)
-    int jets_begin[26][26]{};
-    //singlet_four_p(5)
-    //psum_four_p(5)
+    int jets_begin[26][26]{};    // list of jets the initial colour singlet gives rise to
 
     //TYPE dijet_t (end)
-    int jets_end[26][26]{};
-    //singlet_four_p(5)
-    //psum_four_p(5)
+    int jets_end[26][26]{};     // list of jets the final colour singlet gives rise to
 
+    bool _whiz1 = false ;
+    bool _top_event = false ;
+    bool _higgs_to_glue_glue = false ;
 } ;
 
 #endif

--- a/Analysis/TrueJet/src/TrueJet.cc
+++ b/Analysis/TrueJet/src/TrueJet.cc
@@ -1,7 +1,6 @@
 #include "TrueJet.h"
 #include <stdlib.h>
 #include <math.h>
-//#include <cmath>
 #include <iostream>
 #include <iomanip>
 
@@ -111,8 +110,14 @@ TrueJet::TrueJet() : Processor("TrueJet") {
                             "Name of the  InitialColourNeutralLink output collection"  ,
                             _initialColourNeutralLink,
                             std::string("InitialColourNeutralLink") ) ;
+  // steering
 
-}
+  registerProcessorParameter("Whizard1",
+                             "true: Input has MCParticles in Whizard1 convention ",
+                             _whiz1,
+                             bool(false)
+                             );
+ }
 
 
 
@@ -138,6 +143,9 @@ void TrueJet::processRunHeader( LCRunHeader*  /*run*/) {
 
 void TrueJet::processEvent( LCEvent * event ) { 
 
+
+    // For the concepts this method works with, see the comments in TrueJet.h
+
     evt=event;
     streamlog_out(WARNING) << " processing event: " << evt->getEventNumber() 
         << "   in run:  " << evt->getRunNumber() << std::endl ;
@@ -152,6 +160,7 @@ void TrueJet::processEvent( LCEvent * event ) {
     {
         streamlog_out(WARNING) <<  _MCParticleColllectionName  << " collection not available" << std::endl;
         mcpcol = NULL;
+	return;
     }
     LCCollection* rmclcol = NULL;
     try{
@@ -159,25 +168,36 @@ void TrueJet::processEvent( LCEvent * event ) {
     }
     catch( lcio::DataNotAvailableException e )
     {
-        streamlog_out(WARNING) << _recoMCTruthLink   << " collection not available" << std::endl;
+        streamlog_out(MESSAGE4) << _recoMCTruthLink   << " collection not available" << std::endl;
         rmclcol = NULL;
     }
 
-    if( mcpcol != NULL &&  rmclcol != NULL){
+    // TODO: in w2 : get polarization1 &2 ; count sum of W:s and L/R : if this is odd, then an odd number
+    //   of leptons are expected ( one beam-remnant + zero or more pairs ). For now, just  skip the
+    //   warning about odd number of leptons.
 
-      reltrue = new LCRelationNavigator( rmclcol );
+    if( mcpcol != NULL ){
+
+      if ( rmclcol != NULL ) { reltrue = new LCRelationNavigator( rmclcol ); }
 
       // recast the MCParticles into a PYJETS look-alike, needed for the logic to work:
 
  
-      //std::cout << " calling getPyjets"<< std::endl;
       mcp_pyjets.reserve(4000);
-      //      MCParticleVec  mcp_pyjets;  mcp_pyjets.reserve(4000);
       getPyjets(mcpcol );
+      
+      if  ( _higgs_to_glue_glue ) {
+        streamlog_out(DEBUG4) << " Higgs-> gluon gluon event : TrueJet will not work correctly " << std::endl;
+        if ( reltrue ) delete reltrue ;
+        _nEvt++ ;
+        LCCollectionVec* jet_vec = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE ) ;
+        evt->addCollection( jet_vec,  _trueJetCollectionName);
+        return;	
+      }	
 
-      //std::cout << " return from getPyjets"<< std::endl;
-	fix94();
-      njet=0 ; i_jet=0 ; nstr=0 ;
+
+
+      njet=0 ; current_jet=0 ; nstr=0 ;
       for ( int kk=1 ; kk <= 25 ; kk++ ) {
         boson[kk]=0;  
         elementon[kk]=0;
@@ -186,39 +206,47 @@ void TrueJet::processEvent( LCEvent * event ) {
         fafp[kk]=0;
         nfsr[kk]=0 ;
       }
+      bool seen[4000];
       for ( int kk=1 ; kk <= 4000 ; kk++ ) {
         jet[kk]=0;
         companion[kk] = 0;
+	seen[kk] = false;
       }
 
-      true_lepton() ;
+        // the actual work happens in the following routines. They are each responible to 
+        // find jets stemming from different sources, as indicated by their names.
 
       cluster() ;
+    
+      true_lepton() ;
 
+      photon();
+      
       isr() ;
 
-
-       //   nstr=COUNT( ( 92 == k(1:nlund,2) .AND. jet(1:nlund) == 0 ) )
-       //   njet = 2*nstr+n_hard_lepton+2*nclu+nisr;
       nstr=0;
-      for ( int kk=1 ; kk <= nlund ; kk++ ) {
-        if ( k[kk][2] == 92 && jet[kk] == 0 && k[kk][1] < 30  ) {
+      for ( int k_py=1 ; k_py <= nlund ; k_py++ ) {
+        streamlog_out(DEBUG0) << " Checking string at " << k_py << " k[k_py][2], jet[k_py] and k[k_py][1] : " <<   
+          " " << k[k_py][2] <<  " , " << jet[k_py]  <<    " , " << k[k_py][1] <<                        std::endl;
+        if ( k[k_py][2] == 92 && jet[k_py] == 0 && k[k_py][1] < 30  ) {
+          streamlog_out(DEBUG4) << " string found at " << k_py <<std::endl;
           nstr++;
         }
       }
-      njet = 2*nstr+n_hard_lepton+2*nclu+nisr;
+
+      njet = 2*nstr+n_hard_lepton+2*nclu+nisr+nphot;
 
       if ( nstr != 0 ) {
         string();
       } 
 
       n_beam_jet=0;
-      for (int kk=1 ; kk<=nlund ; kk++) {
-        if ( k[kk][1] >= 30 ) {
+      for (int k_py=1 ; k_py<=nlund ; k_py++) {
+        if ( k[k_py][1] >= 30 ) {
           if ( n_beam_jet == 0 ) {
             n_beam_jet=1;
           }
-          jet[kk]=njet+n_beam_jet;
+          jet[k_py]=njet+n_beam_jet;
         }
       }
 
@@ -229,36 +257,45 @@ void TrueJet::processEvent( LCEvent * event ) {
       // At this point, the job is done. All the rest is printouts, putting things into collections and setting up navigators.
       // Non-debuggung code is beween ******:s and =========:s
 
-      if ( ! ((n_mixed==0) && njet==2*nstr+n_hard_lepton+2*nclu+nisr+n_beam_jet &&
-	      n_jetless==0 && n_hard_lepton%2 == 0 )) {
-        streamlog_out(ERROR) << " inconsiency in jet finding : " << std::endl;
-        streamlog_out(ERROR) << " n_mixed/ njet/ 2*nstr+n_hard_lepton+2*nclu+nisr+n_beam_jet / n_jetless / n_hard_lepton: " << std::endl;
-        streamlog_out(ERROR) << n_mixed <<" / " << njet<< " / " <<2*nstr+n_hard_lepton+2*nclu+nisr+n_beam_jet<< " / " << n_jetless << " / " << n_hard_lepton << std::endl;
-        streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-        streamlog_out(ERROR) << std::endl ; 
+      // FIXME : determine form the event header is an odd or even number of leptons are expected
+      //      if ( ! ((n_mixed==0) && njet==2*nstr+n_hard_lepton+2*nclu+nisr+n_beam_jet &&
+      //	      n_jetless==0 && n_hard_lepton%2 == 0 )) {
+
+      if ( ! ((n_mixed==0) && njet==2*nstr+n_hard_lepton+2*nclu+nisr+n_beam_jet+nphot &&
+	      n_jetless==0 )) {
+        if ( ! _higgs_to_glue_glue ) {
+          streamlog_out(ERROR) << " inconsiency in jet finding : " << std::endl;
+          streamlog_out(ERROR) << " n_mixed/ njet/ 2*nstr+n_hard_lepton+2*nclu+nisr+n_beam_jet / n_jetless / n_hard_lepton: " << std::endl;
+          streamlog_out(ERROR) << n_mixed <<" / " << njet<< " / " <<2*nstr+n_hard_lepton+2*nclu+nisr+n_beam_jet<< " / " 
+                               << n_jetless << " / " << n_hard_lepton << std::endl;
+          streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
+          streamlog_out(ERROR) << std::endl ;
+        }  
       }
  
       streamlog_out(DEBUG3) << " HEPEVT relation table up with jet assignment "  <<std::endl;
-      streamlog_out(DEBUG3) << "    line   status       pdg  parent  first  last      px         py          pz          E             M        jet companion type" << std::endl;
-      streamlog_out(DEBUG3) << "                                       daughter                                                                        jet" << std::endl;
+      streamlog_out(DEBUG3) << "    line   status       pdg  parent  first  last      px         py   "
+                              << "       pz          E             M        jet companion type" << std::endl;
+      streamlog_out(DEBUG3) << "                                       daughter                       "
+                              << "                                                 jet" << std::endl;
 
-      for ( int i=1 ; i <= nlund ; i++){
-	streamlog_out(DEBUG3) << std::setw(7) << i << std::setw(7) <<  k[i][1] << 
-                 std::setw(12) <<  k[i][2] << std::setw(7) <<  k[i][3] << 
-                 std::setw(7) <<  k[i][4] << std::setw(7) << k[i][5] <<
-                 std::setw(12) <<  p[i][1] << 
-                 std::setw(12) <<  p[i][2] << std::setw(12) <<  p[i][3] << 
-                 std::setw(12) <<  p[i][4] << std::setw(12) << p[i][5] <<
+      for ( int k_py=1 ; k_py <= nlund ; k_py++){
+	streamlog_out(DEBUG3) << std::setw(7) << k_py << std::setw(7) <<  k[k_py][1] << 
+                 std::setw(12) <<  k[k_py][2] << std::setw(7) <<  k[k_py][3] << 
+                 std::setw(7) <<  k[k_py][4] << std::setw(7) << k[k_py][5] <<
+                 std::setw(12) <<  p[k_py][1] << 
+                 std::setw(12) <<  p[k_py][2] << std::setw(12) <<  p[k_py][3] << 
+                 std::setw(12) <<  p[k_py][4] << std::setw(12) << p[k_py][5] <<
  
-                 std::setw(7) << jet[i]  <<
-                 std::setw(7) << companion[abs(jet[i])] << std::setw(7) <<  type[abs(jet[i])]<<std::endl;
+                 std::setw(7) << jet[k_py]  <<
+                 std::setw(7) << companion[abs(jet[k_py])] << std::setw(7) <<  type[abs(jet[k_py])]<<std::endl;
       }
-       streamlog_out(DEBUG3) << "       jet     fafp-beg  qrk/lept  fafp-end fafp-boson  type   dijet-beg  dijet-end    boson" << std::endl;
-      for ( int i=1 ; i <= njet ; i++){
-	streamlog_out(DEBUG3) << std::setw(10) << i << std::setw(10) <<  fafp[i] << 
-                 std::setw(10) <<  elementon[i] << std::setw(10) <<  fafp_last[i] << 
-                 std::setw(10) <<  fafp_boson[i] << std::setw(10) << type[i] << std::setw(10) << dijet_begining[i]  <<
-                 std::setw(10) << dijet_end[i] << std::setw(10) <<  boson[i]<<std::endl;
+      streamlog_out(DEBUG3) << "       jet     fafp-beg  qrk/lept  fafp-end fafp-boson  type   dijet-beg  dijet-end    boson" << std::endl;
+      for ( int k_py=1 ; k_py <= njet ; k_py++){
+	streamlog_out(DEBUG3) << std::setw(10) << k_py << std::setw(10) <<  fafp[k_py] << 
+                 std::setw(10) <<  elementon[k_py] << std::setw(10) <<  fafp_last[k_py] << 
+                 std::setw(10) <<  fafp_boson[k_py] << std::setw(10) << type[k_py] << std::setw(10) << dijet_begining[k_py]  <<
+                 std::setw(10) << dijet_end[k_py] << std::setw(10) <<  boson[k_py]<<std::endl;
       }
 
 
@@ -286,33 +323,25 @@ void TrueJet::processEvent( LCEvent * event ) {
 
       //============================
 
-      double str_tmom[3], str_mom[3], str_tmomS[3] , str_tE , str_E , str_tES; 
-      str_tE=0; str_tES=0; str_E=0;
-      for ( int i=0 ; i<3 ; i++ ) {
-         str_tmom[i]=0. ; str_tmomS[i]=0. ; str_mom[i]=0. ; 
-      } 
-
+      double str_tmom[3]={0}, str_mom[3]={0}, str_tmomS[3]={0} , str_tE=0 , str_E=0 , str_tES=0; 
 
       streamlog_out(DEBUG8) << "  Number of jets found : " << njet << std::endl;
 
-      double tmomS[25][3] ;
-      double tES[25];
-      int pid_type[25] ;
-      for ( int ijet=1; ijet<=njet ; ijet++ ) { // jet-loop
-        ReconstructedParticleImpl* true_jet = new ReconstructedParticleImpl;
-        tES[ijet]=0;
-        for ( int i=0 ; i<3 ; i++ ) {
-          tmomS[ijet][i]=0 ;
-        } 
-      
-        //*****************************
-        pid_type[ijet] = -type[ijet] ;
-        //============================
+      double tmomS[25][3]={0.} ;
+      double tES[25]={0.};
+      int pid_type[25]={0} ;
+      for ( int i_jet=1; i_jet<=njet ; i_jet++ ) { // jet-loop
 
+       //*****************************
+         ReconstructedParticleImpl* true_jet = new ReconstructedParticleImpl;
+      
+        pid_type[i_jet] = -type[i_jet] ;
+ 
         jet_vec->addElement(true_jet);
+       //============================
 	
 	streamlog_out(DEBUG1) << std::endl;
-	streamlog_out(DEBUG1) << "  Following jet " << ijet <<   " ( "<< true_jet << ")" << std::endl;
+	streamlog_out(DEBUG1) << "  Following jet " << i_jet <<   " ( "<< true_jet << ")" << std::endl;
         streamlog_out(DEBUG1) << " ============================= "  <<  std::endl;
         streamlog_out(DEBUG1) << " HEPEVT relation table with jet assignment and pfo(s), if any "  <<std::endl;
         streamlog_out(DEBUG1) << "       line    mcp          status    pdg       parent    first     last       jet     pfo(s)" << std::endl;
@@ -320,28 +349,30 @@ void TrueJet::processEvent( LCEvent * event ) {
       }
       
       ReconstructedParticleImpl* true_jet ;
-      for ( int i=1 ; i<=nlund ; i++){ // pyjets loop
-        int ijet =  abs(jet[i]);
-        if ( ijet > 0 ) {
+      for ( int k_py=1 ; k_py<=nlund ; k_py++){ // pyjets loop
+        int i_jet =  abs(jet[k_py]);
+        if ( i_jet > 0 ) {
 
-          true_jet = dynamic_cast<ReconstructedParticleImpl*>(jet_vec->getElementAt(ijet-1));
+          true_jet = dynamic_cast<ReconstructedParticleImpl*>(jet_vec->getElementAt(i_jet-1));
 
              // OK, add jet-to-true link
 
-	  streamlog_out(DEBUG1) << std::setw(10) << i << " ("  <<mcp_pyjets[i] << ")" << std::setw(10) <<  k[i][1]%30 << 
-                 std::setw(10) <<  k[i][2] << std::setw(10) << k[i][3] << 
-                 std::setw(10) <<  k[i][4] << std::setw(10) << k[i][5] << std::setw(10) << jet[i]  ;
+	  streamlog_out(DEBUG1) << std::setw(10) << k_py << " ("  <<mcp_pyjets[k_py] << ")" << std::setw(10) <<  k[k_py][1]%30 << 
+                 std::setw(10) <<  k[k_py][2] << std::setw(10) << k[k_py][3] << 
+                 std::setw(10) <<  k[k_py][4] << std::setw(10) << k[k_py][5] << std::setw(10) << jet[k_py]  ;
 
 
           //*****************************
-          if (  k[i][1] == 1 &&  k[i][2] == 22 && jet[k[i][3]] < 0   && k[k[i][3]][2] != 22 ) {
+          if (  k[k_py][1] == 1 &&  k[k_py][2] == 22 && jet[k[k_py][3]] < 0   && k[k[k_py][3]][2] != 22 ) {
                 // to be able to find FSRs, set weight to -ve for them
-            truejet_truepart_Nav.addRelation(  true_jet, mcp_pyjets[i], ( jet[i]>0 ? -(k[i][1])%30 : 0.0 )) ;
+            truejet_truepart_Nav.addRelation(  true_jet, mcp_pyjets[k_py], ( jet[k_py]>0 ? -(k[k_py][1])%30 : 0.0 )) ;
           } else {
-            truejet_truepart_Nav.addRelation(  true_jet, mcp_pyjets[i], ( jet[i]>0 ? k[i][1]%30 : 0.0 )) ;
+            truejet_truepart_Nav.addRelation(  true_jet, mcp_pyjets[k_py], ( jet[k_py]>0 ? k[k_py][1]%30 : 0.0 )) ;
           }
           LCObjectVec recovec; 
-          recovec = reltrue->getRelatedFromObjects( mcp_pyjets[i]);
+	  if ( rmclcol != NULL ) {
+            recovec = reltrue->getRelatedFromObjects( mcp_pyjets[k_py]);
+	  }  
           //============================ 
 
           // (maybe this will be needed: If the current assumption that also MCPartiles created in
@@ -349,9 +380,9 @@ void TrueJet::processEvent( LCEvent * event ) {
           //  getPyjets should only load gen. stat. /= 0 particles, and then code below
           //  would be needed to assign seen gen. stat. = 0 particles to jets based on their
           //  gen. stat. /= 0 ancestor ?!)
-          //            if ( recovec.size() == 0 &&  k[i][1] == 1 ) { // not reconstructed stable particle
-          //              if ( abs(k[i][2]) != 12 &&  abs(k[i][2]) != 14 &&  abs(k[i][2]) != 16 ) { // not neutrino
-          //                //  mcp_pyjets[i].getDaughter ... etc . If any decendant is seen, make association
+          //            if ( recovec.size() == 0 &&  k[k_py][1] == 1 ) { // not reconstructed stable particle
+          //              if ( abs(k[k_py][2]) != 12 &&  abs(k[k_py][2]) != 14 &&  abs(k[k_py][2]) != 16 ) { // not neutrino
+          //                //  mcp_pyjets[k_py].getDaughter ... etc . If any decendant is seen, make association
           //              }
           //            }
 
@@ -360,54 +391,56 @@ void TrueJet::processEvent( LCEvent * event ) {
             double E,q ;
 
              // true quanaties for this jet (all true seen)
-            tmomS[ijet][0]+=p[i][1] ;
-            tmomS[ijet][1]+=p[i][2] ;
-            tmomS[ijet][2]+=p[i][3] ;
-            tES[ijet]+=p[i][4] ;
 
+	    if ( ! seen[k[k_py][3]] ) {
+	       // add to true-of-seen only if no ancestor of this true has already been counted
+              tmomS[i_jet][0]+=p[k_py][1] ;
+              tmomS[i_jet][1]+=p[k_py][2] ;
+              tmomS[i_jet][2]+=p[k_py][3] ;
+              tES[i_jet]+=p[k_py][4] ;
+            } else {
+              streamlog_out(DEBUG3) << " Ancestor of true particle " << k_py << " already seen, not added again to true-of-seen "  << std::endl;
+            }
+	    seen[k_py] = true ;
 	    streamlog_out(DEBUG1) << " recovec size is " << recovec.size() ;
-            int last_winner = ijet ;
-            for ( unsigned ireco=0 ; ireco<recovec.size() ; ireco++ ) { //  reco-of-this-true loop
+            int last_winner = i_jet ;
+            for ( unsigned i_reco=0 ; i_reco<recovec.size() ; i_reco++ ) { //  reco-of-this-true loop
 
               // add things of this reco-particle to the current jet:
 
               //*****************************
-              ReconstructedParticle* reco_part  = dynamic_cast<ReconstructedParticle*>(recovec[ireco]);
+              ReconstructedParticle* reco_part  = dynamic_cast<ReconstructedParticle*>(recovec[i_reco]);
 
               if (truejet_pfo_Nav.getRelatedFromObjects(reco_part).size() == 0 ) { // only if not yet used
-		streamlog_out(DEBUG3) << " recopart " << ireco ;
+	        streamlog_out(DEBUG3) << " recopart " << i_reco ;
 		bool split_between_jets = false;
-	        int winner , wgt_trk[26] , wgt_clu[26] ;
-		winner=ijet;
-	        for ( int kkk=1 ; kkk <= njet ; kkk++ ) {
-		  wgt_trk[kkk] =0 ; wgt_clu[kkk] = 0 ;
-	        }	
+	        int winner=i_jet , wgt_trk[26]={0} , wgt_clu[26]={0} ;
+
          	LCObjectVec recomctrues = reltrue->getRelatedToObjects(reco_part);
                 static FloatVec recomctrueweights;
 	        recomctrueweights = reltrue->getRelatedToWeights(reco_part);
 	        streamlog_out(DEBUG3) << "     mctrues of this reco " << recomctrues.size() << std::endl ;
-         	for ( unsigned kkk=0 ; kkk<recomctrues.size() ; kkk++ ) {
-		  int jetoftrue ;
-		  MCParticle* an_mcp = dynamic_cast<MCParticle*>(recomctrues[kkk]);
-		  jetoftrue=jet[an_mcp->ext<MCPpyjet>()];
-	          if ( jetoftrue != ijet ) split_between_jets = true;
-		  wgt_trk[jetoftrue]+=int(recomctrueweights[kkk])%10000 ;
-		  wgt_clu[jetoftrue]+=int(recomctrueweights[kkk])/10000 ;
-		  streamlog_out(DEBUG1) << " weights : " << int(recomctrueweights[kkk]) << " " << int(recomctrueweights[kkk])%10000 
-					    << " " << int(recomctrueweights[kkk])/10000 << std::endl ;
+         	for ( unsigned k_mcp_of_reco=0 ; k_mcp_of_reco<recomctrues.size() ; k_mcp_of_reco++ ) {
+		  MCParticle* an_mcp = dynamic_cast<MCParticle*>(recomctrues[k_mcp_of_reco]);
+		  int jetoftrue=jet[an_mcp->ext<MCPpyjet>()];
+	          if ( jetoftrue != i_jet ) split_between_jets = true;
+		  wgt_trk[jetoftrue]+=int(recomctrueweights[k_mcp_of_reco])%10000 ;
+		  wgt_clu[jetoftrue]+=int(recomctrueweights[k_mcp_of_reco])/10000 ;
+		  streamlog_out(DEBUG1) << " weights for jet " << jetoftrue << " : " << int(recomctrueweights[k_mcp_of_reco]) 
+                                          << " " << int(recomctrueweights[k_mcp_of_reco])%10000 
+					  << " " << int(recomctrueweights[k_mcp_of_reco])/10000 << std::endl ;
                 }
                 if ( split_between_jets ) {
-		  double wgt_trk_max, wgt_clu_max ;
-	          int imax_trk, imax_clu;
+		  double wgt_trk_max=0, wgt_clu_max=0 ;
+	          int imax_trk=0, imax_clu=0;
 
-         	  wgt_trk_max=0. ; wgt_clu_max=0. ; imax_trk = 0 ; imax_clu = 0;
-		  for ( int kkk=1 ; kkk <= njet ; kkk++ ) {
-		    streamlog_out(DEBUG3) << "     jetweights for " << kkk << " " << wgt_trk[kkk]  << " " <<  wgt_clu[kkk] ;
-		    if ( wgt_trk[kkk] > wgt_trk_max ) {
-	              imax_trk= kkk ; wgt_trk_max = wgt_trk[kkk] ;
+		  for ( int j_jet=1 ; j_jet <= njet ; j_jet++ ) {
+		    streamlog_out(DEBUG3) << "     jetweights for " << j_jet << " " << wgt_trk[j_jet]  << " " <<  wgt_clu[j_jet] ;
+		    if ( wgt_trk[j_jet] > wgt_trk_max ) {
+	              imax_trk= j_jet ; wgt_trk_max = wgt_trk[j_jet] ;
          	    }  
-		    if ( wgt_clu[kkk] > wgt_clu_max ) {
-		      imax_clu= kkk ; wgt_clu_max = wgt_clu[kkk] ;
+		    if ( wgt_clu[j_jet] > wgt_clu_max ) {
+		      imax_clu= j_jet ; wgt_clu_max = wgt_clu[j_jet] ;
 		    }  
 		  }
 		  streamlog_out(DEBUG3) << "    " << imax_clu << " " << imax_trk << " " <<  wgt_clu_max <<  " " <<  wgt_trk_max ;
@@ -417,8 +450,8 @@ void TrueJet::processEvent( LCEvent * event ) {
 		    winner = imax_clu;
 		  } else {
 		    streamlog_out(DEBUG3) << " was ? " << imax_clu << " " << imax_trk << " " <<  wgt_clu_max <<  " " <<  wgt_trk_max << std::endl;
-		    for ( int kkk=1 ; kkk <= njet ; kkk++ ) {
-		      streamlog_out(DEBUG3) << " was    jetweights for " << kkk << " " << wgt_trk[kkk]  << " " <<  wgt_clu[kkk]  << std::endl;
+		    for ( int j_jet=1 ; j_jet <= njet ; j_jet++ ) {
+		      streamlog_out(DEBUG3) << " was    jetweights for " << j_jet << " " << wgt_trk[j_jet]  << " " <<  wgt_clu[j_jet]  << std::endl;
                     }
                     // probably the cluster is somewhat more reliable in this case. Anyways, this happens very rarely (for 3 PFOs in 6400 4f_had...)
                     if ( imax_clu > 0 ) {
@@ -432,7 +465,7 @@ void TrueJet::processEvent( LCEvent * event ) {
 
                 if ( winner > 0 && winner != last_winner ) true_jet = dynamic_cast<ReconstructedParticleImpl*>(jet_vec->getElementAt(winner-1));
 
-		streamlog_out(DEBUG3) << " and the winner is " << winner << "  ( ijet is " << ijet << " ) " ;	  
+		streamlog_out(DEBUG3) << " and the winner is " << winner << "  ( i_jet is " << i_jet << " ) " ;	  
                 if ( winner > 0 ) {
                   last_winner = winner ;
 
@@ -461,72 +494,95 @@ void TrueJet::processEvent( LCEvent * event ) {
                     //============================ 
 	      
                 } else {
-                  streamlog_out(WARNING) << " reco particle " << ireco << " of pythia-particle " << i << " has weights = 0 to ALL MCPs ??? " << std::endl;
-                  streamlog_out(WARNING) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
+                  // FIXME: a follow on error for h->glueglue: If a particle from a non-higgs jet gets reconstructed into a PFO where
+                  //   the majority contribution is from a higgs jet (which are not found in  h->glueglue, and hence has jet# 0 ).
+ 		  if ( ! _higgs_to_glue_glue ) {
+		    streamlog_out(WARNING) << " reco particle " << i_reco << " of pythia-particle " << k_py 
+                                             << " has weights = 0 to ALL MCPs ??? " << std::endl;
+                    streamlog_out(WARNING) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
+		  }
                 }
               } // end if not yet used
-              else{
+              else {
 		streamlog_out(DEBUG1) << " " << reco_part << " seen more than once ! " << std::endl;
               }
             } // end reco-of-this-true loop
 
-	  } // end if reconstructed
+	  } else { // end if reconstructed
+	    if ( seen[k[k_py][3]] ) { 
+              seen[k_py] = true ;  // this makes sure that in any decay-chain, only the first seen particle will includes in true-of-seen
+              streamlog_out(DEBUG2) << " Ancestor of true particle " << k_py << " was seen, so particle " << k_py 
+                                    << " is marked as seen (even if it wasn't seen itself " << std::endl;
+            }
+          }
   	  streamlog_out(DEBUG1) << std::endl;
 
-        } // end if ijet > 0
+        } // end if i_jet > 0
 
       } // end pyjets loop
-      for ( int ijet=1; ijet<=njet ; ijet++ ) { // jet-loop
 
-        true_jet = dynamic_cast<ReconstructedParticleImpl*>(jet_vec->getElementAt(ijet-1));
+      for ( int i_jet=1; i_jet<=njet ; i_jet++ ) { // jet-loop
+
+        true_jet = dynamic_cast<ReconstructedParticleImpl*>(jet_vec->getElementAt(i_jet-1));
         ParticleIDImpl* pid = new ParticleIDImpl; 
-        pid->setPDG(k[elementon[ijet]][2]);
-        pid->setType(pid_type[ijet]);
+        pid->setPDG(k[elementon[i_jet]][2]);
+        pid->setType(pid_type[i_jet]);
         true_jet->addParticleID(pid);
-        true_jet->ext<TJindex>()=ijet; 
+        true_jet->ext<TJindex>()=i_jet; 
+
       }
 
-      for ( int ijet=1; ijet<=njet ; ijet++ ) { // jet-loop
+      for ( int i_jet=1; i_jet<=njet ; i_jet++ ) { // jet-loop
 
-        true_jet = dynamic_cast<ReconstructedParticleImpl*>(jet_vec->getElementAt(ijet-1));
-
-
+        true_jet = dynamic_cast<ReconstructedParticleImpl*>(jet_vec->getElementAt(i_jet-1));
 
         const double* mom = true_jet->getMomentum(); 
 
 	streamlog_out(DEBUG5) << std::endl;
-	streamlog_out(DEBUG9) << " summary " << ijet << " " << type[ijet]%100 << " " << true_jet->getEnergy() << " " <<  tE[ijet]  << " " <<  tES[ijet] << std::endl ;
-	streamlog_out(DEBUG5) << "  jet       " <<std::setw(4)<< ijet << " (seen)         p : " << mom[0] << " " << mom[1] << " "  << mom[2] 
-                    << " " << " E " << true_jet->getEnergy()<< std::endl;
-	streamlog_out(DEBUG5) << "               "   <<      "  (true)         p : " << tmom[ijet][0] << " " << tmom[ijet][1] << " "  << tmom[ijet][2] 
-                    << " " << " E " << tE[ijet] << std::endl;
-	streamlog_out(DEBUG5) << "               "   <<      "  (true of seen) p : " << tmomS[ijet][0] << " " << tmomS[ijet][1] << " "  << tmomS[ijet][2] 
-                    << " " << " E " << tES[ijet] << std::endl;
-	streamlog_out(DEBUG5) << "  ancestor 1" << std::setw(4)<<elementon[ijet]  << "                p : " << p[elementon[ijet]][1] << " " <<  p[elementon[ijet]][2] << " "  <<  p[elementon[ijet]][3] 
-	            << " " << " E " << p[elementon[ijet]][4]<< std::endl;
-	streamlog_out(DEBUG5) << "  ancestor 2" << std::setw(4)<<fafp_last[ijet] << "                p : " << p[fafp_last[ijet]][1] << " " <<  p[fafp_last[ijet]][2] << " "  <<  p[fafp_last[ijet]][3] 
-                    << " " << " E " << p[fafp_last[ijet]][4]<< std::endl;
-	streamlog_out(DEBUG5) << "  ancestor 3" << std::setw(4)<<fafp[ijet] << "                p : " << p[fafp[ijet]][1] << " " <<  p[fafp[ijet]][2] << " "  <<  p[fafp[ijet]][3] 
-                    << " " << " E " << p[fafp[ijet]][4]<< std::endl;
+	streamlog_out(DEBUG9) << " summary " << i_jet << " " << type[i_jet]%100 << " " << true_jet->getEnergy() << " " 
+                                <<  tE[i_jet]  << " " <<  tES[i_jet] << std::endl ;
+	streamlog_out(DEBUG5) << "  jet       " <<std::setw(4)<< i_jet << " (seen)         p : " 
+                                << mom[0] << " " << mom[1] << " "  << mom[2] 
+                                << " " << " E " << true_jet->getEnergy()<< std::endl;
+	streamlog_out(DEBUG5) << "               "   <<      "  (true)         p : " 
+                                << tmom[i_jet][0] << " " << tmom[i_jet][1] << " "  << tmom[i_jet][2] 
+                                << " " << " E " << tE[i_jet] << std::endl;
+	streamlog_out(DEBUG5) << "               "   <<      "  (true of seen) p : " 
+                                << tmomS[i_jet][0] << " " << tmomS[i_jet][1] << " "  << tmomS[i_jet][2] 
+                                << " " << " E " << tES[i_jet] << std::endl;
+	streamlog_out(DEBUG5) << "  ancestor 1" << std::setw(4)<<elementon[i_jet]  << "                p : " 
+                                << p[elementon[i_jet]][1] << " " <<  p[elementon[i_jet]][2] << " "  <<  p[elementon[i_jet]][3] 
+	                        << " " << " E " << p[elementon[i_jet]][4]<< std::endl;
+	streamlog_out(DEBUG5) << "  ancestor 2" << std::setw(4)<<fafp_last[i_jet] << "                p : " 
+                                << p[fafp_last[i_jet]][1] << " " <<  p[fafp_last[i_jet]][2] << " "  <<  p[fafp_last[i_jet]][3] 
+                                << " " << " E " << p[fafp_last[i_jet]][4]<< std::endl;
+	streamlog_out(DEBUG5) << "  ancestor 3" << std::setw(4)<<fafp[i_jet] << "                p : " 
+                                << p[fafp[i_jet]][1] << " " <<  p[fafp[i_jet]][2] << " "  <<  p[fafp[i_jet]][3] 
+                                << " " << " E " << p[fafp[i_jet]][4]<< std::endl;
 	streamlog_out(DEBUG5) << std::endl;
 
-        streamlog_out(DEBUG5) << "   Character of jet " << ijet << " : "<<type[ijet]%100 <<" (1=string, 2=lepton , 3=cluster, 4=isr, 5=overlay)."  << std::endl;
-        streamlog_out(DEBUG5) << "   Jet from boson ? " << (type[ijet]>=100 ? type[ijet]/100 : 0) << " (0 not from boson, !=0 from boson radiated of that jet)."  << std::endl;
-        streamlog_out(DEBUG5) << "   No. of FSRs : " << nfsr[ijet] << std::endl;
-        streamlog_out(DEBUG5) << "   Jet has no energy ? " << (tE[ijet]<0.001) << std::endl;
+        streamlog_out(DEBUG5) << "   Character of jet " << i_jet << " : "<<type[i_jet]%100 <<" (1=string, 2=lepton , "
+                                <<"3=cluster, 4=isr, 5=overlay, 6=M.E. photon)."  << std::endl;
+        streamlog_out(DEBUG5) << "   Jet from boson ? " << (type[i_jet]>=100 ? type[i_jet]/100 : 0) 
+                                << " (0 not from boson, !=0 from boson radiated of that jet)."  << std::endl;
+        streamlog_out(DEBUG5) << "   No. of FSRs : " << nfsr[i_jet] << std::endl;
+        streamlog_out(DEBUG5) << "   Jet has no energy ? " << (tE[i_jet]<0.001) << std::endl;
 
 	streamlog_out(DEBUG5) << std::endl;
 
-        str_E+= true_jet->getEnergy(); str_tE+= tE[ijet]; str_tES+= tES[ijet];
+        str_E+= true_jet->getEnergy(); str_tE+= tE[i_jet]; str_tES+= tES[i_jet];
         for ( int i=0 ; i<3 ; i++ ) {
           str_mom[i]+=mom[i];
-          str_tmom[i]+=tmom[ijet][i];
-          str_tmomS[i]+=tmomS[ijet][i]; 
+          str_tmom[i]+=tmom[i_jet][i];
+          str_tmomS[i]+=tmomS[i_jet][i]; 
         }
-        if ( ijet%2 == 0 ) {
-          streamlog_out(DEBUG6) << "      Mass of jet " << ijet-1 << " and " << ijet << std::endl;
-          double masssq ;
-          masssq = str_E*str_E - str_mom[0]*str_mom[0] - str_mom[1]*str_mom[1] - str_mom[2]*str_mom[2] ;
+
+        int odd_even = 0 ;
+        if ( type[i_jet]%100 == 3 && n_hard_lepton%2 == 1 ) odd_even = 1;
+
+        if ( i_jet%2 == odd_even && type[i_jet]%100 <= 3 ) {
+          streamlog_out(DEBUG6) << "      Mass of jet " << i_jet-1 << " and " << i_jet << std::endl;
+          double masssq = str_E*str_E - str_mom[0]*str_mom[0] - str_mom[1]*str_mom[1] - str_mom[2]*str_mom[2] ;
           if (  masssq > 0. ) {
              streamlog_out(DEBUG6) << "         Seen         " << sqrt(masssq)  << std::endl;
           }
@@ -538,25 +594,30 @@ void TrueJet::processEvent( LCEvent * event ) {
           if (  masssq > 0. ) {
              streamlog_out(DEBUG6) << "         true of seen " << sqrt(masssq)  << std::endl;
           }
-          if ( type[ijet]%100 == 3  ) {
+          if ( type[i_jet]%100 == 3  ) {
              // cluster - the 91 object does NOT have the mass of the following physical states,
              // so we sum up the descendants - in the vast majority there is only one
             double clu_mass=0 , clu_E= 0., clu_P[4]= {0,0,0};
-            for ( int jj=k[k[elementon[ijet]][4]][4] ; jj<=k[k[elementon[ijet]][4]][5] ; jj++ ) {
-              clu_E += p[jj][4] ;    clu_P[1] += p[jj][1] ;  clu_P[2] += p[jj][2] ;  clu_P[3] += p[jj][3] ;  
+            for ( int j_py=k[k[elementon[i_jet]][4]][4] ; j_py<=k[k[elementon[i_jet]][4]][5] ; j_py++ ) {
+              if ( k[j_py][3] == k[elementon[i_jet]][4] )  {
+                clu_E += p[j_py][4] ;    clu_P[1] += p[j_py][1] ;  clu_P[2] += p[j_py][2] ;  clu_P[3] += p[j_py][3] ;  
+              }
             }
             clu_mass=sqrt(clu_E*clu_E-clu_P[1]*clu_P[1]-clu_P[2]*clu_P[2]-clu_P[3]*clu_P[3] );
             streamlog_out(DEBUG6) << "      string mass :   " <<    clu_mass << std::endl;
-	  } else if ( type[ijet]%100 == 2 ) {
+	  } else if ( type[i_jet]%100 == 2 ) {
             double dilept_mass=0 , dilept_E= 0., dilept_P[4]= {0,0,0};
-            for ( int jj=ijet-1 ; jj<=ijet ; jj++ ) {
-              dilept_E += p[elementon[jj]][4] ;    dilept_P[1] += p[elementon[jj]][1] ;   dilept_P[2] += p[elementon[jj]][2] ;   dilept_P[3] += p[elementon[jj]][3] ;  
+            for ( int j_jet=i_jet-1 ; j_jet<=i_jet ; j_jet++ ) {
+              dilept_E += p[elementon[j_jet]][4] ;    
+              dilept_P[1] += p[elementon[j_jet]][1] ;   
+              dilept_P[2] += p[elementon[j_jet]][2] ;   
+              dilept_P[3] += p[elementon[j_jet]][3] ;  
             }
             dilept_mass=sqrt(dilept_E*dilept_E-dilept_P[1]*dilept_P[1]-dilept_P[2]*dilept_P[2]-dilept_P[3]*dilept_P[3] );
             streamlog_out(DEBUG6) << "      string mass :   " <<    dilept_mass << std::endl;
           } else {  
              // string, just take the number from the 92-object
-            streamlog_out(DEBUG6) << "      string mass :   " <<    p[k[elementon[ijet]][4]][5]  << std::endl;
+            streamlog_out(DEBUG6) << "      string mass :   " <<    p[k[elementon[i_jet]][4]][5]  << std::endl;
           }
     
 	  streamlog_out(DEBUG6) << std::endl;
@@ -565,55 +626,63 @@ void TrueJet::processEvent( LCEvent * event ) {
             str_tmom[i]=0. ; str_tmomS[i]=0. ; str_mom[i]=0. ; 
           } 
           if (  masssq_t > 0. ) {
-            if ( abs( sqrt(masssq_t)- p[k[elementon[ijet]][4]][5] )/  p[k[elementon[ijet]][4]][5]  > 0.001 ) {
-              if ( type[ijet]%100 == 1 && type[ijet-1]%100 == 1 &&  nfsr[ijet]+nfsr[ijet-1]==0) {
-                if (  abs( tE[ijet]+tE[ijet-1]- p[k[elementon[ijet]][4]][4] )/  p[k[elementon[ijet]][4]][4] > 0.001  ) {
-	  	  streamlog_out(ERROR) << " bad match M (sum/initial) " << " " <<  sqrt(masssq_t) << " / " << p[k[elementon[ijet]][4]][5] << std::endl;
-		  streamlog_out(ERROR) << "           E (sum/initial) " << " " <<  tE[ijet]+tE[ijet-1] << " / " << p[k[elementon[ijet]][4]][4] << std::endl;
+            if ( abs( sqrt(masssq_t)- p[k[elementon[i_jet]][4]][5] )/  p[k[elementon[i_jet]][4]][5]  > 0.007 ) {
+              if ( type[i_jet]%100 == 1 && type[i_jet-1]%100 == 1 &&  nfsr[i_jet]+nfsr[i_jet-1]==0) {
+                if (  abs( tE[i_jet]+tE[i_jet-1]- p[k[elementon[i_jet]][4]][4] )/  p[k[elementon[i_jet]][4]][4] > 0.001  ) {
+	  	  streamlog_out(ERROR) << " bad match M (sum/initial) " << " " <<  sqrt(masssq_t) 
+                                         << " / " << p[k[elementon[i_jet]][4]][5] << std::endl;
+		  streamlog_out(ERROR) << "           E (sum/initial) " << " " <<  tE[i_jet]+tE[i_jet-1] 
+                                         << " / " << p[k[elementon[i_jet]][4]][4] << std::endl;
 
                   streamlog_out(DEBUG9) << "list HEPEVT relation table up with jet assignment "  <<std::endl;
-                  streamlog_out(DEBUG9) << "list    line   status       pdg  parent  first  last      px         py          pz          E             M        jet companion type" << std::endl;
-                  streamlog_out(DEBUG9) << "list                                       daughter                                                                        jet" << std::endl;
-                  for ( int i=1 ; i <= nlund ; i++){
-	            streamlog_out(DEBUG9) <<"list "<< std::setw(7) << i << std::setw(7) <<  k[i][1] << 
-                      std::setw(12) <<  k[i][2] << std::setw(7) <<  k[i][3] << 
-                      std::setw(7) <<  k[i][4] << std::setw(7) << k[i][5] <<
-                      std::setw(12) <<  p[i][1] << 
-                      std::setw(12) <<  p[i][2] << std::setw(12) <<  p[i][3] << 
-                      std::setw(12) <<  p[i][4] << std::setw(12) << p[i][5] <<
+                  streamlog_out(DEBUG9) << "list    line   status       pdg  parent  first  last      px         py          pz  "
+                                          <<"        E             M        jet companion type" << std::endl;
+                  streamlog_out(DEBUG9) << "list                                       daughter                           "
+                                          <<"                                             jet" << std::endl;
+                  for ( int i_py=1 ; i_py <= nlund ; i_py++){
+	            streamlog_out(DEBUG9) <<"list "<< std::setw(7) << i_py << std::setw(7) <<  k[i_py][1] << 
+                      std::setw(12) <<  k[i_py][2] << std::setw(7) <<  k[i_py][3] << 
+                      std::setw(7)  <<  k[i_py][4] << std::setw(7) << k[i_py][5] <<
+                      std::setw(12) <<  p[i_py][1] << 
+                      std::setw(12) <<  p[i_py][2] << std::setw(12) <<  p[i_py][3] << 
+                      std::setw(12) <<  p[i_py][4] << std::setw(12) << p[i_py][5] <<
  
-                      std::setw(7) << jet[i]  <<
-                      std::setw(7) << companion[abs(jet[i])] << std::setw(7) <<  type[abs(jet[i])]<<std::endl;
+                      std::setw(7) << jet[i_py]  <<
+                      std::setw(7) << companion[abs(jet[i_py])] << std::setw(7) <<  type[abs(jet[i_py])]<<std::endl;
                   }
-                  streamlog_out(ERROR) << "       jet     fafp-beg  qrk/lept  fafp-end fafp-boson  type   dijet-beg  dijet-end    boson" << std::endl;
-                  for ( int i=ijet-1 ; i <= ijet ; i++){
-	            streamlog_out(WARNING) << std::setw(10) << i << std::setw(10) <<  fafp[i] << 
-                    std::setw(10) <<  elementon[i] << std::setw(10) <<  fafp_last[i] << 
-                    std::setw(10) <<  fafp_boson[4] << std::setw(10) << type[i] << std::setw(10) << dijet_begining[i]  <<
-	            std::setw(10) << dijet_end[i] << std::setw(10) <<  boson[i]<<std::endl;
+                  streamlog_out(DEBUG9) << "list of individual particles with bad parent/kid energy "  <<std::endl;
+                  for ( int i_py=1 ; i_py<=nlund ; i_py++ ) {
+                    if ( jet[i_py] == i_jet || jet[i_py] == i_jet -1 ) {
+                      if ( k[i_py][1] == 11 ) { 
+                        double e_kid=0;
+                        for ( int jj= k[i_py][4] ; jj <=  k[i_py][5] ; jj++ ) {
+                          e_kid+=p[jj][4];
+                        }
+                        if ( (abs(e_kid - p[i_py][4])/ p[i_py][4] ) > 0.001 ) {
+                           streamlog_out(DEBUG9) << i_py << " " <<  k[i_py][4]  << " " << k[i_py][5] << " "  
+                                                   << e_kid << " " << p[i_py][4] << std::endl ;
+                        }
+                      }
+                    }
+                  }
+                  streamlog_out(WARNING) << "       jet     fafp-beg  qrk/lept  fafp-end fafp-boson  "
+                                            <<"type   dijet-beg  dijet-end    boson" << std::endl;
+                  for ( int j_jet=i_jet-1 ; j_jet <= i_jet ; j_jet++){
+	            streamlog_out(WARNING) << std::setw(10) << i_jet << std::setw(10) <<  fafp[j_jet] << 
+                    std::setw(10) <<  elementon[j_jet] << std::setw(10) <<  fafp_last[j_jet] << 
+                    std::setw(10) <<  fafp_boson[4] << std::setw(10) << type[j_jet] << std::setw(10) << dijet_begining[j_jet]  <<
+	            std::setw(10) << dijet_end[j_jet] << std::setw(10) <<  boson[j_jet]<<std::endl;
                   }
                   streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
                   streamlog_out(ERROR) << std::endl ; 
                 } else {
-
-		  streamlog_out(WARNING) << " bad match M (sum/initial) " << " " <<  sqrt(masssq_t) << " / " << p[k[elementon[ijet]][4]][5] << std::endl;
-		  streamlog_out(WARNING) << "           E (sum/initial) " << " " <<  tE[ijet]+tE[ijet-1] << " / " << p[k[elementon[ijet]][4]][4] << std::endl;
-                  streamlog_out(WARNING) << " (As the energy matches well, this is probably due to the B-field) "  <<std::endl;
-                  streamlog_out(WARNING) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                  streamlog_out(WARNING) << std::endl;
-                }
-                for ( int kk=1 ; kk<=nlund ; kk++ ) {
-                  if ( jet[kk] == ijet || jet[kk] == ijet -1 ) {
-                    if ( k[kk][1] == 11 ) { 
-                      double e_kid=0;
-                      for ( int jj= k[kk][4] ; jj <=  k[kk][5] ; jj++ ) {
-                        e_kid+=p[jj][4];
-                      }
-                      if ( (abs(e_kid - p[kk][4])/ p[kk][4] ) > 0.001 ) {
-                         streamlog_out(WARNING) << kk << " " <<  k[kk][4]  << " " << k[kk][5] << " "  << e_kid << " " << p[kk][4] << std::endl ;
-                      }
-                    }
-                  }
+		  streamlog_out(DEBUG8) << " bad match M (sum/initial) " << " " <<  sqrt(masssq_t) 
+                                          << " / " << p[k[elementon[i_jet]][4]][5] << std::endl;
+		  streamlog_out(DEBUG8) << "           E (sum/initial) " << " " <<  tE[i_jet]+tE[i_jet-1] 
+                                          << " / " << p[k[elementon[i_jet]][4]][4] << std::endl;
+                  streamlog_out(DEBUG8) << " (As the energy matches well, this is probably due to the B-field) "  <<std::endl;
+                  streamlog_out(DEBUG8) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
+                  streamlog_out(DEBUG8) << std::endl;
                 }
               }
             }
@@ -633,46 +702,63 @@ void TrueJet::processEvent( LCEvent * event ) {
       LCRelationNavigator FinalColourNeutral_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::RECONSTRUCTEDPARTICLE ) ;
       LCRelationNavigator FinalElementon_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::MCPARTICLE ) ;
 
-      for ( int kk=1; kk<=n_dje ; kk++ ) {
+      for ( int k_dj_end=1; k_dj_end<=n_dje ; k_dj_end++ ) {
         double E=0, M=0 , mom[3]={} ;  int  pdg[26]={};
-        if ( type[jets_end[1][kk]]%100 == 5 ) {
+        if ( type[jets_end[1][k_dj_end]]%100 == 5 ) {
           // beam-jet: No ancestor - just use sum of true-stable
-          E=tE[jets_end[1][kk]];
+          E=tE[jets_end[1][k_dj_end]];
           double psqrs=0;
           for (int jj=0 ; jj<3 ; jj++ ) {
-            mom[jj] = tmom[jets_end[1][kk]][jj];
+            mom[jj] = tmom[jets_end[1][k_dj_end]][jj];
             psqrs += mom[jj]*mom[jj];
           }
           M = sqrt(E*E-psqrs);
 
 	} else {
+
              // all other cases: sum of (unique) direct decendants of the
              // di-jet generator. For strings, clusters and ISR, there is only one
              // (a 92, a 91 or a 22,  respectively), so in these cases the sum is
              // actualy just copying the descendant. For leptons, however, there  are
              // two (the next generation leptons), so the sum is non-trivial.
              // (actually, sometimes also for clustes 0 see below)
+
           int first=nlund , last=0;
-          for ( int jj=1 ; jj<=jets_end[0][kk] ; jj++ ) {
+          for ( int j_jet_end=1 ; j_jet_end<=jets_end[0][k_dj_end] ; j_jet_end++ ) {
+
               // decide which line should be used - this (leptons) - child (strings,gammas) - grandchild (cluster)
               // NB. In the case of leptons, it might be that the first and last leptons are not next to
               // eachother.
-            int this_first, this_last;
-            if (  type[jets_end[1][kk]]%100 == 2 ) {
-                // lepton: need to go one step less as the di-jet generator might
-                // be stable, and hence have no descendants.
-               this_first=elementon[jets_end[jj][kk]];
-               this_last=elementon[jets_end[jj][kk]] ;
-            } else if (  type[jets_end[1][kk]]%100 == 3 ) { 
-             // cluster: need to go one step further (the 91 object doesn't always 
-             // have the mass of the particle it goes to). Sometimes first and
-             // last will actually become different - the cluster goes to more than one
-             // hadron.
-               this_first = k[k[elementon[jets_end[jj][kk]]][4]][4];
-               this_last =  k[k[elementon[jets_end[jj][kk]]][5]][5];
+
+            int this_first=0, this_last=nlund;
+            if (  type[jets_end[1][k_dj_end]]%100 == 2  || type[jets_end[1][k_dj_end]]%100 == 4 || type[jets_end[1][k_dj_end]]%100 == 6 ) {
+
+                 // lepton : need to go one step less as the di-jet generator might
+                 // be stable, and hence have no descendants.
+
+              this_first=elementon[jets_end[j_jet_end][k_dj_end]];
+              this_last=elementon[jets_end[j_jet_end][k_dj_end]] ;
+
+            } else if (  type[jets_end[1][k_dj_end]]%100 == 3 ) { 
+
+                 // cluster: need to go one step further (the 91 object doesn't always 
+                 // have the mass of the particle it goes to). Sometimes first and
+                 // last will actually become different - the cluster goes to more than one
+                 // hadron.
+
+              this_first = k[k[elementon[jets_end[j_jet_end][k_dj_end]]][4]][4];
+              this_last =  k[k[elementon[jets_end[j_jet_end][k_dj_end]]][5]][5];
+
             } else {
-               this_first = k[elementon[jets_end[jj][kk]]][4] ;
-               this_last =  k[elementon[jets_end[jj][kk]]][5];
+
+              if (k[elementon[jets_end[j_jet_end][k_dj_end]]][4] != 0 ) { 
+                this_first = k[elementon[jets_end[j_jet_end][k_dj_end]]][4] ;
+                this_last =  k[elementon[jets_end[j_jet_end][k_dj_end]]][5];
+              } else {
+                this_first = elementon[jets_end[j_jet_end][k_dj_end]] ;
+                this_last =  elementon[jets_end[j_jet_end][k_dj_end]];
+              }
+
             }
 
             if ( this_first < first ) {
@@ -681,15 +767,15 @@ void TrueJet::processEvent( LCEvent * event ) {
             if (  this_last > last ) {
               last= this_last;
             }
-            pdg[jj]=k[elementon[jets_end[jj][kk]]][2];
+
+            pdg[j_jet_end]=k[elementon[jets_end[j_jet_end][k_dj_end]]][2];
             if ( pdg[0] == 0 ) {
-              if ( k[elementon[jets_end[jj][kk]]][4] != 0 ) {
-                pdg[0]=k[k[elementon[jets_end[jj][kk]]][4]][2];
+              if ( k[elementon[jets_end[j_jet_end][k_dj_end]]][4] != 0 ) {
+                pdg[0]=k[k[elementon[jets_end[j_jet_end][k_dj_end]]][4]][2];
               } else {
-                pdg[0]=k[elementon[jets_end[jj][kk]]][2];
+                pdg[0]=k[elementon[jets_end[j_jet_end][k_dj_end]]][2];
               }
             }
-              
           }
           if ( last == first ) {
             E=  p[first][4];
@@ -698,14 +784,17 @@ void TrueJet::processEvent( LCEvent * event ) {
             }
           } else {
             // need double loop for non-consecutive case ( if this could only be F95 !)
-            for ( int ii=1 ; ii<=jets_end[0][kk] ; ii++ ) {
-              for ( int jj=first ; jj<=last ; jj++ ) {
-                if ( abs(jet[jj]) == jets_end[ii][kk] ) {
-                  E+=  p[jj][4];
+            for ( int j_jet_end=1 ; j_jet_end<=jets_end[0][k_dj_end] ; j_jet_end++ ) {
+              for ( int k_py=first ; k_py<=last ; k_py++ ) {
+ 
+                if ( abs(jet[k_py]) == jets_end[j_jet_end][k_dj_end] ) {
+                  E+=  p[k_py][4];
                   for ( int ll=1 ; ll<=3 ; ll++ ) {
-                    mom[ll-1] +=    p[jj][ll];
+                    mom[ll-1] +=    p[k_py][ll];
                   }
+                  if ( type[jets_end[j_jet_end][k_dj_end]]%100 != 3 ) {break;}
                 }
+
               }
             }
           }
@@ -721,26 +810,28 @@ void TrueJet::processEvent( LCEvent * event ) {
         fafpf->setEnergy(E);
         fafpf->setMass(M);
         fafpf->setMomentum(mom);
-        for(int jj=1 ; jj<=jets_end[0][kk] ; jj++) {
-          fafpf->addParticle(dynamic_cast<ReconstructedParticle*>(jet_vec->getElementAt(jets_end[jj][kk]-1)) );
+        for(int j_jet_end=1 ; j_jet_end<=jets_end[0][k_dj_end] ; j_jet_end++) {
+          fafpf->addParticle(dynamic_cast<ReconstructedParticle*>(jet_vec->getElementAt(jets_end[j_jet_end][k_dj_end]-1)) );
         }
         ParticleIDImpl* pid[26];
         pid[0] = new ParticleIDImpl; 
         pid[0]->setPDG(pdg[0]);
-        pid[0]->setType(type[jets_end[1][kk]]%100);  // maybe flag from boson? could be 0,1, or 2 jets in the fafp that's from boson ..
+        pid[0]->setType(type[jets_end[1][k_dj_end]]%100);  // maybe flag from boson? could be 0,1, or 2 jets in the fafp that's from boson ..
         fafpf->addParticleID(pid[0]);
-        for ( int jj=1 ; jj<=jets_end[0][kk] ; jj++ ) {
-          pid[jj]= new ParticleIDImpl; 
-          pid[jj]->setPDG(pdg[jj]);
-          pid[jj]->setType(type[jets_end[jj][kk]]);
-          fafpf->addParticleID(pid[jj]);
-          if ( elementon[jets_end[jj][kk]] > 0 ) {
-            FinalElementon_Nav.addRelation(  jet_vec->getElementAt(jets_end[jj][kk]-1) , mcp_pyjets[elementon[jets_end[jj][kk]]], 1.0 );
+        for ( int j_jet_end=1 ; j_jet_end<=jets_end[0][k_dj_end] ; j_jet_end++ ) {
+          pid[j_jet_end]= new ParticleIDImpl; 
+          pid[j_jet_end]->setPDG(pdg[j_jet_end]);
+          pid[j_jet_end]->setType(type[jets_end[j_jet_end][k_dj_end]]);
+          fafpf->addParticleID(pid[j_jet_end]);
+          if ( elementon[jets_end[j_jet_end][k_dj_end]] > 0 ) {
+            FinalElementon_Nav.addRelation(  jet_vec->getElementAt(jets_end[j_jet_end][k_dj_end]-1) , 
+                        mcp_pyjets[elementon[jets_end[j_jet_end][k_dj_end]]], 1.0 );
           }
-          FinalColourNeutral_Nav.addRelation(  jet_vec->getElementAt(jets_end[jj][kk]-1) , fafpf);
+          FinalColourNeutral_Nav.addRelation(  jet_vec->getElementAt(jets_end[j_jet_end][k_dj_end]-1) , fafpf);
         }
         fafpf_vec->addElement(fafpf);
-      }
+
+      } // di-jet(end) loop
    
            
         // pre-PS part
@@ -750,11 +841,12 @@ void TrueJet::processEvent( LCEvent * event ) {
       LCRelationNavigator InitialElementon_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::MCPARTICLE ) ;
       LCRelationNavigator InitialColourNeutral_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::RECONSTRUCTEDPARTICLE ) ;
 
-      for (int kk=1 ; kk<=n_djb ; kk++ ) {
-        double E=0, M=0 , mom[3]={} ; 
-        int pdg[26]= {};
-        //JL assume Z as default, check for W, H later
+      for (int k_dj_begin=1 ; k_dj_begin<=n_djb ; k_dj_begin++ ) {
+        double E=0, M=0 , mom[3]={0} ; 
+        int pdg[26]= {0};
+
         int bosonid=23 ;
+
              // E and P is sum of (unique) direct decendants of the
              // initial ffbar. Normally, there is only one
              // (a 94), so the sum is actualy just copying the descendant. 
@@ -762,66 +854,99 @@ void TrueJet::processEvent( LCEvent * event ) {
              // the next generation leptons), so the sum is non-trivial.
              // Sometimes this also happens for quraks, ie. they go directly to
              // the genertor quarks of the string.
+
         int first=nlund , last=0;
-        for ( int jj=1 ; jj<=jets_begin[0][kk] ; jj++ ) {
-          if ( k [fafp [jets_begin[jj][kk]] ] [4] == 0 ) {
-            if (  fafp[jets_begin[jj][kk]] < first ) {
-              first= fafp[jets_begin[jj][kk]] ;
+        if ( type[jets_begin[1][k_dj_begin]] == 4 ) {  // i.e. ISR
+
+          pdg[1]=k[elementon[jets_begin[1][k_dj_begin]]][2];
+          first= fafp[jets_begin[1][k_dj_begin]] ;
+          last= fafp[jets_begin[1][k_dj_begin]] ;
+          bosonid=22;
+
+        } else {
+
+        for ( int j_jet_begin=1 ; j_jet_begin<=jets_begin[0][k_dj_begin] ; j_jet_begin++ ) {
+
+
+          int gen_part = fafp [jets_begin[j_jet_begin][k_dj_begin]];
+	  bool take_genpart = false;
+	  if (  k[gen_part][4] == 0 ) {
+	    take_genpart = true;
+	  } else if ( k [k [gen_part] [4]][2] != k[gen_part][2] ||  k [k [gen_part] [4]][1] == 0 ) {
+	    take_genpart = true;
+	  }
+	  if ( take_genpart ) {
+            if (  gen_part < first ) {
+              first=gen_part;
+            }
+            if (  gen_part > last ) {
+              last=gen_part;
             }
           } else {
-            if (  k [fafp [jets_begin[jj][kk]] ] [4] < first ) {
-              first= k[fafp[jets_begin[jj][kk]]][4] ;
-            }
+            if (  k[gen_part][4] < first ) {
+	      first= k[gen_part][4] ;
+	    }  
+            if (  k[gen_part][5] > last ) {
+	      last= k[gen_part][5] ;
+	    }  
+	    
+	  }
+	    
+          pdg[j_jet_begin]=k[elementon[jets_begin[j_jet_begin][k_dj_begin]]][2];
+          int last_backtrack = fafp[jets_begin[j_jet_begin][k_dj_begin]] ;
+          int this_pdg = k[last_backtrack][2] ;
+
+          while (  k[last_backtrack][2] == this_pdg ) {
+            last_backtrack = k[last_backtrack][3];
+            if ( last_backtrack == 0 ) break;
           }
-          if ( k [fafp [jets_begin[jj][kk]] ] [5] == 0 ) {
-            if (  fafp[jets_begin[jj][kk]] > last ) {
-              last= fafp[jets_begin[jj][kk]] ;
-            }
-          } else { 
-            if (  k[fafp[jets_begin[jj][kk]]][5] > last ) {
-              last= k[fafp[jets_begin[jj][kk]]][5] ;
-            }
-          }
-	  //          pdg[jj]=k[fafp[jets_begin[jj][kk]]][2];
-          pdg[jj]=k[elementon[jets_begin[jj][kk]]][2];
-          // TODO: maybe lift this part out into a separate loop ?
-          // JL: first check whether we have an explicit mother in the event listing, like for Higgs events
-          // MB: only do this if the parent *is* a boson
-          if ( k[fafp[jets_begin[jj][kk]]][3] > 0) {
-            if (  abs(k [k[fafp[jets_begin[jj][kk]]][3]] [2]) > 21 &&  abs(k [k[fafp[jets_begin[jj][kk]]][3]] [2]) <= 39 ) {
+
+          if ( last_backtrack > 0) {
+            if (  abs(k[last_backtrack][2]) > 21 &&   abs(k[last_backtrack][2]) <= 39 ) {
                 // ie. any IVB except the gluon
-              bosonid = abs(k [k[fafp[jets_begin[jj][kk]]][3]] [2]);
-              streamlog_out(DEBUG3) << " elementon " << fafp[jets_begin[jj][kk]] << " has explicit mother with PDG = " << bosonid << std::endl;
+              bosonid =  abs(k[last_backtrack][2]) ;
+              streamlog_out(DEBUG3) << " elementon " << fafp[jets_begin[j_jet_begin][k_dj_begin]] 
+                                      << " has explicit mother with PDG = " << bosonid << std::endl;
             }
           }
+
           if ( pdg[0] == 0 ) {
-              //JL this is _not_ the mother boson pdg yet, but a temporary storage for the pdg of the (first) elementon of this boson
-            pdg[0]=abs(k[fafp[jets_begin[jj][kk]]][2]);
-              //JL if ID of one of the following elementons of this boson has a different pdg, assume we have a W
+
+            pdg[0]=abs(k[fafp[jets_begin[j_jet_begin][k_dj_begin]]][2]);
+
           } 
-          else if ( bosonid==23 && abs(k[fafp[jets_begin[jj][kk]]][2]) != pdg[0] ) {
+          else if ( bosonid==23 && abs(k[fafp[jets_begin[j_jet_begin][k_dj_begin]]][2]) != pdg[0] ) {
+
             bosonid=24;
+
           } 
         }
+        }
+        if ( k[last][2] == 92 ) { first = last ; } //  IS THIS RIGHT ? If there is a gluon radiation ?!
+	                                           // should it rather be the other way last="first"
         pdg[0]=bosonid;
+
         if ( last == first ) {
           E=  p[first][4];
           for ( int ll=1 ; ll<=3 ; ll++ ) {
             mom[ll-1] =    p[first][ll];
           }
         } else {
+
           // if several, sum up but make sure that there are no intruders between first and last.
-          for ( int ii=1 ; ii<=jets_begin[0][kk] ; ii++ ) {
-            for ( int jj=first ; jj<=last ; jj++ ) {
-             if ( abs(jet[jj]) == jets_begin[ii][kk] && k[jj][3] < first ) {
-                E+=  p[jj][4];
+          for ( int j_jets_begin=1 ; j_jets_begin<=jets_begin[0][k_dj_begin] ; j_jets_begin++ ) {
+            for ( int k_py=first ; k_py<=last ; k_py++ ) {
+              if ( abs(jet[k_py]) == jets_begin[j_jets_begin][k_dj_begin] && k[k_py][3] < first ) {
+                E+=  p[k_py][4];
                 for ( int ll=1 ; ll<=3 ; ll++ ) {
-                  mom[ll-1] +=    p[jj][ll];
+                  mom[ll-1] +=    p[k_py][ll];
                 }
               }
+
             }
           }
         }
+
         double psqrs=0;
         for ( int ii=1 ; ii<=3 ; ii++ ) {
           psqrs += mom[ii-1]*mom[ii-1];
@@ -838,23 +963,25 @@ void TrueJet::processEvent( LCEvent * event ) {
         ParticleIDImpl* pid[26] ;
         pid[0]= new ParticleIDImpl; 
         pid[0]->setPDG(pdg[0]);
-        pid[0]->setType(type[jets_begin[1][kk]]%100);  
+        pid[0]->setType(type[jets_begin[1][k_dj_begin]]%100);  
         fafpi->addParticleID(pid[0]);
-        for(int jj=1 ; jj<=jets_begin[0][kk] ; jj++) {
-          pid[jj]= new ParticleIDImpl; 
-          pid[jj]->setPDG(pdg[jj]);
-          pid[jj]->setType(type[jets_begin[jj][kk]]);  
-          fafpi->addParticleID(pid[jj]);
-          fafpi->addParticle(dynamic_cast<ReconstructedParticle*>(jet_vec->getElementAt(jets_begin[jj][kk]-1)));
+        for(int j_jet_begin=1 ; j_jet_begin<=jets_begin[0][k_dj_begin] ; j_jet_begin++) {
+          pid[j_jet_begin]= new ParticleIDImpl; 
+          pid[j_jet_begin]->setPDG(pdg[j_jet_begin]);
+          pid[j_jet_begin]->setType(type[jets_begin[j_jet_begin][k_dj_begin]]);  
+          fafpi->addParticleID(pid[j_jet_begin]);
+          fafpi->addParticle(dynamic_cast<ReconstructedParticle*>(jet_vec->getElementAt(jets_begin[j_jet_begin][k_dj_begin]-1)));
         }
         fafpi_vec->addElement(fafpi);
         
-        for ( int jj=1 ; jj<=jets_begin[0][kk] ; jj++ ) {
-          InitialElementon_Nav.addRelation(   jet_vec->getElementAt(jets_begin[jj][kk]-1), mcp_pyjets[fafp[jets_begin[jj][kk]]], 1.0 );
-          InitialColourNeutral_Nav.addRelation(  jet_vec->getElementAt(jets_begin[jj][kk]-1) , fafpi);
+        for ( int j_jet_begin=1 ; j_jet_begin<=jets_begin[0][k_dj_begin] ; j_jet_begin++ ) {
+          InitialElementon_Nav.addRelation(  jet_vec->getElementAt(jets_begin[j_jet_begin][k_dj_begin]-1), 
+                                              mcp_pyjets[fafp[jets_begin[j_jet_begin][k_dj_begin]]], 1.0 );
+          InitialColourNeutral_Nav.addRelation(  jet_vec->getElementAt(jets_begin[j_jet_begin][k_dj_begin]-1) , fafpi);
         }
    
-      }
+      }  // di-jet (begining) loop
+
       //============================ 
 
       
@@ -884,75 +1011,113 @@ void TrueJet::processEvent( LCEvent * event ) {
 
 
       streamlog_out(DEBUG4) << " HEPEVT relation table up with jet assignment, extended status codes, and PFOs w. energy (if any) "  <<std::endl;
-      streamlog_out(DEBUG4) << "    line      status           pdg  parent  first  last      px         py          pz          E             M        jet companion type       PFO/Energy" << std::endl;
-      streamlog_out(DEBUG4) << "           init ext'd                         daughter                                                                        jet" << std::endl;
+      streamlog_out(DEBUG4) << " line      status   pdg    first last  first last  colour  anti-     px         py          pz     "
+                              <<"     E            M        jet companion type       PFO/Energy" << std::endl;
+      streamlog_out(DEBUG4) << "        init ext'd           parent     daughter          colour                               "
+                              <<"                                      jet" << std::endl;
 
-      for ( int i=1 ; i <= nlund ; i++){
+      //      for ( int i_py=1 ; i_py <= nlund ; i_py++){
+      for ( int i_py=1 ; i_py <= std::min(nlund,200) ; i_py++){
+
         int istat=0;
-        if ( jet[i] != 0 ) {
+        if ( jet[i_py] != 0 ) {
           static FloatVec www;
-          www = truejet_truepart_Nav.getRelatedFromWeights(mcp_pyjets[i]);
+          www = truejet_truepart_Nav.getRelatedFromWeights(mcp_pyjets[i_py]);
           istat=int(www[0]);
         }
-	streamlog_out(DEBUG4) << std::setw(7) << i << std::setw(7) <<  k[i][1] << std::setw(7) <<  istat << 
-                 std::setw(12) <<  k[i][2] << std::setw(7) <<  k[i][3] << 
-                 std::setw(7) <<  k[i][4] << std::setw(7) << k[i][5] <<
-                 std::setw(12) <<  p[i][1] << 
-                 std::setw(12) <<  p[i][2] << std::setw(12) <<  p[i][3] << 
-                 std::setw(12) <<  p[i][4] << std::setw(12) << p[i][5] <<
- 
-                 std::setw(7) << jet[i]  <<
-                 std::setw(7) << companion[abs(jet[i])] << std::setw(7) <<  type[abs(jet[i])];
-        LCObjectVec recovec; 
-        recovec = reltrue->getRelatedFromObjects( mcp_pyjets[i]);
-        if ( recovec.size() > 0 ) { // if reconstructed
-           for ( unsigned ireco=0 ; ireco<recovec.size() ; ireco++ ) { //  reco-of-this-true loop
 
-             ReconstructedParticle* reco_part  = dynamic_cast<ReconstructedParticle*>(recovec[ireco]);
-  	     streamlog_out(DEBUG4) << " [" << std::setw(10) << reco_part <<" /"<< std::setw(11) << reco_part->getEnergy() <<"] ";
-           }
-        } else if ( istat == 1 ) {
-  	  streamlog_out(DEBUG4) << " [" << std::setw(10) << "N.A   "<<" /"<< std::setw(11) << "N.A   "<<"] ";
+        if ( k[i_py][1] > 0 &&  k[i_py][1] < 30 ) {
+
+	  streamlog_out(DEBUG4) << std::setw(4) << i_py << std::setw(7) <<  k[i_py][1] << std::setw(5) <<  istat << 
+	    std::setw(7) <<  k[i_py][2] << std::setw(7) <<  k[i_py][3] << std::setw(5) <<  k[i_py][6] <<
+                 std::setw(7) <<  k[i_py][4] << std::setw(5) << k[i_py][5] <<
+                 std::setw(7) <<  k[i_py][7] << std::setw(7) << k[i_py][8] <<
+                 std::setw(12) <<  p[i_py][1] << 
+                 std::setw(12) <<  p[i_py][2] << std::setw(12) <<  p[i_py][3] << 
+                 std::setw(12) <<  p[i_py][4] << std::setw(12) << p[i_py][5] <<
+ 
+                 std::setw(7) << jet[i_py]  <<
+                 std::setw(7) << companion[abs(jet[i_py])] << std::setw(7) <<  type[abs(jet[i_py])];
+        } else {
+	  streamlog_out(DEBUG3) << std::setw(4) << i_py << std::setw(7) <<  k[i_py][1] << std::setw(5) <<  istat << 
+                 std::setw(5) <<  k[i_py][2] << std::setw(7) <<  k[i_py][3] <<  std::setw(5) <<  k[i_py][6] <<
+                 std::setw(7) <<  k[i_py][4] << std::setw(5) << k[i_py][5] <<
+                 std::setw(7) <<  k[i_py][7] << std::setw(7) << k[i_py][8] <<
+                 std::setw(12) <<  p[i_py][1] << 
+                 std::setw(12) <<  p[i_py][2] << std::setw(12) <<  p[i_py][3] << 
+                 std::setw(12) <<  p[i_py][4] << std::setw(12) << p[i_py][5] <<
+ 
+                 std::setw(7) << jet[i_py]  <<
+                 std::setw(7) << companion[abs(jet[i_py])] << std::setw(7) <<  type[abs(jet[i_py])];
         }
-	streamlog_out(DEBUG4) << std::endl;
+
+        if ( reltrue ) {
+          LCObjectVec recovec = reltrue->getRelatedFromObjects( mcp_pyjets[i_py]);
+          if ( recovec.size() > 0 ) { // if reconstructed
+            for ( unsigned i_reco=0 ; i_reco<recovec.size() ; i_reco++ ) { //  reco-of-this-true loop
+              if ( k[i_py][1] > 0 &&  k[i_py][1] < 30 ) {
+
+               ReconstructedParticle* reco_part  = dynamic_cast<ReconstructedParticle*>(recovec[i_reco]);
+  	       streamlog_out(DEBUG4) << " [" << std::setw(8) << reco_part->getEnergy() <<"] ";
+              } else {
+                ReconstructedParticle* reco_part  = dynamic_cast<ReconstructedParticle*>(recovec[i_reco]);
+  	        streamlog_out(DEBUG3) << " [" << std::setw(10) << reco_part <<" /"<< std::setw(8) << reco_part->getEnergy() <<"] ";
+              }
+            }
+          } else if ( istat == 1 ) {
+            if ( k[i_py][1] > 0 &&  k[i_py][1] < 30 ) {
+    	      streamlog_out(DEBUG4) << " [" << std::setw(10) << "N.A   "<<" /"<< std::setw(8) << "N.A   "<<"] ";
+            } else  {
+    	      streamlog_out(DEBUG3) << " [" << std::setw(10) << "N.A   "<<" /"<< std::setw(8) << "N.A   "<<"] ";
+            }
+          }
+        }
+        if ( k[i_py][1] > 0 &&  k[i_py][1] < 30 ) {
+	  streamlog_out(DEBUG4) << std::endl;
+        } else {
+	  streamlog_out(DEBUG3) << std::endl;
+        }
       }
       streamlog_out(DEBUG6) <<  std::endl;
-      streamlog_out(DEBUG6) << "       jet     fafp-beg  qrk/lept  fafp-end fafp-boson  type   dijet-beg  dijet-end    boson" << std::endl;
-      for ( int i=1 ; i <= njet ; i++){
-	streamlog_out(DEBUG6) << std::setw(10) << i << std::setw(10) <<  fafp[i] << 
-                 std::setw(10) <<  elementon[i] << std::setw(10) <<  fafp_last[i] << 
-                 std::setw(10) <<  fafp_boson[i] << std::setw(10) << type[i] << std::setw(10) << dijet_begining[i]  <<
-                 std::setw(10) << dijet_end[i] << std::setw(10) <<  boson[i]<<std::endl;
+
+      streamlog_out(DEBUG6) << "       jet     fafp-beg  qrk/lept  fafp-end fafp-boson  type   "
+                              <<"dijet-beg  dijet-end    boson" << std::endl;
+      for ( int i_jet=1 ; i_jet <= njet ; i_jet++){
+	streamlog_out(DEBUG6) << std::setw(10) << i_jet << std::setw(10) <<  fafp[i_jet] << 
+                 std::setw(10) <<  elementon[i_jet] << std::setw(10) <<  fafp_last[i_jet] << 
+                 std::setw(10) <<  fafp_boson[i_jet] << std::setw(10) << type[i_jet] << 
+                 std::setw(10) << dijet_begining[i_jet]  <<
+                 std::setw(10) << dijet_end[i_jet] << std::setw(10) <<  boson[i_jet]<<std::endl;
       }
       streamlog_out(DEBUG6) <<  std::endl;
       streamlog_out(DEBUG6) << "       Colour-neutral objects at the beginning of the parton shower " << std::endl;
-      streamlog_out(DEBUG6) << "    number    px          py           pz          E           M       type       PDGs        jets " << std::endl;
+      streamlog_out(DEBUG6) << "    number    px          py           pz          E           M   "
+                              <<"    type       PDGs        jets " << std::endl;
       int glurad=0;
-      for ( unsigned kk=0 ; kk<fafpi_vec->size() ; kk++ ) {
+      for ( unsigned i_cn_b=0 ; i_cn_b<fafpi_vec->size() ; i_cn_b++ ) {
         
-        ReconstructedParticle* fafpi = dynamic_cast<ReconstructedParticle*>(fafpi_vec->at(kk));
-        LCObjectVec jts;
-        jts = InitialColourNeutral_Nav.getRelatedFromObjects(fafpi);
+        ReconstructedParticle* fafpi = dynamic_cast<ReconstructedParticle*>(fafpi_vec->at(i_cn_b));
+        LCObjectVec jts = InitialColourNeutral_Nav.getRelatedFromObjects(fafpi);
 
         const double* mom=fafpi->getMomentum();
-	streamlog_out(DEBUG6) << std::setw(7) << kk+1 << std::setw(12) << mom[0] << std::setw(12) <<  mom[1] << std::setw(12)  << mom[2] << 
+	streamlog_out(DEBUG6) << std::setw(7) << i_cn_b+1 << std::setw(12) << mom[0] << 
+                             std::setw(12) <<  mom[1] << std::setw(12)  << mom[2] << 
                              std::setw(12)  <<fafpi->getEnergy() << std::setw(12) << fafpi->getMass() << 
                              std::setw(7)  << fafpi->getParticleIDs()[0]->getType() << "   " ;
-//<< std::setw(10) << fafpi->getParticleIDs()[0]->getPDG() ;
-        for ( unsigned ipid=0 ; ipid < fafpi->getParticleIDs().size() ; ipid++ ) {
-	  if (fafpi->getParticleIDs()[ipid]->getType()>=100 ) glurad=1;
-          if (ipid < fafpi->getParticleIDs().size()-1 ) {
-            streamlog_out(DEBUG6)  << std::setw(3)<< fafpi->getParticleIDs()[ipid]->getPDG()  << "," ;
+        for ( unsigned i_pid=0 ; i_pid < fafpi->getParticleIDs().size() ; i_pid++ ) {
+	  if (fafpi->getParticleIDs()[i_pid]->getType()>=100 ) glurad=1;
+          if (i_pid < fafpi->getParticleIDs().size()-1 ) {
+            streamlog_out(DEBUG6)  << std::setw(3)<< fafpi->getParticleIDs()[i_pid]->getPDG()  << "," ;
           } else {
-            streamlog_out(DEBUG6)  << std::setw(3)<< fafpi->getParticleIDs()[ipid]->getPDG() << "   " ;
+            streamlog_out(DEBUG6)  << std::setw(3)<< fafpi->getParticleIDs()[i_pid]->getPDG() << "   " ;
           }
         }
-        for ( unsigned jj=0 ; jj<jts.size() ; jj++ ) {
-           int ijet=jts[jj]->ext<TJindex>(); 
-           if ( jj < jts.size()-1 ) {
-             streamlog_out(DEBUG6) << std::setw(3) << ijet << "," ; 
+        for ( unsigned j_jet_begin=0 ; j_jet_begin<jts.size() ; j_jet_begin++ ) {
+           int i_jet=jts[j_jet_begin]->ext<TJindex>(); 
+           if ( j_jet_begin < jts.size()-1 ) {
+             streamlog_out(DEBUG6) << std::setw(3) << i_jet << "," ; 
            } else {
-             streamlog_out(DEBUG6) << std::setw(3) << ijet  ;
+             streamlog_out(DEBUG6) << std::setw(3) << i_jet  ;
            }
         }
         streamlog_out(DEBUG6) << std::endl;
@@ -960,16 +1125,16 @@ void TrueJet::processEvent( LCEvent * event ) {
       if ( glurad == 1 ) {
         streamlog_out(DEBUG6) << std::endl;
         streamlog_out(DEBUG6) <<    "              gluon radiation in event : "<< std::endl;
-        for ( unsigned kk=0 ; kk<fafpi_vec->size() ; kk++ ) {
+        for ( unsigned j_cn_b=0 ; j_cn_b<fafpi_vec->size() ; j_cn_b++ ) {
         
-          ReconstructedParticle* fafpi = dynamic_cast<ReconstructedParticle*>(fafpi_vec->at(kk));
-          LCObjectVec jts;
-          jts = InitialColourNeutral_Nav.getRelatedFromObjects(fafpi);
+          ReconstructedParticle* fafpi = dynamic_cast<ReconstructedParticle*>(fafpi_vec->at(j_cn_b));
+          LCObjectVec jts = InitialColourNeutral_Nav.getRelatedFromObjects(fafpi);
 
-          for ( unsigned jj=1 ; jj < fafpi->getParticleIDs().size() ; jj++ ) {
-	    if (fafpi->getParticleIDs()[jj]->getType()>=100 ) {
-              int ijet=jts[jj-1]->ext<TJindex>(); 
-              streamlog_out(DEBUG6)  << std::setw(18)<< ijet << " is from " << fafpi->getParticleIDs()[jj]->getType()/100  << std::endl;
+          for ( unsigned j_pid_cn_b=1 ; j_pid_cn_b < fafpi->getParticleIDs().size() ; j_pid_cn_b++ ) {
+	    if (fafpi->getParticleIDs()[j_pid_cn_b]->getType()>=100 ) {
+              int i_jet=jts[j_pid_cn_b-1]->ext<TJindex>(); 
+              streamlog_out(DEBUG6)  << std::setw(18)<< i_jet << " is from " 
+                                       << fafpi->getParticleIDs()[j_pid_cn_b]->getType()/100  << std::endl;
             }
           }
         }
@@ -977,39 +1142,41 @@ void TrueJet::processEvent( LCEvent * event ) {
 
       streamlog_out(DEBUG6) <<  std::endl;
       streamlog_out(DEBUG6) << "       Colour-neutral objects at the end of the parton shower " << std::endl;
-      streamlog_out(DEBUG6) << "    number    px          py           pz          E           M       type       PDGs        jets " << std::endl;
-      for ( unsigned kk=0 ; kk<fafpf_vec->size() ; kk++ ) {
+      streamlog_out(DEBUG6) << "    number    px          py           pz          E           M   "
+                              <<"    type       PDGs        jets " << std::endl;
+      for ( unsigned i_cn_e=0 ; i_cn_e<fafpf_vec->size() ; i_cn_e++ ) {
         
-        ReconstructedParticle* fafpf = dynamic_cast<ReconstructedParticle*>(fafpf_vec->at(kk));
-        LCObjectVec jts;
-        jts = FinalColourNeutral_Nav.getRelatedFromObjects(fafpf);
+        ReconstructedParticle* fafpf = dynamic_cast<ReconstructedParticle*>(fafpf_vec->at(i_cn_e));
+        LCObjectVec jts = FinalColourNeutral_Nav.getRelatedFromObjects(fafpf);
 
         const double* mom=fafpf->getMomentum();
-	streamlog_out(DEBUG6) << std::setw(7) << kk+1 << std::setw(12) << mom[0] << std::setw(12) <<  mom[1] << std::setw(12)  << mom[2] << 
+	streamlog_out(DEBUG6) << std::setw(7) << i_cn_e+1 << std::setw(12) << mom[0] << 
+                             std::setw(12) <<  mom[1] << std::setw(12)  << mom[2] << 
                              std::setw(12)  <<fafpf->getEnergy() << std::setw(12) << fafpf->getMass() << 
                              std::setw(7)  << fafpf->getParticleIDs()[0]->getType()  << "   ";
         if (  fafpf->getParticleIDs().size() < 3 ) streamlog_out(DEBUG6)  << std::setw(3) <<" ";
-        for ( unsigned ipid=0 ; ipid < fafpf->getParticleIDs().size() ; ipid++ ) {
-          if (ipid < fafpf->getParticleIDs().size()-1 ) {
-            streamlog_out(DEBUG6)  << std::setw(3)<< fafpf->getParticleIDs()[ipid]->getPDG()  << "," ;
+        for ( unsigned i_pid=0 ; i_pid < fafpf->getParticleIDs().size() ; i_pid++ ) {
+          if (i_pid < fafpf->getParticleIDs().size()-1 ) {
+            streamlog_out(DEBUG6)  << std::setw(3)<< fafpf->getParticleIDs()[i_pid]->getPDG()  << "," ;
           } else {
-            streamlog_out(DEBUG6)  << std::setw(3)<< fafpf->getParticleIDs()[ipid]->getPDG() << "   " ;
+            streamlog_out(DEBUG6)  << std::setw(3)<< fafpf->getParticleIDs()[i_pid]->getPDG() << "   " ;
           }
         }
         if (  jts.size() < 2 ) streamlog_out(DEBUG6)  << std::setw(3) <<" ";
-        for ( unsigned jj=0 ; jj<jts.size() ; jj++ ) {
-           int ijet=jts[jj]->ext<TJindex>(); 
-           if ( jj < jts.size()-1 ) {
-             streamlog_out(DEBUG6) << std::setw(3) << ijet << "," ; 
+        for ( unsigned j_jet_end=0 ; j_jet_end<jts.size() ; j_jet_end++ ) {
+           int i_jet=jts[j_jet_end]->ext<TJindex>(); 
+           if ( j_jet_end < jts.size()-1 ) {
+             streamlog_out(DEBUG6) << std::setw(3) << i_jet << "," ; 
            } else {
-             streamlog_out(DEBUG6) << std::setw(3) << ijet  ;
+             streamlog_out(DEBUG6) << std::setw(3) << i_jet  ;
            }
         }
         streamlog_out(DEBUG6) << std::endl;
       }
       streamlog_out(DEBUG6) << std::endl;
+      
 
-    }  // endif( mcpcol != NULL &&  rmclcol != NULL)
+    }  // endif( mcpcol != NULL )
 
 
     //*****************************
@@ -1025,69 +1192,91 @@ void TrueJet::processEvent( LCEvent * event ) {
 void TrueJet::getPyjets(LCCollection* mcpcol )
 {
   const double* ptemp;
-
-  int iii=0;
+  _higgs_to_glue_glue = false;
+  bool _generator_input_format = false;
+  int higgs_line = 0 ;
+  int k_py=0;
   int nMCP = mcpcol->getNumberOfElements()  ;
-  //JL: added so that first_line is the same in all events!
+  _top_event = false ;
   first_line=1;
+
   if ( nMCP > 4000 ) {
-    streamlog_out(WARNING)  << " More than 4000 MCParticles in event " << evt->getEventNumber() << ",   run  " << evt->getRunNumber() << std::endl ;
+    streamlog_out(WARNING)  << " More than 4000 MCParticles in event " << evt->getEventNumber() 
+                              << ",   run  " << evt->getRunNumber() << std::endl ;
   }
-  for(int j=0; j< std::min(nMCP,4000) ; j++){
 
-    MCParticle* mcp = dynamic_cast<MCParticle*>( mcpcol->getElementAt( j ) ) ;
-    //  (assume this is not needed, ie. that the k-vector  can be set up correctly
-    //    also for created-in-simulation  particles. The issue is if decay-products
-    //    of a given particle will be consecutive).
-    // if (mcp->getGeneratorStatus() == 1 || mcp->getGeneratorStatus() == 2 ) {
+  for(int j_mcp=0; j_mcp< std::min(nMCP,4000) ; j_mcp++){
 
-      iii++; 
-      mcp_pyjets[iii]=mcp;
-      mcp->ext<MCPpyjet>()=iii;
+    MCParticle* mcp = dynamic_cast<MCParticle*>( mcpcol->getElementAt( j_mcp ) ) ;
+       //  (assume this is not needed, ie. that the k-vector  can be set up correctly
+       //    also for created-in-simulation  particles. The issue is if decay-products
+       //    of a given particle will be consecutive).
+       // if (mcp->getGeneratorStatus() == 1 || mcp->getGeneratorStatus() == 2 ) {
+
+      if (  j_mcp == 0 && mcp->getSimulatorStatus()==0 ) { _generator_input_format = true ; }
+      k_py++; 
+      mcp_pyjets[k_py]=mcp;
+      mcp->ext<MCPpyjet>()=k_py;
       ptemp=mcp->getMomentum();
-      p[iii][1]=ptemp[0]; 
-      p[iii][2]=ptemp[1]; 
-      p[iii][3]=ptemp[2]; 
-      p[iii][4]=mcp->getEnergy();
-      p[iii][5]=mcp->getMass();
-      k[iii][1]=mcp->getGeneratorStatus();
-      if ( k[iii][1] == 2 ) {  k[iii][1]=11 ;}
-      if ( k[iii][1] == 3 ) {  k[iii][1]=21 ;}
-      if (mcp->isOverlay() ) {  k[iii][1]=k[iii][1]+30 ; }
-      k[iii][2]=mcp->getPDG();
+      p[k_py][1]=ptemp[0]; 
+      p[k_py][2]=ptemp[1]; 
+      p[k_py][3]=ptemp[2]; 
+      p[k_py][4]=mcp->getEnergy();
+      p[k_py][5]=mcp->getMass();
+      k[k_py][1]=mcp->getGeneratorStatus();
+      if ( k[k_py][1] == 2 ) {  k[k_py][1]=11 ;}
+      if ( k[k_py][1] == 3 ) {  k[k_py][1]=21 ;}
+      if ( k[k_py][1] == 4 ) {  k[k_py][1]=22 ;}
+      if (mcp->isOverlay() ) {  k[k_py][1]=k[k_py][1]+30 ; }
+      k[k_py][2]=mcp->getPDG();
+      if ( abs(k[k_py][2]) == 6 ) { _top_event = true ; }
+      if ( k[k_py][2] == 25 ) {
+        higgs_line = k_py ;
+      }
 
-    //    }
+ // }
   }
-  nlund=iii;
+  nlund=k_py;
 
-  for (int j=1; j <= nlund ; j++ ) {
-    k[j][3] = 0;
-    k[j][4] = 0;
-    k[j][5] = 0;
+  for (int j_py=1; j_py <= nlund ; j_py++ ) {
+    k[j_py][3] = 0;
+    k[j_py][4] = 0;
+    k[j_py][5] = 0;
+    k[j_py][7] = 0;
+    k[j_py][8] = 0;
   }
   streamlog_out(DEBUG1) << " before Motherless check: first_line = " << first_line << std::endl ; 
-  for(int j=0; j< nMCP ; j++){
 
-    MCParticle* mcp = dynamic_cast<MCParticle*>( mcpcol->getElementAt( j ) ) ;
-    int i;
+  for(int j_mcp=0; j_mcp< nMCP ; j_mcp++){
+
+    MCParticle* mcp = dynamic_cast<MCParticle*>( mcpcol->getElementAt( j_mcp ) ) ;
+    int i_py=0;
     if ( mcp->ext<MCPpyjet>() != 0 ) {
-      i= mcp->ext<MCPpyjet>();
+
+      i_py= mcp->ext<MCPpyjet>();
       if (  mcp->getParents().size() != 0 ) {
-        k[i][3]=mcp->getParents()[0]->ext<MCPpyjet>();
+        k[i_py][3]=mcp->getParents()[0]->ext<MCPpyjet>();
+	if ( k[i_py][3] ==  higgs_line ) {
+	  if ( k[i_py][2] == 21 ) {
+	    _higgs_to_glue_glue = true;
+	  }
+	}  
       } else {
-//JL  was i > first_line+2, but due to the > sign, this skips the 3 first particles, while we just want to omit the first 2 here!        
-        if ( i > first_line+1 &&  ! mcp->isOverlay() &&  k[i][3] == 0 && abs(mcp->getPDG()) != 6 && abs(mcp->getPDG()) != 24 ) {
-          streamlog_out(MESSAGE4) << " Motherless generator particle " << i << ". pdg: " << mcp->getPDG() << std::endl ; 
+        if ( i_py > first_line+1 &&  ! mcp->isOverlay() &&  k[i_py][3] == 0 && abs(mcp->getPDG()) != 6 && abs(mcp->getPDG()) != 24 ) {
+          streamlog_out(MESSAGE4) << " Motherless generator particle " << i_py << ". pdg: " << mcp->getPDG() << std::endl ; 
           streamlog_out(MESSAGE4) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-//JL          k[i][3]=3;
-          k[i][3]=-1;
+          k[i_py][3]=-1;
         }
        
       }
-      if (  mcp->getParents().size() == 2 ) {
-        k[i][6]=mcp->getParents()[1]->ext<MCPpyjet>();
+
+      k[i_py][7]=mcp->getColorFlow()[0];
+      k[i_py][8]=mcp->getColorFlow()[1];
+
+      if (  mcp->getParents().size() > 1 ) {
+        k[i_py][6]=mcp->getParents()[mcp->getParents().size()-1]->ext<MCPpyjet>();
       } else {
-        k[i][6]=0;
+        k[i_py][6]=0;
       }
       
       if ( mcp->getDaughters().size() != 0 ) {
@@ -1104,32 +1293,37 @@ void TrueJet::getPyjets(LCCollection* mcpcol )
            // This case can't be fixed, yet as the check should only be applied to lines after the parton-shower,
            // which we can't determine yet. Instead it is taken care of in the gouping method.)
 
-        if ( k[i][1]!=0 ) {
-          int has_genstat0_daughter=0;
-          for ( unsigned idat=0 ; idat <  mcp->getDaughters().size() ; idat++ ) {
-            int jdat=mcp->getDaughters()[idat]->ext<MCPpyjet>();
-            if ( mcp->getDaughters()[idat]->getGeneratorStatus()==0 || (mcp->getDaughters()[idat]->getSimulatorStatus()==0 && k[jdat][1]==1 )) {
-              has_genstat0_daughter=1;
-            }
-          }
-          if ( has_genstat0_daughter==1 ) {
-
-            if ( k[i][1] < 30 ) {
-              k[i][1]=1;
-            }
-            for ( unsigned idat=0 ; idat <  mcp->getDaughters().size() ; idat++ ) {
-              int jdat=mcp->getDaughters()[idat]->ext<MCPpyjet>();
-              if ( k[jdat][1] < 30 ) {
-                k[jdat][1]=0;
+        if ( ! _generator_input_format ) { // none of the below can happen if we are looking at the generator input MCparticle collection 
+          if ( k[i_py][1]!=0 ) {
+            int has_genstat0_daughter=0;
+            for ( unsigned i_dau=0 ; i_dau <  mcp->getDaughters().size() ; i_dau++ ) {
+              int j_dau=mcp->getDaughters()[i_dau]->ext<MCPpyjet>();
+              if ( mcp->getDaughters()[i_dau]->getGeneratorStatus()==0 || (mcp->getDaughters()[i_dau]->getSimulatorStatus()==0 && k[j_dau][1]==1 )) {
+                has_genstat0_daughter=1;
               }
             }
-          }
-        } else {
+            if ( has_genstat0_daughter==1 ) {
 
-          for ( unsigned idat=0 ; idat <  mcp->getDaughters().size() ; idat++ ) {
-            int jdat=mcp->getDaughters()[idat]->ext<MCPpyjet>();
-            if ( k[jdat][1] < 30 ) {
-              k[jdat][1]=0;
+              if ( k[i_py][1] < 30 ) {
+                k[i_py][1]=1;
+              }
+
+              for ( unsigned i_dau=0 ; i_dau <  mcp->getDaughters().size() ; i_dau++ ) {
+                int j_dau=mcp->getDaughters()[i_dau]->ext<MCPpyjet>();
+                if ( k[j_dau][1] < 30 ) {
+                  k[j_dau][1]=0;
+                }
+              }
+
+            }
+
+          } else {
+
+            for ( unsigned i_dau=0 ; i_dau <  mcp->getDaughters().size() ; i_dau++ ) {
+              int j_dau=mcp->getDaughters()[i_dau]->ext<MCPpyjet>();
+              if ( k[j_dau][1] < 30 ) {
+                k[j_dau][1]=0;
+              }
             }
           }
         }
@@ -1139,417 +1333,596 @@ void TrueJet::getPyjets(LCCollection* mcpcol )
            // particle end in a simulation particle, which is OK for the
            // logic elsewhere !
 
-        for ( unsigned idat=0 ; idat <  mcp->getDaughters().size() ; idat++ ) {
-          int jdat=mcp->getDaughters()[idat]->ext<MCPpyjet>();
-          if ( jdat < k[i][4] ||  k[i][4] == 0 ) {
-            k[i][4]=jdat;
+        for ( unsigned i_dau=0 ; i_dau <  mcp->getDaughters().size() ; i_dau++ ) {
+          int j_dau=mcp->getDaughters()[i_dau]->ext<MCPpyjet>();
+          if ( j_dau < k[i_py][4] ||  k[i_py][4] == 0 ) {
+            k[i_py][4]=j_dau;
           }
-          if ( jdat > k[i][5] ) {
-            k[i][5]=jdat;
+          if ( j_dau > k[i_py][5] ) {
+            k[i_py][5]=j_dau;
           }
+	  if ( abs(k[i_py][2]) == 6 ) {  // fix for top quark - possibly not needed with whiz2 ?
+	    if (k[k[i_py][4]][2] != 94 ) { 
+   	      k[i_py][5]= k[i_py][4]+1;
+	      k[k[i_py][5]][3] = i_py;
+	    }  
+	  }
+
         }
       } 
-    }
+    }  // endif ( mcp->ext<MCPpyjet>() != 0 )
+  } // end MCP loop
+
+
+  // At this point basically 99% of the job is done. However, there is still the CMShower lines (pdg=94).
+  // These have several mothers and several daughters. The 4-momentum is conserved in total, but not for
+  // the individual components one-by-one. Here we will short-circuit them, i.e. the history codes will
+  // connect mother and daughters directly. This is no problem if all pdg:s are different in the group
+  // of particles going in and out of the 94. The problem arrises when this is not the case (e.g. e+e-e+e-).
+  // Here we need to look at the momenta of the particles and match which dauther is closest to which
+  // mother. Remember, they will *not* be identical, so there is a bit of guessing.
+  // Note that the mothers of a 94 are not necessarily adjecent. They *are* in the range between k[line94][3] 
+  // and k[line94][6], but there might be "intruders" between these lines.
+
+
+  streamlog_out(DEBUG4)  << " HEPEVT relation table before 94-fixing"  <<std::endl;
+  streamlog_out(DEBUG4)  << "       line      status    pdg       parent    first     last     second             anti   " << std::endl;
+  streamlog_out(DEBUG4)  << "                                             daughter daugther    parent   colour   colour " << std::endl;
+  for ( int j_py=1 ; j_py<=nlund ; j_py++ ) {
+    if (  k[j_py][1] != 0 &&   k[j_py][1] < 30 ) {
+      streamlog_out(DEBUG4)  << std::setw(10) << j_py << std::setw(10) <<  k[j_py][1] << 
+                 std::setw(10) <<  k[j_py][2] << std::setw(10) <<  k[j_py][3] << 
+                 std::setw(10) <<  k[j_py][4] << std::setw(10) << k[j_py][5]  << 
+                 std::setw(10) << k[j_py][6] << std::setw(10)<< k[j_py][7] << std::setw(10) << k[j_py][8] << std::endl;
+    } else { 
+      streamlog_out(DEBUG3)  << std::setw(10) << j_py << std::setw(10) <<  k[j_py][1] << 
+                 std::setw(10) <<  k[j_py][2] << std::setw(10) <<  k[j_py][3] << 
+                 std::setw(10) <<  k[j_py][4] << std::setw(10) << k[j_py][5]  << 
+                 std::setw(10) << k[j_py][6] << std::setw(10)<< k[j_py][7] << std::setw(10) << k[j_py][8] << std::endl;
+    }      
   }
 
-    // follows a VERY tedious part to fix wrongly assigned oarents to 94:s sometimes done in the stdhep reader....
-    // (mostly (only?) a problem for 6f-leptonic)
+  //  94 fix. 
 
-  streamlog_out(DEBUG1) << " HEPEVT relation table before 94-fixing"  <<std::endl;
-  streamlog_out(DEBUG1) << "       line      status    pdg       parent    first     last     second " << std::endl;
-  streamlog_out(DEBUG1) << "                                             daughter daugther    parent " << std::endl;
-  for ( int j=1 ; j<=nlund ; j++ ) {
-    streamlog_out(DEBUG1) << std::setw(10) << j << std::setw(10) <<  k[j][1] << 
-                 std::setw(10) <<  k[j][2] << std::setw(10) <<  k[j][3] << 
-                 std::setw(10) <<  k[j][4] << std::setw(10) << k[j][5]  << std::setw(10) << k[j][6] <<std::endl;
-  }
-  for ( int i=1 ; i<=nlund ; i++ ) {
-    if ( k[i][4] ==  k[i][5] && k[ k[i][4]][2] == 94 ) {
-        // check if the parent-daughther relation for 94:s is really correct.
-        // there is a fixup of missing relations in the input stdhep in stdhepreader
-        // that sometimes goew astray (my bad, in fact). If this seems to be the case
-        // remove the wrong one, and leave it to fix94 to get it right
-      int line94=k[i][4];
-      int parent1=k[line94][3] ; int parent2=k[line94][6] ;
-      int kid1=k[line94][4] ; int kid2=k[line94][5] ;
-      if ( parent1 != 0 && parent2 != 0 ) {
-        if ( abs((p[kid1][4]+p[kid2][4])-(p[parent1][4]+p[parent2][4]))/(p[parent1][4]+p[parent2][4]) > 0.0001 ) {
-          streamlog_out(WARNING) << " Inconsitent 94 object: Energy of parents = "<< p[kid1][4]+p[kid2][4] << " , of kids = " <<  p[parent1][4]+p[parent2][4] << std::endl;
-          streamlog_out(WARNING) << " parents: " << parent1 << " " << parent2 << ". Kids: " << kid1 << " " << kid2  << std::endl;
-          streamlog_out(WARNING) << " pdgs:    " << k[parent1][2] << " " << k[parent2][2]  << ". Kids: " << k[kid1][2]  << " " << k[kid2][2]   << std::endl;
-          int evnb_print=0;
-          if ( ! ((k[ parent1 ][2] == k[ kid1 ][2] &&
-              k[ parent2 ][2] == k[ kid2 ][2] ) ||
-             (k[ parent2 ][2] == k[ kid1 ][2] &&
-              k[ parent1 ][2] == k[ kid2 ][2] ) ) ) {
-               // wrong-wrong=wrong !!!
-            int p1w=0;
-            if ( k[ parent1 ][2] !=  k[ kid1 ][2] && k[ parent1 ][2] !=  k[ kid2 ][2] ) {
-               // parent1 is wrong 
-    	      streamlog_out(ERROR) << " parent 1 is wrong flavor-wise ?? " << std::endl;
-              streamlog_out(ERROR) << " "<<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-              streamlog_out(ERROR)  << " "<<  line94  << " " << k[parent1 ][2] << " " <<  k[parent2 ][2]  << " " <<
-                                            k[kid1 ][2] << " " <<  k[kid2 ][2]  << std::endl;
-              streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-              streamlog_out(ERROR) << std::endl ;  if( streamlog_level(ERROR) ){ evnb_print=1;}
-              k[line94][3] = 0;
-              k[parent1][4]= k[parent1][5]=0;
-              p1w=1;
-            }
-            int p2w=0 ;
-            if ( k[ parent2 ][2] !=  k[ kid1 ][2] && k[ parent2 ][2]!=  k[ kid2 ][2] ) {
-             //     // parent2 is wrong 
-              p2w=1;
-              if ( p1w == 1 ) {
-    	        streamlog_out(ERROR) << " BOTH parents wrong  flavor-wise ? ! " << std::endl;
-                streamlog_out(ERROR) << " " <<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-                streamlog_out(ERROR) << " "  <<  line94  << " " << k[parent1 ][2] << " " <<  k[parent2 ][2]  << " " <<
-                                            k[kid1 ][2] << " " <<  k[kid2 ][2]  << std::endl;
-                streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(ERROR) << std::endl ; if( streamlog_level(ERROR) ){ evnb_print=1;}
-              } else {
-                streamlog_out(DEBUG3) << " parent 2 is wrong flavor-wise  " << std::endl;
-                streamlog_out(DEBUG3) << " "  <<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-                streamlog_out(DEBUG3) << " "  <<  line94  << " " << k[parent1 ][2] << " " <<  k[parent2 ][2]  << " " <<
-                                            k[kid1 ][2] << " " <<  k[kid2 ][2]  << std::endl;
-                streamlog_out(DEBUG3) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(DEBUG3) << std::endl ; if( streamlog_level(DEBUG3) ){ evnb_print=1;}
-  
-              }
-              k[line94][6] = 0;
-              k[parent2][4]= k[parent2][5]=0;
+  for ( int i_py=1 ; i_py<=nlund ; i_py++ ) {
+
+    // if the daughters of the parents to a 94 is not (only) the 94,
+    // check if between the 94 line and the second daughter of the
+    // parent of the 94 actually has the particle *going in* to the 94 (not the
+    // 94) as parent. If so, change the dautghter lines of the incomming particle
+    // to these lines (and ignore the 94). If not, move those that are not daughters
+    // to the 94 instead, and set also the second daughter of the parent to the
+    // 94.
+ 
+    if ( k[i_py][2] == 94 && k[i_py][1] < 30 ) {
+       // A 94: treat that:
+       //   case 1: 2->2 , clear-cut connect in to out dirctly
+       //   case 2: 1->1+gamma : FSR, chnage 94 to 95, else unchanged.
+       //   case 3: 4->4, unique flavours, incomming has only 94 as daughter, outgoind only 94 as mother: : as case 1
+       //   case 4: as case 3, but flavours not unique: Check directions etc, then connect directly
+       //   case 5: 4->4, some weidness in parent-daughter relations: to study
+       //   case 6: n->m, n != m: to study
+       //   case 7: odd->m : Does that ever happen, except for the FSR case?
+       //   case 8: Anything else : Does that ever happen
+       //   case X: any of the above, but with intruders between first and last mother and/or daughter: to study
+       //
+
+      int mothers[10] ={0};
+      int daughters[10][10] ={0};
+
+      int line94 = i_py ;
+      if ( _whiz1 ) { stdhep_reader_bug_workaround(line94) ; }
+
+      int first_94_mother= k[line94][3];
+      int last_94_mother= k[line94][6];
+      int first_94_daughter =  k[line94][4];
+      int last_94_daughter =  k[line94][5];
+
+      int i_mo=0;
+      for ( int mother = first_94_mother ; mother <= last_94_mother; mother++ ) {
+        if ( (abs(k[mother][2]) == 24 && abs(k[k[mother][3]][2]) !=6 ) || k[mother][2]==23 || k[mother][2]==25 ) continue;
+        if ( abs(k[mother][4]) !=  line94 ) continue; // intruder, go to next line
+
+        i_mo++;
+        mothers[0]=i_mo;
+        mothers[i_mo]=mother;
+        int i_dau=0;	
+	daughters[i_mo][0]=0;
+        int pdg_mother=k[mother][2];
+        float p_mother[6];
+        for ( int ip=1; ip <=5 ; ip++ ) {
+          p_mother[ip]=p[mother][ip];
+        }
+
+        if ( k[mother][4] == line94 && k[mother][5] == line94 ) {
+
+            // normal case
+
+	  if ( _whiz1 ) { // Maybe useful not only for whiz1 ? If so, also should check k[][7:8] == 0
+            int n_94_mother = 0 ;
+            for ( int j_py = first_94_mother ; j_py <=  last_94_mother ; j_py++ ) {
+              if ( k[j_py][4] == line94 ) { n_94_mother++ ; }
             } 
-            if ( p1w ==0 && p2w == 0 ) {
-    	      streamlog_out(DEBUG3) << "  neither parent wrong  flavor-wise ?? " << std::endl;
-              streamlog_out(DEBUG3) << " "<<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-              streamlog_out(DEBUG3) << " " <<  line94  << " " << k[parent1 ][2] << " " <<  k[parent2 ][2]  << " " <<
-                                            k[kid1 ][2] << " " <<  k[kid2 ][2]  << std::endl;
-              streamlog_out(DEBUG3) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-              streamlog_out(DEBUG3) << std::endl ; if( streamlog_level(DEBUG3) ){ evnb_print=1;} 
-              k[line94][6] = 0;
-              k[parent2][4]= k[parent2][5]=0;
-            }
-          } else {
-  
-            // flavours OK - check direction
-  
-            double dirdiff1[4];
-            double dirdiff2[4];
-            double dirp1[4], dirk1[4], abspp1, abspk1;
-            double dirp2[4], dirk2[4], abspp2, abspk2;
-            abspp1= sqrt(p[ parent1][1]*p[ parent1][1]+p[ parent1][2]*p[ parent1][2]+ p[ parent1][3]*p[ parent1][3]);
-            abspk1= sqrt(p[ kid1][1]*p[ kid1][1]+p[ kid1][2]*p[ kid1][2]+ p[ kid1][3]*p[ kid1][3]);
-            abspp2= sqrt(p[ parent2][1]*p[ parent2][1]+p[ parent2][2]*p[ parent2][2]+ p[ parent2][3]*p[ parent2][3]);
-            abspk2= sqrt(p[ kid2][1]*p[ kid2][1]+p[ kid2][2]*p[ kid2][2]+ p[ kid2][3]*p[ kid2][3]);
-            dirp1[1]=p[ parent1][1]/abspp1; dirp1[2]=p[ parent1][2]/abspp1; dirp1[3]=p[ parent1][3]/abspp1;
-            dirk1[1]=p[ kid1][1]/abspk1; dirk1[2]=p[ kid1][2]/abspk1; dirk1[3]=p[ kid1][3]/abspk1;
-            dirp2[1]=p[ parent2][1]/abspp2; dirp2[2]=p[ parent2][2]/abspp2; dirp2[3]=p[ parent2][3]/abspp2;
-            dirk2[1]=p[ kid2][1]/abspk2; dirk2[2]=p[ kid2][2]/abspk2; dirk2[3]=p[ kid2][3]/abspk2;
-  
-            if (  k[ parent1 ][2] ==  k[ kid1 ][2] &&  k[ parent2 ][2] ==  k[ kid2 ][2] ) {
-              dirdiff1[1]=dirp1[1]-dirk1[1]; dirdiff1[2]=dirp1[2]-dirk1[2]; dirdiff1[3]=dirp1[3]-dirk1[3]; 
-              dirdiff2[1]=dirp2[1]-dirk2[1]; dirdiff2[2]=dirp2[2]-dirk2[2]; dirdiff2[3]=dirp2[3]-dirk2[3]; 
-              
-              if ( sqrt( dirdiff1[1]* dirdiff1[1] + dirdiff1[2]* dirdiff1[2] + dirdiff1[3]* dirdiff1[3] )  > 0.001 ) {
-                  // parent1 is wrong 
-    	        streamlog_out(ERROR) << " parent 1 is wrong direction-wise ?? " << std::endl;
-                streamlog_out(ERROR) << " "<<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-                streamlog_out(ERROR)  << " " << k[parent1 ][2] << " " <<  p[parent1 ][1]  << " " <<  p[parent1 ][2]  << " " <<  p[parent1 ][3]  << std::endl;
-                streamlog_out(ERROR)  << " " << k[kid1 ][2] << " " <<  p[kid1 ][1]  << " " <<  p[kid1 ][2]  << " " <<  p[kid1 ][3]  << std::endl;
-                streamlog_out(ERROR)  << " " << k[kid1 ][2] << " " <<  dirdiff1[1]  << " " <<  dirdiff1[2]  << " " <<  dirdiff1[3]  << std::endl;
-                streamlog_out(ERROR)  << " " <<  sqrt( dirdiff1[1]* dirdiff1[1] + dirdiff1[2]* dirdiff1[2] + dirdiff1[3]* dirdiff1[3] ) <<  std::endl;
-                streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(ERROR) << std::endl ; if( streamlog_level(ERROR) ){ evnb_print=1;}
-                k[line94][3] = 0;
-                k[parent1][4]= k[parent1][5]=0;
-  
-              } else if ( sqrt( dirdiff2[1]* dirdiff2[1] + dirdiff2[2]* dirdiff2[2] + dirdiff2[3]* dirdiff2[3] )  > 0.001 ) {
-    	        streamlog_out(DEBUG3) << " parent 2 is wrong direction-wise. " << std::endl;
-                streamlog_out(DEBUG3) << " "<<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-                streamlog_out(DEBUG3)  << " " << k[parent2 ][2] << " " <<  p[parent2 ][1]  << " " <<  p[parent2 ][2]  << " " <<  p[parent2 ][3]  << std::endl;
-                streamlog_out(DEBUG3)  << " " << k[kid2 ][2] << " " <<  p[kid2 ][1]  << " " <<  p[kid2 ][2]  << " " <<  p[kid2 ][3]  << std::endl;
-                streamlog_out(DEBUG3)  << " " << k[kid2 ][2] << " " <<  dirdiff2[1]  << " " <<  dirdiff2[2]  << " " <<  dirdiff2[3]  << std::endl;
-                streamlog_out(DEBUG3)  << " " <<  sqrt( dirdiff2[1]* dirdiff2[1] + dirdiff2[2]* dirdiff2[2] + dirdiff2[3]* dirdiff2[3] ) <<  std::endl;
-                streamlog_out(DEBUG3) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(DEBUG3) << std::endl ; if( streamlog_level(DEBUG3) ){ evnb_print=1;}
-                k[line94][6] = 0;
-                k[parent2][4]= k[parent2][5]=0;
+	    if ( n_94_mother == 2 ) {
+	      if ( k[mother][2] > 0 ) {
+	         k[mother][7] = i_py ; k[mother][8] = 0 ;
+	         k[k[mother][3]][7] = i_py ; k[k[mother][3]][8] = 0 ;
               } else {
-                streamlog_out(ERROR) << " However, I can't find what exactly was wrong. " << std::endl ; 
-                streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(ERROR) << std::endl ; evnb_print=1;
-                // all OK
-              } 
-            } else if (  k[ parent1 ][2] ==  k[ kid2 ][2] &&  k[ parent2 ][2] ==  k[ kid1 ][2] ) {
-              dirdiff1[1]=dirp1[1]-dirk2[1]; dirdiff1[2]=dirp1[2]-dirk2[2]; dirdiff1[3]=dirp1[3]-dirk2[3]; 
-              dirdiff2[1]=dirp2[1]-dirk1[1]; dirdiff2[2]=dirp2[2]-dirk1[2]; dirdiff2[3]=dirp2[3]-dirk1[3]; 
-              if (  sqrt( dirdiff1[1]* dirdiff1[1] + dirdiff1[2]* dirdiff1[2] + dirdiff1[3]* dirdiff1[3] )  > 0.001 ) {
-                  // parent1 is wrong 
-                streamlog_out(ERROR) << " parent 1 is wrong direction-wise ?? " << std::endl;
-                streamlog_out(ERROR) << " "<<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-                streamlog_out(ERROR)  << " " << k[parent1 ][2] << " " <<  p[parent1 ][1]  << " " <<  p[parent1 ][2]  << " " <<  p[parent1 ][3]  << std::endl;
-                streamlog_out(ERROR)  << " " << k[kid2 ][2] << " " <<  p[kid2 ][1]  << " " <<  p[kid2 ][2]  << " " <<  p[kid2 ][3]  << std::endl;
-                streamlog_out(ERROR)  << " " << k[kid2 ][2] << " " <<  dirdiff1[1]  << " " <<  dirdiff1[2]  << " " <<  dirdiff1[3]  << std::endl;
-                streamlog_out(ERROR)  << " " <<  sqrt( dirdiff1[1]* dirdiff1[1] + dirdiff1[2]* dirdiff1[2] + dirdiff1[3]* dirdiff1[3] ) <<  std::endl;
-                streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(ERROR) << std::endl ; if( streamlog_level(ERROR) ){ evnb_print=1;}
-  
-                k[line94][3] = 0;
-                k[parent1][4]= k[parent1][5]=0;
-  
-              } else if (  sqrt( dirdiff2[1]* dirdiff2[1] + dirdiff2[2]* dirdiff2[2] + dirdiff2[3]* dirdiff2[3] )  > 0.001 ) {
-                streamlog_out(DEBUG3) << " parent 2 is wrong direction-wise. " << std::endl;
-                streamlog_out(DEBUG3) << " "<<  line94  << " " << parent1 << " " <<  parent2  << " " <<kid1 << " " <<  kid2  << std::endl;
-                streamlog_out(DEBUG3)  << " " << k[parent2 ][2] << " " <<  p[parent2 ][1]  << " " <<  p[parent2 ][2]  << " " <<  p[parent2 ][3]  << std::endl;
-                streamlog_out(DEBUG3)  << " " << k[kid1 ][2] << " " <<  p[kid1 ][1]  << " " <<  p[kid1 ][2]  << " " <<  p[kid1 ][3]  << std::endl;
-                streamlog_out(DEBUG3)  << " " << k[kid1 ][2] << " " <<  dirdiff2[1]  << " " <<  dirdiff2[2]  << " " <<  dirdiff2[3]  << std::endl;
-                streamlog_out(DEBUG3)  << " " <<  sqrt( dirdiff2[1]* dirdiff2[1] + dirdiff2[2]* dirdiff2[2] + dirdiff2[3]* dirdiff2[3] ) <<  std::endl;
-                streamlog_out(DEBUG3) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(DEBUG3) << std::endl ; if( streamlog_level(DEBUG3) ){ evnb_print=1;}
-  
-                k[line94][6] = 0;
-                k[parent2][4]= k[parent2][5]=0;
-              } else {
-                streamlog_out(ERROR) << " However, I can't find what exactly was wrong. " << std::endl ; 
-                streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-                streamlog_out(ERROR) << std::endl ; if( streamlog_level(ERROR) ){ evnb_print=1;}
-                // all OK
-              } 
-            } else {
-              streamlog_out(ERROR) << " How could I arrive here ??? "  << std::endl;
-              streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-              streamlog_out(ERROR) << std::endl ; if( streamlog_level(ERROR) ){ evnb_print=1;}
+	         k[mother][7] = 0 ; k[mother][8] = i_py ;
+	         k[k[mother][3]][7] = 0 ; k[k[mother][3]][8] = i_py ;
+              }
+              int oma=mother;
+              while ( oma > 3 ) {
+	         k[oma][7] = k[mother][7] ; k[oma][8]=k[mother][8] ;
+                 oma=k[oma][3];
+              }
+	    }  
+	  } // endif ( _whiz1 )
+ 
+            // find the daughter that best matches the current mother
+
+          int best_match = 0;
+          double min_dist = 1.0e20;          
+          for ( int daughter=first_94_daughter ; daughter <=  last_94_daughter ; daughter++ ) { 
+            if ( k[daughter][2] == pdg_mother ) {
+              double dist=((p_mother[1]-p[daughter][1])*(p_mother[1]-p[daughter][1]) +
+                           (p_mother[2]-p[daughter][2])*(p_mother[2]-p[daughter][2]) +
+                           (p_mother[3]-p[daughter][3])*(p_mother[3]-p[daughter][3]));
+              if ( dist < min_dist ) {
+                best_match=daughter;
+                min_dist=dist;
+              }
             }
           }
-          if( evnb_print==0 ) {
-            streamlog_out(WARNING) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-            streamlog_out(WARNING) << std::endl ; 
+
+          if ( best_match == 0 ) {
+            streamlog_out(ERROR)  << " No best match ... " << std::endl;
+          } else {
+
+            i_dau++;
+            daughters[i_mo][0]=i_dau;
+            daughters[i_mo][i_dau]=best_match;
+
+          } 
+
+        } else {  // mother has several daughters, find the daughter that has the same pdg as the mother (actually an intruder)
+
+          bool found_daughter = false ;
+          for ( int daughter=k[mother][4]  ; daughter <=  k[mother][5] ; daughter++ ) {
+            if ( k[daughter][3] == mother && daughter != line94 ) {
+              found_daughter = true;
+              i_dau++;
+              daughters[i_mo][0]=i_dau;
+              daughters[i_mo][i_dau]=daughter;
+            }
+          }
+
+          if ( ! found_daughter ) {
+            streamlog_out(ERROR)  << " Only daughter of the mother of a 94 is neither the 94, "
+                                    <<"nor a particle with same pdg as the mother " << std::endl;
+          }
+        }
+
+        if (daughters[i_mo][0] == 0 ) {
+          streamlog_out(ERROR)  << " Did not find any daughters to the mother of a 94" << std::endl;
+        } 
+      }
+
+        // Here all is sorted out, update the found history relations.
+
+      for ( int j_mo=1 ; j_mo <= mothers[0] ; j_mo++ ) {
+
+        int mother=mothers[j_mo];
+
+        for ( int j_dau=1 ; j_dau <= daughters[j_mo][0] ; j_dau++ ) {
+          int daughter=daughters[j_mo][j_dau];
+          if ( j_dau == 1 ) k[mother][4]=daughter;
+          k[mother][5]=daughter;
+          k[daughter][3]=mother;
+        }
+
+      }
+    }  // endif this is a 94 line  
+  } // for all lines
+
+  streamlog_out(DEBUG3)  << " HEPEVT relation table, after 94 fixing"  <<std::endl;
+  streamlog_out(DEBUG3)  << "       line      status    pdg       parent    first     last     second             anti   " << std::endl;
+  streamlog_out(DEBUG3)  << "                                             daughter daugther    parent   colour   coulour " << std::endl;
+
+  for ( int j_py=1 ; j_py<=nlund ; j_py++ ) {
+     streamlog_out(DEBUG3)  << std::setw(10) << j_py << std::setw(10) <<  k[j_py][1] << 
+                 std::setw(10) <<  k[j_py][2] << std::setw(10) <<  k[j_py][3] << 
+                 std::setw(10) <<  k[j_py][4] << std::setw(10) << k[j_py][5]  << std::setw(10) << k[j_py][6] << 
+                 std::setw(10) <<  k[j_py][7] << std::setw(10) << k[j_py][8] << std::endl;
+  }
+} 
+
+void TrueJet::stdhep_reader_bug_workaround( int line94 )
+{
+  int first_94_mother= k[line94][3];
+  int last_94_mother= k[line94][6];
+  int first_94_daughter =  k[line94][4];
+  int last_94_daughter =  k[line94][5];
+
+
+
+  bool inconsitent_pid =
+    (( k[first_94_daughter][2] != k[first_94_mother][2] && k[first_94_daughter][2] != k[last_94_mother][2] ) ||  // inconsistent pdgs
+     ( k[ last_94_daughter][2] != k[first_94_mother][2] && k[ last_94_daughter][2] != k[last_94_mother][2] )) ;
+
+  bool inconsitent_E =
+    ( abs((p[last_94_mother][4]+p[first_94_mother][4]) -p[line94][4])/p[line94][4] > 0.001 ) ;  // inconsitent E
+
+  bool gluon_daughters = (  k[first_94_daughter][2] == 21 || k[last_94_daughter][2] == 21 ) ; // 94->gluons is OK as is.
+
+  if ( ( inconsitent_pid || inconsitent_E ) && ( ! gluon_daughters )) {
+    int right_mother = 0 ;
+    int sought_mother = 0 ;
+    int new_mother = 0; 
+    bool first = true;
+    while ( 1 ) {
+
+
+      if ( first ) {
+        right_mother = first_94_mother;
+      } else {
+        right_mother = last_94_mother;
+      }
+
+      if ( first ) {
+        if ( inconsitent_pid ) {
+          if ( k[first_94_daughter][2]*k[last_94_daughter][2] > 0 ) {
+
+            streamlog_out(ERROR)  << " 94 DAUGHTERS wrong of 94 on line " << line94 
+                                    << " : both fermions or both anti-fermions " <<std::endl;
+            // Probably does not happen ...
+
+          } else if ( k[first_94_mother][2]*k[last_94_mother][2] > 0 ) {
+
+            streamlog_out(DEBUG4)  << " 94 MOTHERS wrong of 94 on line " << line94 
+                                     << " : both fermions or both anti-fermions " <<std::endl;
+
+            // In this case, already the particle or antiparticle nature of the daughter tells 
+            // us the mother of which particle we need
+            // to find in the record to correct things.
+
+          } else {
+
+            streamlog_out(ERROR)  << " 94 on line " << line94 << " is wrong : differnt PDGs, but both mothers and daughters are "
+                              << "fermions/anti-fermion pairs ???  " <<std::endl;
+            // Probably does not happen ...
+       
+          } 
+        } 
+      }
+      
+
+      if ( k[first_94_daughter][2] == k[right_mother][2] ) {  
+        sought_mother = last_94_daughter; 
+      } else {
+        sought_mother = first_94_daughter; 
+      }
+
+      new_mother = 0 ;
+      double target[5]={0};
+      for ( int jjj=1 ; jjj<=4 ; jjj++ ){target[jjj]=p[line94][jjj]-p[right_mother][jjj];}
+      for ( int search_line = line94-1 ; search_line >= 1 ; search_line-- ) {
+        if ( k[search_line][2] == k[sought_mother][2] ) {
+          if ( abs(p[search_line][1] - target[1])/ abs(target[1]) < 0.05 &&
+               abs(p[search_line][2] - target[2])/ abs(target[2]) < 0.05 &&
+               abs(p[search_line][3] - target[3])/ abs(target[3]) < 0.05    ) {
+            new_mother=search_line; 
+            break ;
           }
         }
       }
-    }
-  }
-    // end of a VERY tedious part to fix wrongly assigned oarents to 94:s sometimes done in the stdhep reader....
+      if ( new_mother != 0 ) { break ; }
+      if ( ! first ) { break ; }
+      first = false;
+    } // while ( 1 )
 
-  streamlog_out(DEBUG2) << " HEPEVT relation table"  <<std::endl;
-  streamlog_out(DEBUG2) << "       line      status    pdg       parent    first     last     second " << std::endl;
-  streamlog_out(DEBUG2) << "                                             daughter daugther    parent " << std::endl;
-  for ( int j=1 ; j<=nlund ; j++ ) {
-    streamlog_out(DEBUG2) << std::setw(10) << j << std::setw(10) <<  k[j][1] << 
-                 std::setw(10) <<  k[j][2] << std::setw(10) <<  k[j][3] << 
-                 std::setw(10) <<  k[j][4] << std::setw(10) << k[j][5]  << std::setw(10) << k[j][6] <<std::endl;
-  }
-} 
+
+    if ( new_mother == 0 ) {
+      streamlog_out(ERROR)  << " 94 on line " << line94 << " is wrong, but could not figure out un what way. " ;
+    } else {
+      if ( new_mother < right_mother ) {
+        first_94_mother = new_mother ; last_94_mother = right_mother ;
+      } else {
+        first_94_mother = right_mother ; last_94_mother = new_mother ;
+      }
+    }
+
+    k[line94][3] = first_94_mother ; k[line94][6] = last_94_mother ; 
+    k[first_94_mother][4] = line94 ;k[first_94_mother][5] = line94 ;
+    k[last_94_mother][4] = line94 ;k[last_94_mother][5] = line94 ;
+         
+  } // if(inconsitent_pid || inconsitent_E )
+}
 void TrueJet::true_lepton()
 {
-  int ihard_lepton_1[4011],CMshowers[4011], nCMshowers;
-  int ihard_lepton[4011];
-  int lept, gotit ;
-      //! count number of hard leptons. The condition is: it should be a lepton lepton (pdg 11 to 16). It is
-      //! hard either if it is  comming from line 3, or if comes from line 1, goes to a single daughter which
-      //! is an electron. (The second part is needed for beam-remenant electrons in odd-f events)
+  int ihard_lepton_1[4011]={0} ;
+  int ihard_lepton[4011]={0};
+  int lept=0;
+
+      //! count number of hard leptons. The condition is: it should be a lepton lepton (pdg 11 to 16). 
+      //! In whiz2, it is hard if the status of its parent is 21, or it comes from a W or a Z.
+      //! In whiz1, it is hard either if it is  comming from line 3, or if comes from line 1, goes to 
+      //! a single daughter which is an electron. (The second part is needed for beam-remenant 
+      //! electrons in odd-f events)
 
    n_hard_lepton = 0;
-   for ( int kk=1 ; kk<= nlund ; kk++ ) {
-     if ( ( abs(k[kk][2]) >= 11 && abs(k[kk][2]) <= 16 ) )  {
-       streamlog_out(DEBUG1) << " found lepton, kk = " << kk << ", k[kk][3] = " << k[kk][3] << ", k[3][3] = " << k[3][3] <<  std::endl ; 
-       if (
-//JL          ((k[kk][3] == 3) || (k[kk][3] == 1 && k[kk][4] ==k[kk][5] && abs(k[k[kk][5]][2])==11 ))) {
-// make sure that line 3 has a parent, thus it is not a parentless particle in Higgs sample
-//JL          ((k[kk][3] == 3 && k[3][3] > 0) || (k[kk][3] == 0 && kk > 2) || (k[kk][3] == 1 && k[kk][4] ==k[kk][5] && abs(k[k[kk][5]][2])==11 )))) {
-          ((k[kk][3] == 3 && k[3][3] > 0) || (k[kk][3] == -1) || (k[kk][3] == 1 && k[kk][4] ==k[kk][5] && abs(k[k[kk][5]][2])==11 ))) {
-         n_hard_lepton++;
-         ihard_lepton_1[n_hard_lepton]=kk;
-         ihard_lepton[n_hard_lepton]=0;
-         streamlog_out(DEBUG1) << "     hard according to condition 1 " << std::endl;
+   int start_loop=1;
+
+   if ( _top_event ) { // start looking for leptons after the last top - there are un-connected leptons before that to avoid!
+     for ( int k_py=nlund ; k_py>= 1 ; k_py-- ) {
+       if ( abs(k[k_py][2]) == 6 ) {
+         start_loop = k_py ;
+         break ;
        }
-       //JL also count leptons as hard if their mother or grandma is a Higgs boson
-       //JL necessary to protect into W bosons from semi-leptonic quark decays etc
-       else if (abs(k[k[kk][3]][2]) == 25 || ((abs(k[k[kk][3]][2]) == 24 || abs(k[k[kk][3]][2]) == 23) && abs(k[k[k[kk][3]][3]][2]) == 25)) {
+     } 
+   }
+ 
+   for ( int k_py= start_loop  ; k_py<= nlund ; k_py++ ) {
+     if ( ( abs(k[k_py][2]) >= 11 && abs(k[k_py][2]) <= 16 ) )  {
+       streamlog_out(DEBUG1) << " found lepton, k_py = " << k_py << ", k[k_py][3] = " 
+                               << k[k_py][3] << ", k[3][3] = " << k[3][3] <<  std::endl ; 
+       if (
+	   (( ! _whiz1 ) && ((k  [k[k_py][3]][1] == 21 ) || ( (abs(k [k[k_py][3]][2]) == 23 ||   
+                             abs(k [k[k_py][3]][2]) == 24 ) && k[k [k[k_py][3]][3]][1] == 21  )) ) ||
+           (   _whiz1 && ((k[k_py][3] == 3 && k[3][3] > 0) || (k[k_py][3] == -1) || 
+                          (k[k_py][3] == 1 && k[k_py][4] ==k[k_py][5] && abs(k[k[k_py][5]][2])==11 )))  ) {
+
          n_hard_lepton++;
-         ihard_lepton_1[n_hard_lepton]=kk;
+         ihard_lepton_1[n_hard_lepton]=k_py;
          ihard_lepton[n_hard_lepton]=0;
-         streamlog_out(DEBUG1) << "     hard according to condition 2 " << std::endl;
+         streamlog_out(DEBUG4) << " lepton on line " << k_py  <<" hard according to condition 1 " << std::endl;
+       }
+       else if (abs(k[k[k_py][3]][2]) == 25 || 
+          ((abs(k[k[k_py][3]][2]) == 24 || abs(k[k[k_py][3]][2]) == 23) && 
+            abs(k[k[k[k_py][3]][3]][2]) == 25)) { // lepton from higgs, or from H->ZZ*/WW*
+         n_hard_lepton++;
+         ihard_lepton_1[n_hard_lepton]=k_py;
+         ihard_lepton[n_hard_lepton]=0;
+         streamlog_out(DEBUG4) << " lepton on line " << k_py  <<" hard according to condition 2 " << std::endl;
+       }
+       else if ( k[k[k[k_py][3]][3]][1] == 22 && k[k_py][1] < 20 ) { // grandmother has code 22 (= incomming), 
+                                                                     // lepton has code < 20
+         n_hard_lepton++;
+         ihard_lepton_1[n_hard_lepton]=k_py;
+         ihard_lepton[n_hard_lepton]=0;
+         streamlog_out(DEBUG4) << " lepton on line " << k_py  <<" hard according to condition 3 " << std::endl;
+       }
+       else if ( _top_event && ( abs(k[k[k_py][3]][2]) == 24) ) { // ultimate ( via only W:s ) ancestor is a top quark
+	 int oma = k[k_py][3] ;
+	 while ( 1 ) {
+	   if ( oma < 3 ) break ;
+           if  ( abs(k[k[oma][3]][2]) == 24 ) {  
+             oma=k[oma][3] ;
+	   } else if (  abs(k[k[oma][3]][2]) == 6 ) {
+             n_hard_lepton++;
+             ihard_lepton_1[n_hard_lepton]=k_py;
+             ihard_lepton[n_hard_lepton]=0;
+             streamlog_out(DEBUG4) << " lepton on line " << k_py  <<" hard according to condition 4 " << std::endl;
+             break;
+           } else {
+             break ;
+           }
+         }
        }
      }
    }
+
+   // here n_hard_leptons is the number of hard leptons (i.e. directly from the initial state of from a boson).
+   // and ihard_lepton_1[..] contains the list of pyjets lines of these
+   
    if ( n_hard_lepton == 0 ) return ;
 
       //! Sort the leptons in "color singlets", ie. in groups of flavour/anti-flavour. In most events this is
       //! the order they come in, but in the case of all flavour being the same, it isn't
 
-   nCMshowers=0 ;
-   for ( int kk=1 ; kk<=nlund ; kk++ ) {
-     if ( k[kk][2] == 94 ) {
-       nCMshowers++;
-       CMshowers[nCMshowers]=kk;
-     }
-   }
+   // Outcome of this loop is the list of hard leptons in ihard_lepton which is ordered in pairs
+   // from the same boson, or if that cant't be figured out, by flavour - anti-flavour pairs.
 
-   int n_94_related=0 ;
-   for (int kk=1; kk <= nCMshowers ; kk++ ) {
-     int line=k[CMshowers[kk]][3];
-       // DO WHILE ( (.NOT. ANY (ihard_lepton_1(1:n_hard_lepton) == line )) .AND. line > 3 ) ; line=k(line,3) ; ENDDO
-     gotit=0;
-//JL     while ( line > 3 ) {
-//JL  include line 3 if parent is -1 (means has been set above because mother is missing)
-     while ( line > 3 || k[line][3] == -1) {
-       for ( int jj=1 ; jj <= n_hard_lepton ; jj++ ) {
-         if (  ihard_lepton_1[jj] == line ) { 
-           gotit=1 ; 
-         }
-       }
-       if ( gotit==1 ) {
-         break;
-       } else {
-         line=k[line][3];
-       }
-     }   
-//JL      if ( line <= 3 ) { continue ; }
-//JL  exclude line 3 if parent is -1 (means has been set above because mother is missing)
-     if ( line <= 3 && k[line][3] != -1) { continue ; }
-       // ll = transfer(maxloc( [(1,kk=1,n_hard_lepton)] ,(ihard_lepton_1(1:n_hard_lepton) == line)),ll) 
-     int ll=0;
-     for ( int jj=1 ; jj <= n_hard_lepton ; jj++ ) {
-       if ( ihard_lepton_1[jj] == line ) {
-         ll=jj;
-         break;
-       }
-     }
-     n_94_related=n_94_related+1;
-     ihard_lepton[n_94_related] =  ihard_lepton_1[ll]  ; ihard_lepton_1[ll]=0 ;
-     line=k[CMshowers[kk]][6];
-     gotit=0;
-//JL     while ( line > 3 ) {
-//JL  include line 3 if parent is -1 (means has been set above because mother is missing)
-     while ( line > 3 || k[line][3] == -1) {
-       for ( int jj=1 ; jj <= n_hard_lepton ; jj++ ) {
-         if (  ihard_lepton_1[jj] == line ) { 
-           gotit=1 ; 
-         }
-       }
-       if ( gotit==1 ) {
-         break;
-       } else {
-         line=k[line][3];
-       }
-     }   
-//JL     if ( line <= 3 ) { std::cout << " oups ! " << std::endl; }
-//JL  exclude line 3 if parent is -1 (means has been set above because mother is missing)
-     if ( line <= 3 && k[line][3] != -1) {  std::cout << " oups ! " << std::endl; }
-     for ( int jj=1 ; jj <= n_hard_lepton ; jj++ ) {
-       if ( ihard_lepton_1[jj] == line ) {
-         ll=jj;
-         break;
-       }
-     }
-     n_94_related=n_94_related+1;
-     ihard_lepton[n_94_related] =  ihard_lepton_1[ll]  ; ihard_lepton_1[ll]=0 ;
-   }
-
-
-   for (int kk= n_94_related+1; kk<=n_hard_lepton; kk++ ) {
-     if ( ihard_lepton[kk] == 0 ) {
-       for ( int ll=1; ll<=n_hard_lepton ; ll++ ) {
-         if ( ihard_lepton_1[ll] != 0 ) {
-           ihard_lepton[kk]= ihard_lepton_1[ll];
-           ihard_lepton_1[ll]= 0;
+   for (int j_lept= 1; j_lept<=n_hard_lepton; j_lept++ ) {
+     if ( ihard_lepton[j_lept] == 0 ) {
+       for ( int l_lept=1; l_lept<=n_hard_lepton ; l_lept++ ) {
+         if ( ihard_lepton_1[l_lept] != 0 ) {
+           ihard_lepton[j_lept]= ihard_lepton_1[l_lept];
+           ihard_lepton_1[l_lept]= 0;
            break ;
          }
        }
-       //flav= (k[ihard_lepton[kk]][2])>0 ? abs(k[ihard_lepton[kk]][2])-11 : -(abs(k[ihard_lepton[kk]][2])-11) ; flav=flav/2;
-       for ( int ll=1; ll <= n_hard_lepton ; ll++ ) {
-         if (  flavour(k[ihard_lepton_1[ll]][2]) == -flavour(k[ihard_lepton[kk]][2]) ) {
-           ihard_lepton[kk+1]=ihard_lepton_1[ll] ;
-           ihard_lepton_1[ll]=0 ;
-           break; 
+
+       int k_py = ihard_lepton[j_lept] ;
+       int n_hint = 0;
+       int n_boson = 0;
+       int hint_companion = 0 ;
+       int boson_companion = 0 ;
+       int fallback_companion = 0;
+       for ( int l_lept=1; l_lept <= n_hard_lepton ; l_lept++ ) {
+
+         int l_py = ihard_lepton_1[l_lept] ;
+
+         if (  flavour(k[l_py][2]) == flavour(k[k_py][2]) && k[l_py][2]*k[k_py][2] <0 ) { // consider only 
+                                                                                          // lepton-flavour/anti-lepton flavour groupings
+           if ( ( k[l_py][2] > 0 && k[l_py][7] ==  k[k_py][8] &&  k[l_py][7] != 0 )  || 
+                ( k[l_py][2] < 0 && k[l_py][8] ==  k[k_py][7] &&  k[l_py][8] != 0 ) ){// a hint on grouping (leptons from the same 94)
+             streamlog_out(DEBUG4) << " hint match for lepton on lines " << l_py << " and " << k_py << std::endl;
+             hint_companion =  l_lept;
+             n_hint++ ;
+           }
+           if ( k[l_py][3] == k[k_py][3] ) {
+             if (  k[k[l_py][3]][2] == 23 || k[k[l_py][3]][2] == 24 || k[k[l_py][3]][2] == 25 ) { // leptons from the same boson
+               streamlog_out(DEBUG4) << " boson match for lepton on lines " << l_py << " and " << k_py << std::endl;
+               boson_companion =  l_lept;
+               n_boson++;
+             } 
+             if ( k[l_py][7] == 0 && k[l_py][8]==0 &&  k[k_py][7] == 0 && k[k_py][8]==0 ) {// if no hint nor boson parent found, 
+                                                                                           // use this: at least it has the right flavour.
+               fallback_companion =  l_lept ;
+             }
+           }
+         }
+       }
+
+       if ( n_hint == 1 ) {
+
+         ihard_lepton[j_lept+1]= ihard_lepton_1[hint_companion] ; 
+         ihard_lepton_1[hint_companion]=0;
+
+       } else if (n_boson == 1 ) {
+
+         ihard_lepton[j_lept+1]=ihard_lepton_1[boson_companion] ; 
+         ihard_lepton_1[boson_companion]=0;
+
+       } else {
+
+         if ( n_hint > 1 || n_boson > 1 ) {
+           streamlog_out(DEBUG4)<< " Problem finding companion lepton to lepton on line " << k_py 
+                                 << " : n_boson = " << n_boson << " , n_hint = " << n_hint << std::endl;
+         }
+
+         if (fallback_companion != 0 ) { // no hint nor boson parent: take any lepton with the right 
+                                         // lepton flavour as companion
+
+           ihard_lepton[j_lept+1]=ihard_lepton_1[fallback_companion];
+           ihard_lepton_1[fallback_companion]=0;
+
          }
        }
      }
    }
+
+   // To summerise: at this point we have in ihard_lepton[1  - n_hard_lepton ] the pyjets line numbers of
+   // all found hard leptons. These can come directly from the in-state or from a boson. If they are involved in
+   // a CM-shower, the ones *going in* into it are the ones in  ihard_lepton.
+   
       //! assign to jets. Basically the jet is the index in the list, -ve if it later on goes into a
       //! 94, +ve otherwise.
 
-   for ( int  kk=1; kk<=n_hard_lepton ; kk++ ) {
+      // outcome of this loop is the -(jet number) for each hard lepton in jet[ (each hard-lepton pyjets-line) ] and the elementon
+      // of the corresponding jet elementon[jet] = hard-lepton pyjets-line. lept on exit will be the first post-CM shower
+      // incarnation of the lepton. 
 
-     lept = ihard_lepton[kk];
-     streamlog_out(DEBUG1) << " assigning leptons to jets: ihard_lepton[" << kk << "] = " << ihard_lepton[kk] << " and has PDG " << k[lept][2] << std::endl ; 
+   if (  n_hard_lepton%2 != 0  ) {
+     if ( abs(k[ihard_lepton[n_hard_lepton]][2]) != 22 ) {
 
-        // ! initially, set to -kk
+       // If there is an odd number of initial leptons or photons, possibly we are looking at an
+       // odd-fermion sample. In that case, assume - resonably - that the beam-remnant is the first 
+       // hard lepton seen. Make it the last instead. That way it will be the one not grouped.
+       //
+       // TODO: Keep an eye on this : gamma in ME (not tested) ? 
+       // Also: better condition for this case (best would be process-type from the run header)
 
-     jet[lept]=-(i_jet+kk);
-     //JL this is premature - set elementon below after checking for 94 daughters of leptons (tau's!)
-     //MB reverted that, the elementon should be as close as possible to the hard interaction; the check for 94:s is
-     //just to check if the jet-number should be positive or negative.
-     if ( k[lept][4] == k[lept][5] &&  k[lept][4] != 0 ) {
-       if ( k[ k[lept][4] ][2] == 94 ) {
-          elementon[i_jet+kk]=lept ;
-       } else {
-         elementon[i_jet+kk]=k[lept][4];  // Behold the beauty of my new word !
+       int beamrem=ihard_lepton[1];
+       for ( int  j_lept=2; j_lept<=n_hard_lepton ; j_lept++ ) {
+         ihard_lepton[j_lept-1]=ihard_lepton[j_lept];
        }
-     } else {
-       elementon[i_jet+kk]=lept ;
-     } 
-     fafp_last[i_jet+kk]=lept;  // so it goes when too specific variable names were choosen ...
+       ihard_lepton[n_hard_lepton]=beamrem;
+     }
+   }
+   for ( int  j_lept=1; j_lept<=n_hard_lepton ; j_lept++ ) {
 
-        // ! loop until either stable or 94 descendent found
+     lept = ihard_lepton[j_lept];
+     streamlog_out(DEBUG4) << " assigning leptons to jets: ihard_lepton[" << j_lept << "] = " << ihard_lepton[j_lept] 
+                           << " jet : " << current_jet+j_lept <<std::endl ; 
+   }
+   for ( int  j_lept=1; j_lept<=n_hard_lepton ; j_lept++ ) {
+
+     lept = ihard_lepton[j_lept];
+     streamlog_out(DEBUG4) << " assigning leptons to jets: ihard_lepton[" << j_lept << "] = " << ihard_lepton[j_lept] 
+                           << " and has PDG " << k[lept][2] << " jet : " << current_jet+j_lept<< std::endl ; 
+
+        // ! initially, set to -j_lept
+
+     jet[lept]=-(current_jet+j_lept);
+
+     fafp_last[current_jet+j_lept]=lept;  // so it goes when too specific variable names were choosen ...
+
+
+     if ( _top_event ) {  // we want to back-track the lepton to the top, so that jet grouping can group all top daughters into on "c.n."
+       int oma = lept ;
+       int fafp_top = 0;
+       while ( 1 ) {
+	 if ( oma < 3 ) break ;
+         if  ( abs(k[k[oma][3]][2]) == 24 ) {  
+           oma=k[oma][3] ;
+	 } else if (  abs(k[k[oma][3]][2]) == 6 ) {
+           fafp_top = k[oma][3]; 
+           oma=k[oma][3] ;
+         } else {
+           break ;
+         }
+       }
+       if ( fafp_top != 0 ) { fafp_last[current_jet+j_lept]=fafp_top; }
+     }
+
+        // ! loop until either stable descendent found
 
      while ( k[lept][2] != 94 && k[lept][1] != 1 && k[lept][4] == k[lept][5] ) {
        lept = k[lept][4] ;
      }
+   
+     streamlog_out(DEBUG2)<< " after looping to stable : " << lept << " " <<  k[lept][2] << std::endl;
 
-     if (  k[lept][2] == 94 ) {
-
-         // ! 94 decendant found. find which of the two daughters of the 94
-         // ! corresponds to the lepton we're considering in this iteration, and move
-         // ! to that line in pyjets
-
-       if (  k[k[lept][4]][2] == k[ihard_lepton[kk]][2] ) {
-         lept = k[lept][4];
-       } else if (  k[k[lept][5]][2] == k[ihard_lepton[kk]][2]  ) {
-         lept=k[lept][5];
-       } else {
-         streamlog_out(WARNING) << " WARNING: Error in hard lepton-finding " << std:: endl;
-         streamlog_out(WARNING) << lept << "  goes to " << k[lept][4] << " and "  << k[lept][5] << " which are " <<  k[k[lept][4]][2] << " and " <<  k[k[lept][5]][2]<< std:: endl;
-         streamlog_out(WARNING) << " ihard_lepton on " << ihard_lepton[kk] << " which is " <<  k[ihard_lepton[kk]][2] << std::endl ;
-         streamlog_out(WARNING) << " This means that the wrong guess for grouping of leptons to probable boson parent were made, due to an ambigous situation, " << std::endl ;
-         streamlog_out(WARNING) << " ie. jets are OK, but di-jets are not in the expected order. " << std::endl ;
-         streamlog_out(WARNING) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-         streamlog_out(WARNING) << std::endl ; 
+     while ( true ) {
+       int ida=0;
+       bool is_elementon = true ;
+       if ( k[lept][1] != 1 && ( k[lept][4] == k[lept][5] &&  k[lept][4] != 0 )) {
+         ida=k[lept][4] ; 
+         if ( k[ida][2] == k[lept][2] ) {
+	   is_elementon = false;
+         }
        }
+
+       if ( is_elementon ) {
+
+         jet[lept]=current_jet+j_lept ;
+         elementon[current_jet+j_lept]=lept ;
+	 break;
+       } else {
+
+         lept=ida ;
+
+       }
+
      }
 
-        // ! Here we know for sure that line lept in pyjets is a post-first-94-if-any lepton:
-        // ! set jet to +ve.
-     jet[lept]=i_jet+kk ;
-     //JL set elementon here after 94 check!
-     //MB: reverted
-   }
+   }  
 
-     // ! set jet for all further descendants of hard leptons . Don't change already set assignments,
-     
-   for ( int kk=1; kk<=nlund ; kk++ ) {
-     if ( jet[kk] == 0 && abs(jet[k[kk][3]]) > i_jet && abs(jet[k[kk][3]]) <= i_jet+n_hard_lepton ) {
+     // ! set jet for all further descendants of hard leptons . Don't change already set assignments. Never assign a jet to a 94.
+
+   for ( int k_py=1; k_py<=nlund ; k_py++ ) {
+     if ( jet[k_py] == 0 && k[k_py][2] != 94 && abs(jet[k[k_py][3]]) > current_jet && abs(jet[k[k_py][3]]) <= current_jet+n_hard_lepton ) {
 
          // ! this is indeed a descendant of a hard lepton 
-
-       jet[kk] = jet[k[kk][3]];
+       if ( k[k_py][1] == 1 ) {
+         jet[k_py] = abs(jet[k[k_py][3]]);
+         if ( k[k_py][2] == 22 && k[k[k_py][3] ][2] == k[elementon[jet[k_py]]][2] ) {
+           nfsr[jet[k_py]]++;
+         } 
+       } else { 
+         jet[k_py] = jet[k[k_py][3]];
+       } 
      }
    }
-   i_jet=i_jet+n_hard_lepton ;
-
+   current_jet=current_jet+n_hard_lepton ;
 
 }
+
 void TrueJet::cluster()
 {
-   int clus[4011];
-   int clu , jet1, jet2;
+   int clus[4011]={0};
+   int clu=0 , jet1=0, jet2=0;
 
    nclu=0;
-   for (int kk=1; kk<=nlund ; kk++ ) {
-     if ( k[kk][2] == 91 && k[kk][1] < 30  ) {
+   for (int k_py=1; k_py<=nlund ; k_py++ ) {
+     streamlog_out(DEBUG0) << " Checking cluster at " << k_py << " k[k_py][2], and k[k_py][1] : " <<   
+          " " << k[k_py][2] <<    " , " << k[k_py][1] <<                        std::endl;
+     if ( k[k_py][2] == 91 && k[k_py][1] < 30  ) {
+       streamlog_out(DEBUG4) << " cluster found at " << k_py <<std::endl;
        nclu++;
-       clus[nclu]=kk;
+       clus[nclu]=k_py;
      }
    }
    if ( nclu == 0 ) return;
@@ -1566,128 +1939,196 @@ void TrueJet::cluster()
        //! the mother of the cluster, and the second is the line after, or possibly
        //! a few linese later.
 
-     jet1=i_jet+2*(i_clu-1)+1 ; jet2= i_jet+2*(i_clu-1)+2;
+     jet1=current_jet+2*(i_clu-1)+1 ; jet2= current_jet+2*(i_clu-1)+2;
      elementon[jet1]=k[clu][3];
      elementon[jet2]=elementon[jet1];
      while ( k[elementon[jet2]+1][4] == clu ) {
        elementon[jet2]=elementon[jet2]+1;
      }
-
+     streamlog_out(DEBUG4) << " Assigning jets " << jet1 << " or " << jet2 
+                             << " to CLUSTER at " << clu << std::endl;
      assign_jet(jet1,jet2,clu) ;
 
    }
-   i_jet=i_jet+ 2*nclu;
+   current_jet=current_jet+ 2*nclu;
 
 }
+
+void TrueJet::photon()
+{
+   int phots[4011]={0};
+
+   nphot=0;
+   for (int k_py=1; k_py<=nlund ; k_py++ ) {
+     streamlog_out(DEBUG0) << " Checking photon at " << k_py << " k[k_py][2], and k[k_py][1] : " <<   
+          " " << k[k_py][2] <<    " , " << k[k_py][1] <<                        std::endl;
+     if ( k[k_py][2] == 22 && k[k_py][1] < 30  ) {
+       if ( ( ! _whiz1 ) && (k  [k[k_py][3]][1] == 21 ) ) {
+         nphot++;
+         phots[nphot]=k_py;
+         streamlog_out(DEBUG4) << " photon on line " << k_py  <<" hard according to condition 1 " << std::endl;
+       }
+       else if (abs(k[k[k_py][3]][2]) == 25 ) {
+         nphot++;
+         phots[nphot]=k_py;	 
+         streamlog_out(DEBUG4) << " photon on line " << k_py  <<" hard according to condition 2 " << std::endl;
+       }
+     }
+   }
+
+   if ( nphot == 0 ) return;
+
+   for ( int i_phot=1 ; i_phot<=nphot ; i_phot++ ) {
+
+      // ! jet assignment - index in the list. -ve if "decayimg", which might be the case
+      // ! for explicitly requested gammas.
+
+     elementon[current_jet+i_phot] =  phots[i_phot];
+     fafp_last[current_jet+i_phot] =  phots[i_phot];
+     if ( k[ phots[i_phot]][1] == 1 ) {
+       jet[ phots[i_phot]]=current_jet+i_phot;
+     } else {
+       jet[ phots[i_phot]]=-(current_jet+i_phot);
+     } 
+   }
+   for ( int  k_py=1; k_py<=nlund ; k_py++ ) {
+     if ( jet[k_py] == 0 && abs(jet[k[k_py][3]]) > current_jet && abs(jet[k[k_py][3]]) <= current_jet+nphot ) {
+  
+          //  ! this is indeed a descendant of a hard photon
+  
+       jet[k_py] = abs(jet[k[k_py][3]]);
+     }
+   }
+
+   current_jet=current_jet+ nphot;
+
+}
+
 void TrueJet::isr()
 {
-  int iisr[4011];
-   //   nisr = COUNT([ ( (ANY(k(kk,3)==[1,3]) .AND.  (k(kk,2)==22) &
-   //          .AND.(k(kk,4)==k(kk,5)) .AND. (k(k(kk,4),2) ==22)), kk=1,nlund)  ])
-   // index=[(kk,kk=1,nlund+10)]
-   // iisr = PACK(index(1:nlund),[ ( (ANY(k(kk,3)==[1,3]) .AND.  (k(kk,2)==22) &
-   //                     .AND.(k(kk,4)==k(kk,5)) .AND. (k(k(kk,4),2) ==22) ), kk=1,nlund)  ] )
+   int iisr[4011]={0};
+
    nisr=0;
-   for (int kk=1; kk<=nlund ; kk++ ) {
-     if ( (k[kk][3] == 1 || k[kk][3] == 3 || k[kk][3] == 0 ) &&  ( k[kk][2]==22 ) && (k[kk][4]==k[kk][5]) && (k[k[kk][4]][2] ==22) ) {
+   for (int k_py=1; k_py<=nlund ; k_py++ ) {
+     if  ( (( ! _whiz1 ) && ( (k[k_py][3] == 3 || k[k_py][3] == 4 ) &&  ( k[k_py][2]==22 ) && ( k[k_py][1] < 20 ) )) ||
+           ((  _whiz1  ) && ( (k[k_py][3] == 1 || k[k_py][3] == 3 || k[k_py][3] == 0 ) &&  ( k[k_py][2]==22 ) && 
+                              (k[k_py][4]==k[k_py][5]) && (k[k[k_py][4]][2] ==22) && (k[k[k_py][4]][1] != 0)  ) )){
        nisr++;
-       iisr[nisr] = kk ;
+       iisr[nisr] = k_py ;
      }
    }
    if ( nisr > 0 ) {
      // ! jet assignment - index in the list. -ve if "decayimg", which might be the case
      // ! for explicitly requested gammas.
-     for ( int kk=1 ; kk<=nisr ; kk++ ) {
-       elementon[i_jet+kk] =  iisr[kk];
-       if ( k[ iisr[kk]][1] == 1 ) {
-         jet[ iisr[kk]]=i_jet+kk;
+
+     for ( int j_isr=1 ; j_isr<=nisr ; j_isr++ ) {
+       elementon[current_jet+j_isr] =  iisr[j_isr];
+       fafp_last[current_jet+j_isr] =  iisr[j_isr];
+       if ( k[ iisr[j_isr]][1] == 1 ) {
+         jet[ iisr[j_isr]]=current_jet+j_isr;
        } else {
-         jet[ iisr[kk]]=-(i_jet+kk);
+         jet[ iisr[j_isr]]=-(current_jet+j_isr);
        }
      }
        
-     for ( int  kk=1; kk<=nlund ; kk++ ) {
-       if ( jet[kk] == 0 && abs(jet[k[kk][3]]) > i_jet && abs(jet[k[kk][3]]) <= i_jet+nisr ) {
+     for ( int  k_py=1; k_py<=nlund ; k_py++ ) {
+       if ( jet[k_py] == 0 && abs(jet[k[k_py][3]]) > current_jet && abs(jet[k[k_py][3]]) <= current_jet+nisr ) {
   
           //  ! this is indeed a descendant of an isr
   
-         jet[kk] = abs(jet[k[kk][3]]);
+         jet[k_py] = abs(jet[k[k_py][3]]);
        }
      }
-     i_jet=i_jet+nisr;
+     current_jet=current_jet+nisr;
    }
 }
+
 void TrueJet::string()
 {
-  int n_left, sstr,lquark,lstr, istr,str_nb,jet1,jet2,istr_previous,iback;
-  int str_index[4011], rev_index[4011];
+  int n_left=0, sstr=0,lquark=0,lstr=0, istr=0,str_nb=0,jet1=0,jet2=0,istr_previous=0,iback=0;
+  int str_index[4011]={0}, rev_index[4011]={0};
+
      //!! Move jets away to make room for string-induced ones at the lowest indicies
-       // 
-       //    tjet=0
-       //    WHERE ( jet /=0 ) tjet=sign(abs(jet)+2*nstr,jet) ; jet=tjet
-       //    elementon= EOSHIFT(elementon(1:njet),-2*nstr)
-       //    nfsr = EOSHIFT(nfsr(1:njet),-2*nstr)
-       //    hard = EOSHIFT(hard(1:njet),-2*nstr)
-       //    fafp_last= EOSHIFT(fafp_last(1:njet),-2*nstr)
-       //    boson = EOSHIFT(boson(1:njet),-2*nstr)
-       //    fafp_boson = EOSHIFT(fafp_boson(1:njet),-2*nstr)
 
-   for ( int kk=1 ; kk<=nlund ; kk++ ) {
-     rev_index[kk]=0;
-     if ( jet[kk] != 0 ) {
-       jet[kk]=(jet[kk]>0 ? jet[kk]+2*nstr : jet[kk]-2*nstr);
+   for ( int k_py=1 ; k_py<=nlund ; k_py++ ) {
+     rev_index[k_py]=0;
+     if ( jet[k_py] != 0 ) {
+       jet[k_py]=(jet[k_py]>0 ? jet[k_py]+2*nstr : jet[k_py]-2*nstr);
      }
    }
+
    if ( nstr > 0 ) {
-     for (int kk=njet ; kk>=1 ; kk-- ) {
-       elementon[kk+2*nstr]=elementon[kk] ; 
-       elementon[kk]=0;
-       nfsr[kk+2*nstr]=nfsr[kk] ; 
-       nfsr[kk]=0;
-       fafp_last[kk+2*nstr]=fafp_last[kk];
-       fafp_last[kk]=0;
-       boson[kk+2*nstr]=boson[kk];
-       boson[kk]=0;
-       fafp_boson[kk+2*nstr]=fafp_boson[kk];
-       fafp_boson[kk]=0;
+     for (int j_jet=njet-2*nstr ; j_jet>=1 ; j_jet-- ) {
+       elementon[j_jet+2*nstr]=elementon[j_jet] ; 
+       elementon[j_jet]=0;
+       nfsr[j_jet+2*nstr]=nfsr[j_jet] ; 
+       nfsr[j_jet]=0;
+       fafp_last[j_jet+2*nstr]=fafp_last[j_jet];
+       fafp_last[j_jet]=0;
+       boson[j_jet+2*nstr]=boson[j_jet];
+       boson[j_jet]=0;
+       fafp_boson[j_jet+2*nstr]=fafp_boson[j_jet];
+       fafp_boson[j_jet]=0;
      }
    }
 
-   i_jet=0 ; 
+   current_jet=0 ; 
 
         //! Decode the event record. First find the line of the first string,
         //! the last quark of the last string (lquark, at the line before the first string),
         //! the last string (lstr, the daughter of the lquark quark), and the number of strings (nstr).
   
-      //    str_index=PACK(=[(kk,kk=1,pjetss)],(jet(1:nlund)==0 .and. k(1:nlund,2) /= 91.and. k(1:nlund,2) /= 21))
-      //   
-      //    n_left=COUNT ( (jet(1:nlund)==0 .and. k(1:nlund,2) /= 91.and. k(1:nlund,2) /= 21) )
-      //    rev_index(1:nlund)=0 ; FORALL ( kk=1:n_left) rev_index(str_index(kk))=kk
-      //   
-      //    sstr = transfer(maxloc( [(1,kk=1,n_left)] ,( (92 == [ (k(str_index(kk),2),kk=1,n_left ) ] ) ) ),sstr) ; 
-      //    lquark=str_index(sstr-1) ;    lstr=K(lquark,4) ;  istr=lstr ; str_nb = nstr
 
+   for ( int k_py=1 ; k_py<= nlund ; k_py++ ) {
+     streamlog_out(DEBUG0) << " particle " << k_py << " with PDG " << k[k_py][2] 
+                           << " is assigned to jet " << jet[k_py] << std::endl;
 
-   n_left=0; sstr=0;
-   for ( int kk=1 ; kk<= nlund ; kk++ ) {
-     streamlog_out(DEBUG0) << " particle " << kk << " with PDG " << k[kk][2] << " is assigned to jet " << jet[kk] << std::endl;
-     if (jet[kk]==0 && k[kk][2] != 91 &&  k[kk][2] != 21 && k[kk][1] < 30 ){
+     if (jet[k_py]==0 && k[k_py][2] != 91  && k[k_py][2] != 94 &&  k[k_py][2] != 21 &&  k[k_py][2] != 23 &&  
+           k[k_py][2] != 24 &&  k[k_py][2] != 25 && k[k_py][1] < 30 ){ // only look for fermions or gammas (not already 
+                                                                       // assigned to jets because they are leptons, from 
+                                                                       // clusters, isr, whatever...) in the P.S.
        n_left++;
-       str_index[n_left]=kk;
-       rev_index[kk]=n_left;
-       if ( sstr == 0 &&  k[kk][2] == 92 ) {
+       str_index[n_left]=k_py;
+       rev_index[k_py]=n_left;
+       if ( sstr == 0 &&  k[k_py][2] == 92 ) {
          sstr=n_left;
        }
      }
    }     
+
+
+     // sstr is the index in str_index of the first 92 found, and lquark is the quark on the line before that.
+     // This is the last quark of the last string in the event.
+
    lquark=str_index[sstr-1];
-   if (k[k[lquark][4]][2] != 92 ) {
-     streamlog_out(ERROR) << " INFO: Non-contigous string ancestors (1)" << std::endl;
-     streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
-     streamlog_out(ERROR) << std::endl ; 
-  }
+
+   if (k[k[lquark][4]][2] != 92 ) { // there might be an intruder between the lquark and the first string. This is taken care of here
+     if ( ! _higgs_to_glue_glue ) {
+       int lll = lquark  ;
+       while ( lll >= k[str_index[sstr]][3] ) {
+         if ( k[lll][4] == str_index[sstr] ) {
+           break ;
+         } else {
+           lll-- ;
+         }
+       }
+       if ( lll >   k[str_index[sstr]][3] ) {
+         lquark = lll ;
+       } else { 
+         // FIXME  : this happens in H->glueglue, Need radical re-thinking for that.
+         streamlog_out(ERROR) << " INFO: Non-contigous string ancestors (1)" << std::endl;
+         streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
+         streamlog_out(ERROR) << std::endl ;
+       }
+     }  
+   }
+
+
+     // lstr is the last string and is the daughter of the last quark of the last string
+
    lstr=k[lquark][4] ;  istr=lstr ; str_nb = nstr ;
-   streamlog_out(DEBUG3) << "  sstr, lstr, lquark, i_jet, str_nb " << sstr << " " << lstr << " " << lquark  << " " << i_jet  << " " << str_nb << std::endl;
+   streamlog_out(DEBUG3) << "  sstr, lstr, lquark, current_jet, str_nb " << sstr << " " << lstr << " " 
+                         << lquark  << " " << current_jet  << " " << str_nb << std::endl;
 
         //! now the jet-assignment. Start by looking at the last string (lstr),
         //! stop once the first has been reached. decide if the particle should be
@@ -1696,14 +2137,20 @@ void TrueJet::string()
         //! between the two quark directions.
   
    while( istr >= str_index[sstr]) {
-  
-     streamlog_out(DEBUG0) << "calculating jet1/2 from i_jet = " << i_jet << ", str_nb = " << str_nb  << std::endl;
-     streamlog_out(DEBUG0) << "istr =  = " << istr << ", k[istr][3] = " << k[istr][3]  << ", lquark = " << lquark << std::endl;
-     jet1= i_jet+2*(str_nb-1)+1 ; jet2=i_jet+2*(str_nb-1)+2 ; elementon[jet1]=k[istr][3] ; elementon[jet2]=lquark ;
 
-     streamlog_out(DEBUG0) << "calling assign_jet with jet1, jet2 = " << jet1 << ", " << jet2 << std::endl;
-     assign_jet(jet1,jet2,istr) ;
+     streamlog_out(DEBUG1) << " calculating jet1/2 from current_jet = " << current_jet << ", str_nb = " << str_nb  << std::endl;
+     streamlog_out(DEBUG1) << " istr = " << istr << ", k[istr][3] = " << k[istr][3]  << ", lquark = " << lquark << std::endl;
 
+     jet1= current_jet+2*(str_nb-1)+1 ; jet2=current_jet+2*(str_nb-1)+2 ; 
+
+     elementon[jet1]=k[istr][3] ; elementon[jet2]=lquark ; // elementons: the last quarks before hadronisation, the ones
+                                                           // jet-numbering pivots around.
+
+     streamlog_out(DEBUG4) << " Assigning jets " << jet1 << " or " << jet2 << " to STRING at " << istr << std::endl;
+
+     assign_jet(jet1,jet2,istr) ;  // assigns jets *both* to ancestors and decendants of the elementons
+
+     streamlog_out(DEBUG4) << " Assigned jets " << std::endl; 
 
         //! the previous string is the mother of its hadrons, eg. the last one, which is
         //! on the line before the current string:
@@ -1712,14 +2159,14 @@ void TrueJet::string()
   
      istr_previous=istr ;
      iback=str_index[rev_index[istr]-1]  ; istr = k[iback][3] ;
-  
-     if ( istr < str_index[sstr] ) break ;
+     if ( istr < str_index[sstr] ) break ;   // before the py-line of the first string -> done
   
         //! back-up: end-quark of the previous string is the line before the start-quark
         //! of the present string:
-  
+
+     int lquark_start = str_index[rev_index[k[istr_previous][3]]-1]  ;
      lquark=str_index[rev_index[k[istr_previous][3]]-1]  ;
-  
+
      if ( k[lquark][4] != istr && lquark > 0 ) {
 
          //!! Once again the very unusual case: need to search for the end of the new string backwards
@@ -1731,11 +2178,17 @@ void TrueJet::string()
        while (  lquark>-1 && k[lquark][4] != istr ) {
          lquark=lquark-1;
        }
-       if ( lquark == 0 ) { 
-         streamlog_out(ERROR) << " ERROR: Quack ?! " << std::endl ;         
-         streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
-         streamlog_out(ERROR) << std::endl ; 
 
+       if ( lquark <= 0 ) {
+         lquark = lquark_start ;
+         while (  lquark<nlund && ( k[lquark][4] != istr || lquark == k[istr][3] )) {
+           lquark=lquark+1;
+         }
+         if ( lquark >=  nlund ) {
+           streamlog_out(ERROR) << " ERROR: Quack ?! " << std::endl ;         
+           streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
+           streamlog_out(ERROR) << std::endl ; 
+         }
        }
      }
  
@@ -1745,100 +2198,115 @@ void TrueJet::string()
   
    }
 }
-void TrueJet::assign_jet(int jet1,int jet2,int this_fafp)
+
+void TrueJet::assign_jet(int jet1,int jet2,int this_string)
 {
- double dir_diff[4];
- int first_p1, first_p2;
-  streamlog_out(DEBUG0) << "assign_jet: elementon[" << jet1 << "] = " << elementon[jet1] 
+   double dir_diff[4]={0};
+   int first_p1=0, first_p2=0;
+   streamlog_out(DEBUG4) << "   assign_jet: elementon[" << jet1 << "] = " << elementon[jet1] 
                                   << ", elementon[" << jet2 << "] = " << elementon[jet2] << std::endl;
   
+    // elementon is the last quark before hadronisation (i.e. either of the two going into to 92 objects).
+    // jet1/2 is the jet-number of that one. The output is first_p1/2 which is the first quark in the
+    // chain leading up to the elementon. fafp_last is the last quark before any 94 or boson (last in the sense
+    // of going back the history!)  - often the same as first_p, while nfsr is the number of FSRs in the jet, 
+    // boson is the line of any boson in the P.S. yieding a qqbar pair (typically a gluon), and fafp_boson is 
+    // the ultimate ancestor of the boson.
   
-  first_parton( elementon[jet1], jet1 , first_p1, fafp_last[jet1], nfsr[jet1], boson[jet1], fafp_boson[jet1]);
-  first_parton( elementon[jet2], jet2 , first_p2, fafp_last[jet2], nfsr[jet2], boson[jet2], fafp_boson[jet2]);
+   first_parton( elementon[jet1], jet1 , first_p1, fafp_last[jet1], nfsr[jet1], boson[jet1], fafp_boson[jet1]);
+   streamlog_out(DEBUG4) << " back in assign_jets for jet " << jet1 << " fafp_last = " <<  fafp_last[jet1] 
+                         << " nfsr = " << nfsr[jet1]<< " boson = " <<  boson[jet1]
+                         << " fafp_boson = " <<  fafp_boson[jet1] << std::endl;
+
+   first_parton( elementon[jet2], jet2 , first_p2, fafp_last[jet2], nfsr[jet2], boson[jet2], fafp_boson[jet2]);
+   streamlog_out(DEBUG4) << " back in assign_jets for jet " << jet2 << " fafp_last = " <<  fafp_last[jet2] 
+                         << " nfsr = " << nfsr[jet2]<< " boson = " <<  boson[jet2]
+                         << " fafp_boson = " <<  fafp_boson[jet2] << std::endl;
 
      //   !  difference between the two quark directions: one is at elementon(jet1), the
-     //   !  other is qyuark(jet2) = three lines of fortran, 20 lines of C++ ...
+     //   !  other is elementon(jet2) = three lines of fortran, 20 lines of C++ ...
+     //   !  The closest match will determine which elementon the final hadrons are assigned to
+     //   !  and hence the jet-numbering.
 
-   //  dir_diff(1:3) = p(elementon(jet2),1:3)/sqrt(sum( p(elementon(jet2),1:3)**2))- p(elementon(jet1),1:3)/ sqrt(sum(p(elementon(jet1),1:3)**2))
-   //   jet(k(fafp,4):k(fafp,5)) = jet2  
-   //   FORALL ( kk=k(fafp,4):k(fafp,5), (DOT_PRODUCT(dir_diff(1:3),p(kk,1:3)) <=0))  jet(kk)= jet1
 
-  double absp_1=0;
-  double absp_2=0;
+   double absp_1=0;
+   double absp_2=0;
 
-  for ( int kk=1; kk<=3 ; kk++ ) {
-   absp_1+=p[elementon[jet1]][kk]*p[elementon[jet1]][kk] ;
-   absp_2+=p[elementon[jet2]][kk]*p[elementon[jet2]][kk] ;
-  }
-  absp_1=sqrt(absp_1); 
-  absp_2=sqrt(absp_2); 
-  for ( int kk=1; kk<=3 ; kk++ ) {
-   dir_diff[kk]      = 
+   for ( int kk=1; kk<=3 ; kk++ ) {
+     absp_1+=p[elementon[jet1]][kk]*p[elementon[jet1]][kk] ;
+     absp_2+=p[elementon[jet2]][kk]*p[elementon[jet2]][kk] ;
+   }
+
+   absp_1=sqrt(absp_1); 
+   absp_2=sqrt(absp_2); 
+   for ( int kk=1; kk<=3 ; kk++ ) {
+     dir_diff[kk]      = 
        p[elementon[jet2]][kk]/absp_2-  p[elementon[jet1]][kk]/absp_1;
-  }
+   }
 
-   for (int kk=k[this_fafp][4]; kk<=k[this_fafp][5] ; kk++ ) {
-     double dot=0;
-     for ( int jj=1 ; jj<=3 ; jj++ ) {
-       dot+=dir_diff[jj]*p[kk][jj] ;
-     }
-     if ( dot <= 0. ) {
-       jet[kk] = jet1 ;
-     } else {
-       jet[kk] = jet2 ;
-     } 
-   } 
-   for ( int kk=k[elementon[jet2]][5]+1; kk <=nlund ; kk++ ) {
-     if ( jet[kk] == 0 && k[kk][1] < 30 ) {
-       jet[kk] = abs(jet[k[kk][3]]);
-       if (  k[kk][2] == 21 || abs( k[kk][2])<=6 ) {
-               //  can happen if a paricle decay is done by gluons (Ypsilon etc.)
-         jet[kk] = -jet[kk];
+   for (int k_py_had=k[this_string][4]; k_py_had<=k[this_string][5] ; k_py_had++ ) { // this loops over the first generation hadrons
+     if ( k[k_py_had][3] == this_string ) {
+       double dot=0;
+       for ( int jj=1 ; jj<=3 ; jj++ ) {
+         dot+=dir_diff[jj]*p[k_py_had][jj] ;
        }
+       if ( dot <= 0. ) {  // by projcting on the *difference* between the two elelementon directions,
+                           // one just need to check the sign to know which is closest!
+         jet[k_py_had] = jet1 ;
+       } else {
+         jet[k_py_had] = jet2 ;
+       } 
+     }
+   } 
+
+   for ( int k_py=k[elementon[jet2]][5]+1; k_py <=nlund ; k_py++ ) { // k[elementon[jet2]][5]+1 is the first
+                                                                     // hadron of the string (actually any of
+                                                                     // elementon[jet1/jet2][4/5] would do...)
+
+     if ( jet[k_py] == 0 && k[k_py][1] < 30 ) { // if not already assigned, and not overlay. NB that the first
+                                                // generation already was assigned above.
+       jet[k_py] = abs(jet[k[k_py][3]]);        // i.e. jet is the same as it's mother - fair enough !
+       if (  k[k_py][2] == 21 || abs( k[k_py][2])<=6 ) {
+               //  can happen if a paricle decay is done by gluons (Ypsilon etc.)
+         jet[k_py] = -jet[k_py];
+       }
+       if ( jet[k_py] != 0 ) streamlog_out(DEBUG1) << "     Particle " << k_py 
+              << " assigned to jet " << abs(jet[k[k_py][3]]) << std::endl;
      }
    }
 
 }
-void TrueJet::first_parton(int this_partic,int this_jet,int& first_partic,int& last_94_parent,int& nfsr_here,int& info,int& info2)
 
-//   INTEGER, INTENT(IN)  :: this_partic
-//   INTEGER, INTENT(IN)  :: this_jet
-//   INTEGER, INTENT(OUT) :: first_partic
-//   INTEGER, INTENT(OUT) :: last_94_parent
-//   INTEGER, INTENT(INOUT) :: nfsr
-//   INTEGER, INTENT(OUT) :: info
-//   INTEGER, INTENT(OUT) :: info2
+void TrueJet::first_parton(int this_partic,int this_jet,int& first_partic,int& last_94_parent,int& nfsr_here,int& info,int& info2)
 {
-   int this_quark,this_quark_save,quark_pdg,boson_ancestor,istat,boson_last_94_parent,istat2;
+   int this_quark=0,quark_pdg=0,boson_ancestor=0,istat=0,boson_last_94_parent=0,istat2=0;
 
    this_quark=this_partic;
    jet[this_quark]=-this_jet;
    quark_pdg=k[this_quark][2];
    
-   streamlog_out(DEBUG0) << "first_parton: this_quark = " << this_quark 
+   streamlog_out(DEBUG4) << "   first_parton: this_quark = " << this_quark 
                          << ",  quark_pdg = " <<  quark_pdg << std::endl;
                      
 
    last_94_parent =  0;
 
       //! back-track quarks to the begining of the event record, or until the quark-chain is broken
-      //! Beginning of record is hit when the parent of a quark is an electron, and the chain is
-      //! brocken if the parent of a quark is a gluon (21) or a W (24).
+      //! Beginning of record is hit when the parent of a quark is an electron, photon or a whizard inserted boson 
+      //! and the chain is brocken if the parent of a quark is a gluon (21) or a W (24, non-resonanc-insertion).
 
       //! start at this_quark, which might on entry actually be something else (a gluon or a W)
 
-//JL   while (  abs(k[k[this_quark][3]][2]) != 11 &&  abs(k[k[this_quark][3]][2]) != 21   &&  abs(k[k[this_quark][3]][2]) != 24  ) {
-// JL and what about Z?
    while (  k[this_quark][3] > 0 &&
-            abs(k[k[this_quark][3]][2]) != 11 &&  abs(k[k[this_quark][3]][2]) != 21   
-        &&  abs(k[k[this_quark][3]][2]) != 23 &&  abs(k[k[this_quark][3]][2]) != 24    &&  abs(k[k[this_quark][3]][2]) != 25  ) {
- 
-     streamlog_out(DEBUG0) << "start of while loop:  this_quark = " << this_quark 
+            abs(k[k[this_quark][3]][2]) != 11 &&  abs(k[k[this_quark][3]][2]) != 21    &&  abs(k[k[this_quark][3]][2]) != 22 
+        &&  abs(k[k[this_quark][3]][2]) != 23 &&  abs(k[k[this_quark][3]][2]) != 24    &&  abs(k[k[this_quark][3]][2]) != 25 ) {
+               // (this end-condition works both for whiz1 and whiz2)
+
+     streamlog_out(DEBUG3) << "     start of while loop:  this_quark = " << this_quark 
                            << ", its PDG = " << k[this_quark][2] 
                            << ", its parent = " << k[this_quark][3] 
                            << ", parent's PDG  = " << abs(k[k[this_quark][3]][2])  
                            << ", quark_pdg  = " << quark_pdg << std::endl;
-     this_quark_save =   this_quark ;
 
      //! step back in the history
 
@@ -1851,68 +2319,10 @@ void TrueJet::first_parton(int this_partic,int this_jet,int& first_partic,int& l
 
        quark_pdg=k[this_quark][2];
 
-       if ( quark_pdg == 94 ) {
-
-
-	    //! well, actually it wasn't a quark, but a 94. Need to step
-	    //! back one step further and find the right parent to go on following
-
-//JL         if ( abs(k[k[this_quark][3]][2]) == 24 ||  abs(k[k[this_quark][3]][2]) == 21 ) {
-         if ( abs(k[k[this_quark][3]][2]) == 24 ||  abs(k[k[this_quark][3]][2]) == 21 ) {
-
-	        //! first parent of the 94 was the boson => the quark is the second one:
-
-           this_quark=k[this_quark][6];
-         } else {
-
-	       //! and v.v.
-
-           this_quark=k[this_quark][3];
-         }
-
-	    //! get the right pdg for future stepping
-
-         quark_pdg=k[this_quark][2];
-
-       }
      } 
-     if (   k[this_quark][2] == 94 ) {
-       streamlog_out(DEBUG0) << "this_quark is a 94, its parent = " << k[this_quark][3] 
-                             << ", parent's PDG  = " << k[k[this_quark][3]][2]  
-                             << ", quark_pdg  = " << quark_pdg << std::endl;
 
-
-	 //! the current line is (still) a 94. Select which of the two parents of it
-	 //! is to be followed. It is the one with the right flavour. A special case
-	 //! is if the parents are tops: then we must either already be following a top -
-	 //! in which case there is no problem - or a b. In the latter case the right top
-	 //! to follow is the one with the right sign,
-        
-       if (  k[k[this_quark][3]][2] == quark_pdg ||
-               (abs(k[k[this_quark][3]][2]) == 6 &&
-		(k[k[this_quark][3]][2]>0 ? 5 : -5 ) ==  quark_pdg )) {
-
-         this_quark =  k[this_quark][3];
-       } else {
-         this_quark =  k[this_quark][6];
-       }
-
-       streamlog_out(DEBUG0) << "this_quark was a 94, new this_quark = " << this_quark
-                             << ", its PDG  = " << k[this_quark][2] << std::endl;
-
-            //! save this line - it might turnout to be the parent of the last 94 (looking 
-            //! towards the beginning of the history)
-
-       last_94_parent =  this_quark;
-       if (  this_quark ==  this_quark_save ) {
-        streamlog_out(ERROR) << " ERROR: didnt find parant of 94 ?! " << this_quark << std::endl;
-        streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
-        streamlog_out(ERROR) << std::endl ; 
-
-       }
-     }
 	    //! jet-assignment if requested. Set to -ve to indicate that we are in the
-	    //! oarton shower,
+	    //! parton shower,
 
      if ( this_jet != 0 ) {jet[this_quark]=-this_jet;}
 
@@ -1920,6 +2330,7 @@ void TrueJet::first_parton(int this_partic,int this_jet,int& first_partic,int& l
             //! the photon has the same mother, it is an FSR
 
      if  ( k[this_quark+1][2] == 22 &&  k[this_quark+1][3] ==  k[this_quark][3] ) {
+
        streamlog_out(DEBUG5) << " FSR from  " << this_quark << std::endl;
        if ( this_jet != 0 ) {
 
@@ -1930,23 +2341,44 @@ void TrueJet::first_parton(int this_partic,int this_jet,int& first_partic,int& l
          nfsr_here=nfsr_here+1;
        }
      } 
-     streamlog_out(DEBUG0) << "  end of while loop: this_quark = " << this_quark 
+
+     streamlog_out(DEBUG3) << "     end of while loop: this_quark = " << this_quark 
                            << ", its PDG = " << k[this_quark][2] 
                            << ", its parent = " << k[this_quark][3] 
                            << ", parent's PDG  = " << abs(k[k[this_quark][3]][2])  
                            << ", quark_pdg  = " << quark_pdg << std::endl;
    }
 
-     //! we are here because we've reached the end of the chain. If this happened
-     //! becasue the parent was a boson, we recurse
+     // check if a boson parent is a "real" boson or a resonance insertion, which is flagged by the
+     // fact that the parent of the boson is a beam-particle (electron or photon), with status code 21,
+     // Resonance insertion were never done in Whiz1, so it is no problem that statuscode 21 is not
+     // assigned for Whiz1 - the condition should always evaluate to false, anyhow!
+     //
+     // We also stop in the parent of the boson is a higgs, both for Whiz1 and 2.
+   int resonance_insertion = 0;
+   streamlog_out(DEBUG3) << "     resonance_insertion check : " <<  abs(k[k[this_quark][3]][2]) << std::endl;
+   if ( abs(k[k[this_quark][3]][2]) == 23  || abs(k[k[this_quark][3]][2]) == 24 ) {
+     int lanc = k[k[this_quark][3]][3];
+     streamlog_out(DEBUG1) << "     lanc = " << lanc << " " << k[lanc][2] << " " << k[lanc][1] << std::endl ;
+     if ( ( ( abs(k[lanc][2]) == 11 || abs(k[lanc][2]) == 22 ) && k[lanc][1] == 21 ) ||
+          ( abs(k[lanc][2]) == 25    ) ){ // This is not a "real" boson, but a technical resonance insert
+       resonance_insertion = 1;
+     }
+   }
 
-   if ( abs(k[k[this_quark][3]][2]) == 21  || abs(k[k[this_quark][3]][2]) == 24 ) {
+   streamlog_out(DEBUG3) << "     resonance_insertion = " << resonance_insertion << std::endl;
+
+     //! we are here because we've reached the end of the chain. If this happened
+     //! becasue the parent was a boson radiated during the PS, we recurse. (Else we arrived at the
+     //! initial state and are done.)
+
+   if ( resonance_insertion == 0 && ( abs(k[k[this_quark][3]][2]) == 21  || abs(k[k[this_quark][3]][2]) == 24 )) {
        //! recurse.
 
        //! jet-number set to 0 => do not assign jet numbers anymore. The untimate first
        //! partic will go into boson_ancestor, parent of the last 94 into boson_last_94_parent.
 
-     streamlog_out(DEBUG0) << "in while loop calling first_parton with: k[this_quark][3] = " << k[this_quark][3] << std::endl;
+     streamlog_out(DEBUG3) << "     in while loop calling first_parton with: k[this_quark][3] = " << k[this_quark][3] << std::endl;
      first_parton(k[this_quark][3],0 ,boson_ancestor, boson_last_94_parent, nfsr_here, istat,istat2);
 
        //! the way this bottoms-out: second to last argument (istat in the call) is set to 0 if
@@ -1979,15 +2411,21 @@ void TrueJet::first_parton(int this_partic,int this_jet,int& first_partic,int& l
      info2=0;
 
    }
-   if ( last_94_parent == 0 )  {last_94_parent=k[this_quark][4];}
+
+   if ( last_94_parent == 0 )  {last_94_parent=this_quark;}
 
    first_partic = this_quark;
-
+      streamlog_out(DEBUG4) << "   first_parton, return:  = first_partic " << first_partic 
+                         << ",  last_94_parent = " <<  last_94_parent << std::endl;
+                     
 
 }
+
 int TrueJet::flavour(int k2)
 {
-   int k2l;
+  // note that flavour is a bit ambigous: for quarks it is the type of the quark (6 values in the SM),
+  // for leptons it is the family of the lepton (3 valuse in the SM). Here we mean "family" in both cases.
+   int k2l=0;
 
    if ( abs(k2)>16) return 0 ;
    if ( abs(k2) > 10 ) {
@@ -1998,538 +2436,313 @@ int TrueJet::flavour(int k2)
     return k2 > 0 ? k2l/2  : k2l/2 ;
     // sign(k2l/2,k2);
 }
-void TrueJet::grouping(){
 
+void TrueJet::grouping(){
    int ijet=0 ;
-   for ( int kk=1 ; kk<=njet ; kk++ ) {
-     tE[kk]=0;
+   for ( int k_jet=1 ; k_jet<=njet ; k_jet++ ) {
+     tE[k_jet]=0;
      for ( int i=0 ; i<3 ; i++ ) {
-          tmom[kk][i]=0. ;
+          tmom[k_jet][i]=0. ;
      } 
    }
-   for ( int i=1 ; i<=nlund ; i++){ 
-     if ( jet[i]>0 ) {
-       if ( k[i][1] == 11 ) {
+   for ( int i_py=1 ; i_py<=nlund ; i_py++){
+     if ( jet[i_py]>0 ) {
+       if ( k[i_py][1] == 11 ) {
          double Ekid=0;
-         for ( int jj=k[i][4] ; jj <= k[i][5] ; jj++ ) {
+         for ( int jj=k[i_py][4] ; jj <= k[i_py][5] ; jj++ ) {
            Ekid+= p[jj][4];
          }
-         if ( abs(Ekid-p[i][4])/p[i][4] > 0.001 ) {
-           streamlog_out(WARNING) << " Particle " << i << " has energy " << p[i][4] << 
+         if ( abs(Ekid-p[i_py][4])/p[i_py][4] > 0.001 ) {
+           streamlog_out(DEBUG3) << " Particle " << i_py << " has energy " << p[i_py][4] << 
                  " , but the sum of its genstat1 kids is " << Ekid << std::endl;
-           streamlog_out(WARNING) << " indicating that Geant did something fishy and un-documented in MCParticle " 
+           streamlog_out(DEBUG3) << " indicating that Geant did something fishy and un-documented in MCParticle " 
                 << std::endl ;
-           streamlog_out(WARNING) << " (Counter-meassures taken, so it should be OK.) " << std::endl ;
-           streamlog_out(WARNING) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl;
-           streamlog_out(WARNING) << std::endl ; 
+           streamlog_out(DEBUG3) << " (Counter-meassures taken, so it should be OK.) " << std::endl ;
+           streamlog_out(DEBUG3) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl;
+           streamlog_out(DEBUG3) << std::endl ;
+	   const double* v = mcp_pyjets[k[i_py][4]]->getVertex();
+           if ( v[0]*v[0] + v[1]*v[1] > 10. ) {
+             if ( k[i_py][1] < 30 ) {
+	         k[i_py][1]=1;
+             }
+             for ( int j_dau=k[i_py][4] ; j_dau <= k[i_py][5] ; j_dau++ ) {
 
-           if ( k[i][1] < 30 ) {
-             k[i][1]=1;
-           }
-           for ( int jj=k[i][4] ; jj <= k[i][5] ; jj++ ) {
-
-             if ( k[jj][1] < 30 ) {
-               k[jj][1]=0;
+               if ( k[j_dau][1] < 30 ) {
+		     k[j_dau][1]=0;
+               }
              }
            }
-       
          }
          
-       } else if  ( k[i][1] == 0 ) {
-         for ( unsigned idat=0 ; idat <   mcp_pyjets[i]->getDaughters().size()  ; idat++ ) {
-           int jdat=mcp_pyjets[i]->getDaughters()[idat]->ext<MCPpyjet>();
-           if ( k[jdat][1] < 30 ) {
-             k[jdat][1]=0;
+       } else if  ( k[i_py][1] == 0 ) {
+         for ( unsigned i_dau=0 ; i_dau <   mcp_pyjets[i_py]->getDaughters().size()  ; i_dau++ ) {
+           int j_dau=mcp_pyjets[i_py]->getDaughters()[i_dau]->ext<MCPpyjet>();
+           if ( k[j_dau][1] < 30 ) {
+             k[j_dau][1]=0;
            }
          }
          
        }
      }
    }
-   for ( int i=1 ; i<=nlund ; i++){ 
-     ijet=abs(jet[i]);
+   for ( int i_py=1 ; i_py<=nlund ; i_py++){ 
+     ijet=abs(jet[i_py]);
 
-     if ( k[i][1]%30 == 1 ) { // true quanaties for this jet (all true stable) NB. Checks HEPEVT code,
-                             // not wether there are daughters. This is right, since Mokka does not
+     if ( k[i_py][1]%30 == 1 ) { // true quanaties for this jet (all true stable) NB. Checks HEPEVT code,
+                             // not wether there are daughters. This is right, since Mokka/DDsim does not
                              // change the HEPEVT status in MCParticle, even if an interaction with
                              // seeable daughters takes place. To check: "un-used daughters", ie.
                              // the opposite case, where the generator has decayed a particle,
-                             // but the decay happens after Mokka has destroyed the parent.
+                             // but the decay happens after Mokka/DDsim has destroyed the parent.
                              // Also: generator-decays of longlived charged-particles: probaly
                              // (chek that) the MCParticle info is after application of the
                              // B-field, so the direction of the momentum has changed.
                              // [Finally: the crossing-angle. To what has it been applied? 
                              //  everything it seems, so that should be OK]
-       //if ( mcp_pyjets[i]->getGeneratorStatus() != 0 ) {
-         tmom[ijet][0]+=p[i][1] ;
-         tmom[ijet][1]+=p[i][2] ;
-         tmom[ijet][2]+=p[i][3] ;
-         tE[ijet]+=p[i][4] ;
-	 //}
-       }
-    }
-      //!!   Add info on jet-type to return (1=from string,2=lepton,3=from cluster,4=isr + x00=comes from boson, 
-      //!!   boson from jet x) and indication of the companion. 
 
-      //   type=[(1,kk=1,2*nstr),(2,kk=2*nstr+1, 2*nstr+n_hard_lepton),(3,kk=2*nstr+n_hard_lepton+1, 2*nstr+n_hard_lepton+2*nclu), 4,kk=2*nstr+n_hard_lepton+2*nclu+1,njet)]
-      //   FORALL (kk=1:njet-nisr) companion(kk)=kk+1
-      //   FORALL (kk=1:njet-nisr,( MODULO(kk,2) == 0 )) companion(kk)=kk-1
-      //  ! initial color-singlett
-      //    WHERE ( fafp_boson(1:njet) /= 0 ) 
-      //      fafp(1:njet) = fafp_boson(1:njet)
-      //    ELSEWHERE
-      //      fafp(1:njet) = fafp_last(1:njet)
-      //    ENDWHERE
+         tmom[ijet][0]+=p[i_py][1] ;
+         tmom[ijet][1]+=p[i_py][2] ;
+         tmom[ijet][2]+=p[i_py][3] ;
+         tE[ijet]+=p[i_py][4] ;
 
-
-    for ( int kk=1 ; kk <= njet ; kk++ ) {
-      if ( kk <= 2*nstr ){
-       type[kk]=1;
-      } else if ( kk<= 2*nstr+n_hard_lepton ){
-       type[kk]=2;
-      } else if ( kk<=  2*nstr+n_hard_lepton+2*nclu ){
-       type[kk]=3;
-      } else if ( kk<= 2*nstr+n_hard_lepton+2*nclu+nisr ){
-       type[kk]=4;
-      } else if ( kk<= njet ){
-       type[kk]=5;
-      } 
-      if ( boson[kk] != 0 ) {
-        type[kk]=abs(jet[boson[kk]])*100+type[kk];
-      }
-      if ( fafp_boson[kk] != 0 ) {
-        fafp[kk]=fafp_boson[kk];
-        if ( k[ fafp_boson[kk] ] [4] != 0 ) {
-          if ( k [k[ fafp_boson[kk] ] [4]][2] != 94 ) {
-            fafp[kk]=fafp_last[kk];
-          }
-        }
-      } else {
-        fafp[kk]=fafp_last[kk];
-      }
-
-    }
-    for  (int kk=1 ; kk<=njet-nisr-n_beam_jet; kk++) {
-      if ( kk%2 == 0 ) {
-        companion[kk]=kk-1;
-      } else {
-        companion[kk]=kk+1;
-      }
-    }
-
-
-      
-
-    n_djb = 0 ;       
-    n_dje = 0;  
-    //int dijet_end[26] ; 
-    //int group[26][26] ; int dijet_begining[26] ; 
-     // FORALL (KK=1:njet) group(0,kk) = COUNT((k(fafp(1:njet),4)==k(fafp(kk),4) .AND.k(fafp(kk),4) /= 0  ))
-     // FORALL (kk=1:njet) group(1: group(0,kk) ,kk) = pack(index(1:njet),(k(fafp(1:njet),4)==k(fafp(kk),4) .AND.k(fafp(kk),4) /= 0 ))
-    for ( int kk=1 ; kk<= njet ; kk++ ) {
-      group[0][kk]=0;
-      for ( int jj=1 ; jj<= njet ; jj++ ) {
-   
-        if (k[fafp[jj]][4]==k[fafp[kk]][4] && k[fafp[kk]][4] != 0  ) {
-          group[0][kk]++;
-          group[group[0][kk]][kk] = jj;
-        }
-      }
-    }
-
-    for ( int  kk=1; kk<= njet ; kk++ ){
-      if ( type[kk]%100 <= 3 ) {
-        //!  possible special case: the original fermions goes directly into the final string, without
-        //!  passing a 94 (first condition) or there is no copy, ie. the first f-anti-f pair already is the elementon
-        if ( group[0][kk] <= 1 ) {
-          if ( ( k[fafp[kk]][4] == elementon[kk] && k[fafp[companion[kk]]][4] == elementon[companion[kk]] ) ||
-               ( fafp[kk]  == elementon[kk] && fafp[companion[kk]] == elementon[companion[kk]]) ) {
-            //! ... this is the case
-           group[0][kk]=2 ;  group[0][companion[kk]]=2 ; 
-           group[1][kk] = std::min(kk,companion[kk]);
-           group[2][kk] = std::max(kk,companion[kk]) ;
-           group[1][companion[kk]] = std::min(kk,companion[kk]);
-           group[2][companion[kk]] = std::max(kk,companion[kk]) ;
-          }
-        }
-      }
-    }
-
-      //! figure out the different jet combinations. (If there are no bosons, it's straigh forward:
-      //! it's just the odd+even combinations. Also if one only cares about the final singlet
-      //! the same aplies, boson or not)
-
-    for ( int kk=1; kk<=njet ; kk++ ) {
-      dijet_begining[kk] = 0;
-        // DO jj=1,n_djb
-        //   IF ( ALL(group(1:group(0,kk),kk)==jets_begin(1:group(0,kk),jj)) )  dijet_begining(kk) = jj
-        // ENDDO
-      if ( group[0][kk] > 0 )  {
-        for ( int  jj=1; jj<=n_djb ; jj++ ) {
-          int gotit=1;
-          for ( int ii=1 ; ii<= group[0][kk] ; ii++ ) {
-            if  ( ! (group[ii][kk]==jets_begin[ii][jj] )) {
-              gotit=0;
-            }
-          }
-          if ( gotit ) {
-            dijet_begining[kk] = jj;
-          }
-        }
-      }
-      if ( dijet_begining[kk] == 0 && group[0][kk] > 0 ) {
-        n_djb++;
-        dijet_begining[kk] = n_djb;
-        for ( int jj=0 ; jj<= group[0][kk] ; jj++ ){
-          jets_begin[jj][n_djb] = group[jj][kk];
-        }
-      }
-      dijet_end[kk] = 0;
-      for ( int jj=1 ; jj<=n_dje ; jj++ ) {
-        if ( std::min(kk,companion[kk])==jets_end[1][jj] &&
-             std::max(kk,companion[kk])==jets_end[2][jj] ) {
-          dijet_end[kk] = jj;
-        }
-      }
-      if ( dijet_end[kk] == 0 ) {
-        n_dje++;
-        dijet_end[kk] = n_dje; 
-        if ( companion[kk] > 0 ) {
-          jets_end[1][n_dje] = std::min(kk,companion[kk]);
-          jets_end[2][n_dje] = std::max(kk,companion[kk]);
-          jets_end[0][n_dje] = 2 ;
-        } else {
-          jets_end[1][n_dje] = kk;
-          jets_end[0][n_dje] = 1;
-        }
-      }
-    }   
-
-    nboson=0;n_jetless=0; n_0_E_jets=0; n_2jet_clu=0;
-    for ( int kk=1 ; kk<=njet ; kk++ ) {
-      if (type[kk]/100 != 0 ){
-        nboson++;
-      }
-      if (tE[kk]<0.000001 ) {
-	n_0_E_jets++;
-      }
-      if ( jet[kk]==0 && k[kk][1]==1 ) {
-	n_jetless++;
-      }
-      if ( (type[kk]%100== 3) && ( tE[kk]> 0.0000001 ) &&
-	   ( tE[companion[kk]] >  0.0000001)) {
-	n_2jet_clu++;
-      }
-    }
-    n_mixed=0;
-    for ( int kk=1 ; kk<=njet-1 ; kk+=2 ) {  
-      if ((type[kk]%100==1) &&
-          ( (k[fafp[kk]][4] !=  k[fafp[kk+1]][4]) && ( k[fafp[kk]][4] != elementon[kk]  ||  k[fafp[kk+1]][4] != elementon[kk+1]  ) ) ) {
-	n_mixed++;
-      }
-    }  
-    //   jsum=jets_summary_t(njet,n_djb,n_dje,2*nstr, n_hard_lepton, nboson,  2*nclu,nisr , n_mixed,  n_jetless, n_2jet_clu, n_0_E_jets,jt(1:njet),dijb(1:n_djb),dije(1:n_dje)) 
-
-}
-
-void TrueJet::fix94()
-{ int nodd, line , nCMshowers, nCandidate_94s;
-  int odd_lines[4011];
-  int  CMshowers[4011];
-  int  Candidate_94s[4011];
-
-  first_line=1;
-  fix_top() ;
-  //  nodd=COUNT((K(first_line:nlund,1)==11 .AND. K(first_line:nlund,4)==0 .AND. K(first_line:nlund,2)/=21))
-  //  odd_lines=PACK ( index,(K(first_line:nlund,1)==11 .AND. K(first_line:nlund,4)==0 .AND. K(first_line:nlund,2)/=21 )) 
-  //  nCMshowers=COUNT((K(first_line:nlund,2)==94))
-  //  CMshowers=PACK ( index,(K(first_line:nlund,2)==94)) 
-
-   nodd = 0 ;  nCMshowers=0 ;
-   for ( int kk=first_line ; kk<=nlund ; kk++ ) {
-     if ( k[kk][1] == 11 && k[kk][4] == 0 && k[kk][2] != 21 ) {
-       nodd++;
-       odd_lines[nodd]=kk;
      }
-     if ( k[kk][2] == 94 ) {
-       nCMshowers++;
-       CMshowers[nCMshowers]=kk;
+   }
+      //!!   Add info on jet-type to return (1=from string,2=lepton,3=from cluster,4=isr,5=overlay,6=M.E. photon.
+      //!!   (+ x00=comes from boson, boson from jet x) and indication of the companion. 
+
+
+   for ( int k_jet=1 ; k_jet <= njet ; k_jet++ ) {
+     if ( k_jet <= 2*nstr ){
+       type[k_jet]=1;
+     } else if ( k_jet<= 2*nstr+2*nclu ){
+       type[k_jet]=3;
+     } else if ( k_jet<=  2*nstr+2*nclu+n_hard_lepton ){
+       type[k_jet]=2;
+     } else if ( k_jet<=  2*nstr+2*nclu+n_hard_lepton+nphot ){
+       type[k_jet]=6;
+     } else if ( k_jet<= 2*nstr+n_hard_lepton+2*nclu+nphot+nisr ){
+       type[k_jet]=4;
+     } else if ( k_jet<= njet ){
+       type[k_jet]=5;
+     } 
+     if ( boson[k_jet] != 0 ) {
+       type[k_jet]=abs(jet[boson[k_jet]])*100+type[k_jet];
+     }
+     if ( fafp_boson[k_jet] != 0 ) {
+       fafp[k_jet]=fafp_boson[k_jet];
+     } else {
+       fafp[k_jet]=fafp_last[k_jet];
+     }
+   }
+
+   for  (int k_jet=1 ; k_jet<=njet-nisr-n_beam_jet-nphot-n_hard_lepton%2 ; k_jet++) {
+     if ( k_jet%2 == 0 ) {
+       companion[k_jet]=k_jet-1;
+     } else {
+       companion[k_jet]=k_jet+1;
      }
    }
 
 
-  for ( int kk=1 ; kk<=nodd; kk++ ) {
-    line=odd_lines[kk];
-    //  nCandidate_94s=COUNT([( ( ANY( k(k(CMshowers(ipi),4:5),2) == k(line,2)) ),ipi=1,nCMshowers)])
-    //  Candidate_94s=PACK(CMshowers(1:nCMshowers),[( ( ANY( k(k(CMshowers(ipi),4:5),2) == k(line,2)) ),ipi=1,nCMshowers)])
-     nCandidate_94s=0 ;
-     for ( int ipi=1 ; ipi<=nCMshowers ; ipi++ ) {
-       if (  k[k[CMshowers[ipi]][4]][2] == k[line][2] ||  k[k[CMshowers[ipi]][5]][2] == k[line][2] ) {
-         nCandidate_94s++;
-         Candidate_94s[nCandidate_94s]=CMshowers[ipi] ;
-       }
+   // TODO: the following would be much simpler if the groups would be sets, not lists: then the
+   // order of the entries would not be important, and one would not need to explictly add
+   // k_jet to it's own group. In fact, except for top-events , any jets is always grouped with
+   // it's companion, so all what the following code is doing is to check is the initial c.n.
+   // jets connect to a jet which is not already it's companion...
+   // [In top events, where the initial b:s from the t decay are each-others companions, but should
+   // not be grouped - rather we want to group jets from the same top together into an "initial
+   // colour-neutral" - a misnomer in this case.]
+
+   for ( int k_jet=1 ; k_jet<= njet ; k_jet++ ) {
+     group[0][k_jet]=0;
+   }
+
+   for ( int k_jet=1 ; k_jet<= njet ; k_jet++ ) {
+     if ( type[k_jet] == 4 || type[k_jet] == 6  ) { // trivial grouping of photons
+       group[0][k_jet]=1 ;  group[1][k_jet]=k_jet ;
      }
-     //	std::cout << "  nCandidate_94s "<<  nCandidate_94s << std::endl;
-     if ( nCandidate_94s == 1 )  {
+     
+     if ( type[k_jet]%100 <= 3 ) {  // only group strings, clusters and hard leptons
 
-         if ( k[Candidate_94s[1]][3] != line ) {
-           k[Candidate_94s[1]][6] = line ;
-         } else {
-           for ( int ll=first_line ; ll<=nlund ; ll++ ) {
-             if ( k[ll][4] == Candidate_94s[1] ) {
-               k[Candidate_94s[1]][6] = ll;
-               break;
-             }
-           }
-         }
-         k[line][4] = Candidate_94s[1] ;
-         k[line][5] = Candidate_94s[1] ;
-       //  ! only one candidate, should be fine. 
-       //    But check, anyhow, that there is *some*
-       //         ! line that has this candiadte 94 as a daugter. If not, print a warning (has
-       //         ! never happend during my checks)
-       // !!!! 
-       //
-       //       IF ( COUNT(k(first_line:nlund,4)== Candidate_94s(1) ) == 1 ) THEN
-       //         k(line,4:5) = Candidate_94s(1)
-       //         second_parent(Candidate_94s(1)) = line
-       //       ELSE
-       //         print *, ' hum 1 ', COUNT(k(first_line:nlund,4)== Candidate_94s(1) ), Candidate_94s(1)
-       //       ENDIF    
-     } else {
-       int gotit=0; 
-       int mothers=0;
-       for ( int ipi=1; ipi<= nCandidate_94s ; ipi++ ){
-         // IF ( COUNT(k(first_line:nlund,4)== Candidate_94s(ipi) ) == 1 ) THEN
-           // mothers=PACK ( index,(K(first_line:nlund,4)==Candidate_94s(ipi)))
-         double Ekids=p[Candidate_94s[ipi]][4];
-         int nda=0 ;
-         for ( int jj=first_line ; jj<= nlund ; jj++ ) {
-           if ( k[jj][4] ==  Candidate_94s[ipi] ) {
-             nda++;
-             mothers=jj;
-           }
-         }
-         if ( nda == 1 ) {
+       bool k_lept=(abs(k[fafp[k_jet]][2])>=11 && abs(k[fafp[k_jet]][2])<=16);
 
-           //    ! ... this candidate 94 hasn't already two aughters, so it might be the one.
+       streamlog_out(DEBUG4) << std::endl;
+ 
+       for ( int j_jet=1 ; j_jet<= njet ; j_jet++ ) {
+         if ( type[j_jet]%100 <= 3 ) {  
 
-           double Eparents=p[mothers][4]+p[line][4] ;
-           if ( ((k[mothers][2]  == k[k[Candidate_94s[ipi]][4]][2] &&
-                 k[line][2]     == k[k[Candidate_94s[ipi]][5]][2] )  ||
-                 (k[mothers][2] == k[k[Candidate_94s[ipi]][5]][2] && 
-                 k[line][2]     == k[k[Candidate_94s[ipi]][4]][2] )) &&
-                 ( abs(Ekids- Eparents)/Ekids < 0.0001 ) ) {
+           bool j_lept=(abs(k[fafp[j_jet]][2])>=11 && abs(k[fafp[j_jet]][2])<=16);
 
-               // Right flavour, right mass : say no more
+	   // the reasons to group k_jet with j_jet:
 
-             if ( k[Candidate_94s[ipi]][3] != line ) {
-               k[Candidate_94s[ipi]][6] = line ;
-             } else {
-               for ( int ll=first_line ; ll<=nlund ; ll++ ) {
-                 if ( k[ll][4] == Candidate_94s[ipi] ) {
-                   k[Candidate_94s[ipi]][6] = ll;
-                   break;
-                 }
+           bool colour_connected =  ((  k[fafp[j_jet]][2]<0 && k[fafp[k_jet]][2]>0 && 
+                                          k[fafp[j_jet]][8] == k[fafp[k_jet]][7] && k[fafp[j_jet]][8] != 0  ) ||  
+                                     (  k[fafp[j_jet]][2]>0 && k[fafp[k_jet]][2]<0 && 
+                                          k[fafp[j_jet]][7] == k[fafp[k_jet]][8] && k[fafp[j_jet]][7] != 0 ));
+           bool no_colour = ( k[fafp[j_jet]][7]+ k[fafp[j_jet]][8]+ k[fafp[k_jet]][7]+ k[fafp[k_jet]][8] == 0 );
+          
+           bool boson_connected =  (k[fafp[j_jet]][3]==k[fafp[k_jet]][3] && 
+                                        (  abs(k[k[fafp[k_jet]][3]][2]) == 6  || 
+                                               k[k[fafp[k_jet]][3]][2]  == 23 ||   
+                                           abs(k[k[fafp[k_jet]][3]][2]) == 24 || 
+					   k[k[fafp[k_jet]][3]][2]  == 25 ));
+           bool same_parent = ( k[fafp[j_jet]][3]==k[fafp[k_jet]][3] && k[fafp[k_jet]][3] != 0 );
+           bool same_family = (  flavour( k[fafp[k_jet]][2]) == flavour( k[fafp[j_jet]][2])) ;
+
+ 	   if (k_lept == j_lept || _top_event ) { // only group quarks with quarks, leptons with leptons, except in top events,
+                                                  // where we find it more useful to group all decay-products of the tops together,
+                                                  // which might imply grouping quarks with leptons. Note that the concept of
+                                                  // "initial colour neutral" is therefore not really apt in this case!
+
+             if (( fafp[j_jet] == fafp[k_jet] ) ||         // the fafp:s are the same or have the same parent. NB will group k_jet with itself!
+                   colour_connected || 
+                   boson_connected ||
+		   (no_colour && (same_parent && same_family)) || 
+                   (companion[k_jet] == j_jet  && abs(  k[fafp[k_jet]][2]) != 6) ) {  
+
+               group[0][k_jet]++;
+               group[ group[0][k_jet] ][k_jet] = j_jet;
+
+	       if ( k_jet != j_jet ) {
+	         streamlog_out(DEBUG4) << " Jet " << k_jet << " was grouped with jet " << j_jet <<" .";
+	         streamlog_out(DEBUG4) << " fafp of the jets are " <<  fafp[k_jet] << " (pdg " <<  k[fafp[k_jet]][2] 
+                                                    <<  ") and  " <<  fafp[j_jet]  <<" (pdg " <<  k[fafp[j_jet]][2] <<" ) ." ;
+	         if ( k[fafp[k_jet]][3] != 0 ) {
+	           streamlog_out(DEBUG4) << " parents of the fafp of the jets are " << k[fafp[k_jet]][3]<< " and  " <<   k[fafp[j_jet]][3] <<" .";
+	         }
+	         streamlog_out(DEBUG4) << " colour-connection : " <<  colour_connected<< std::endl;
                }
              }
-             k[line][4] = Candidate_94s[ipi] ;
-             k[line][5] = Candidate_94s[ipi] ;
-             gotit=1;
-             break;
+           }
+	 }
+       }
+       streamlog_out(DEBUG4) << " group of jet " << k_jet << " : " ;
+       bool compthere=false;
+       for ( int i_grp=1 ; i_grp <=  group[0][k_jet] ; i_grp++ ) {
+         streamlog_out(DEBUG4) <<group[i_grp][k_jet] << " " ;
+         if (group[i_grp][k_jet] == companion[k_jet] || companion[k_jet] == 0 )   { compthere = true ; }
+       }
+       if ( ! compthere && not _top_event ) {
+         streamlog_out(ERROR) << " jet " << k_jet << " : companion " << companion[k_jet] << " not in group " << std::endl;  
+       }
+       streamlog_out(DEBUG4) << std::endl;
+       if ( group[0][k_jet] <= 1 && ( type[k_jet] != 2 || n_hard_lepton%2 == 0 ) ) {
+         streamlog_out(ERROR) << " jet " << k_jet << " ungrouped " << std::endl;
+       }
+     }
+   }
+
+   n_djb = 0 ;       
+   n_dje = 0;  
+
+       //! figure out the different jet combinations. (If there are no bosons, it's straight forward:
+       //! it's just the odd+even combinations. Also if one only cares about the final singlet
+       //! the same aplies, boson or not)
+
+       // We want to find how many colour-neutrals we have before the P.S., and which jets they
+       // go into. dijet_begining[k_jet] will be the number of that c.n., and conversely, jets_begin[initial cn#]
+       // is the list of the jets each initial cn goes to.
+       // Likewise (but trivially) dijet_end[k_jet] is the number of the final cn the jet, belongs to -
+       // jets_end[final cn#] is the list (which always, by construction, contains two adjecent jets).
+
+       // TODO: the below would be simpler if group would be sets. Then just set-equality would be needed to check
+       //  The logic below needs identical groups not only to contain the same numbers, but also that they are in the same
+       //  order!
+
+   for ( int k_jet=1; k_jet<=njet ; k_jet++ ) {
+
+     dijet_begining[k_jet] = 0;
+
+     if ( group[0][k_jet] > 0 )  {
+       for ( int  i_djb=1; i_djb<=n_djb ; i_djb++ ) {
+         int gotit=1;
+         for ( int i_grpmbr=1 ; i_grpmbr<= group[0][k_jet] ; i_grpmbr++ ) {
+           if  ( ! (group[i_grpmbr][k_jet]==jets_begin[i_grpmbr][i_djb] )) {
+             gotit=0;
            }
          }
-       }
-
-       if ( gotit == 0 ) {
-         streamlog_out(ERROR) << " hum 2 " << line << " " << k[line][4]  << " " << k[line][5] << std::endl;
-         streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
-         streamlog_out(ERROR) << std::endl ; 
-
-         // call pylist(2)
-
+         if ( gotit ) {
+           dijet_begining[k_jet] = i_djb;
+         }
        }
      }
 
-     if (  k[line][4] == 0 &&  ( k[line][2] != 21 ||  p[line][4] > 0.0000001) ) {
-          //! ( this never happens in my tests)
-       streamlog_out(ERROR) << " ERROR: line "<< line <<" still odd " << k[line][2] << " " << p[line][4] <<std::endl;
-       streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-       streamlog_out(ERROR) << std::endl ; 
-
-          //  CALL pylist(2)
-          //  is_odd = .TRUE.
+     if ( dijet_begining[k_jet] == 0 && group[0][k_jet] > 0 ) {
+       n_djb++;
+       dijet_begining[k_jet] = n_djb;
+       for ( int i_grpmbr=0 ; i_grpmbr<= group[0][k_jet] ; i_grpmbr++ ){
+         jets_begin[i_grpmbr][n_djb] = group[i_grpmbr][k_jet];
+       }
      }
-  }
-    // ! fill in second_parent for lines where all was OK already
 
-  for ( int kk=1 ; kk <=nCMshowers ; kk++ ){
-    line=CMshowers[kk] ;
-    int ipi=0;
-    if (  k[line][6] == 0 ) {
-      ipi=k[line][3];
-      for (int jj=-5 ; jj<=5 ; jj++ ) {
-        if (jj !=0 ) {
-            // ! look 5 lines before and after the mother of this 94
-          if ( k[ipi+jj][4] ==  k[ipi][4] ) {
-            k[line][6]=ipi+jj ;
-            break ;
-          }
-        }
-      }
-    }
-    if (   k[line][6]== 0 ) {
-        //! (this never happens, so the +/- 5 lines seems to be OK)
-      streamlog_out(ERROR) << " Second parent not found " << line  <<std::endl;
-      streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ; 
-      streamlog_out(ERROR) << std::endl ; 
+     dijet_end[k_jet] = 0;
+     for ( int i_dje=1 ; i_dje<=n_dje ; i_dje++ ) {
+       if ( std::min(k_jet,companion[k_jet])==jets_end[1][i_dje] &&
+           std::max(k_jet,companion[k_jet])==jets_end[2][i_dje] ) {
+         dijet_end[k_jet] = i_dje;
+       }
+     }
 
-    }
+     if ( dijet_end[k_jet] == 0 ) {
+       n_dje++;
+       dijet_end[k_jet] = n_dje; 
+       if ( companion[k_jet] > 0 ) {
+         jets_end[1][n_dje] = std::min(k_jet,companion[k_jet]);
+         jets_end[2][n_dje] = std::max(k_jet,companion[k_jet]);
+         jets_end[0][n_dje] = 2 ;
+       } else {
+         jets_end[1][n_dje] = k_jet;
+         jets_end[0][n_dje] = 1;
+       }
+     }
 
-  }
-
-}
-
-void TrueJet::fix_top()
-{
-    int ipi;
-    int this_fla[3];
-    first_line=1 ;
-    int first_top = 0 ; 
-
-    //	std::cout << " enter "<< std::endl;
-      //    IF ( ANY( abs(k(1:nlund,2)) == 6 ) ) THEN 
+   }   
 
 
-    int kkk=1 ; 
-    while ( abs(k[kkk][2]) != 6 && kkk <= nlund ) {
-      kkk++ ;
-    }
-    first_top=kkk;
+     // collect some topology and consitency information:
 
-    if ( first_top < nlund ) {
-      if ( (k[first_top][4] == k[first_top+1][4] &&  k[first_top][5] == k[first_top+1][5]) &&
-            k[first_top][4] ==  k[first_top][5]  &&  k[k[first_top][4]][2] == 94 ) {
+   nboson=0;n_jetless=0; n_0_E_jets=0; n_2jet_clu=0;
+   for ( int k_jet=1 ; k_jet<=njet ; k_jet++ ) {
+     if (type[k_jet]/100 != 0 ){
+       nboson++;
+     }
+     if (tE[k_jet]<0.000001 ) {
+       n_0_E_jets++;
+     }
+     if ( jet[k_jet]==0 && k[k_jet][1]==1 ) {
+       n_jetless++;
+     }
+     if ( (type[k_jet]%100== 3) && ( tE[k_jet]> 0.0000001 ) &&
+	 ( tE[companion[k_jet]] >  0.0000001)) {
+       n_2jet_clu++;
+     }
+   }
 
-         //! the two top's goes into a 94: Make it correct:
-         //!  mother of first two tops set to 3 (from 0) and
-         //!  change the mother of the W from heaven-knows-what
-         //!  to the corresponding top, and change the daughter
-         //! of it to th4 94 the correspondig b goes into.
-        
-         k[first_top][3]=3 ;  k[first_top+1][3]=3 ;
+   n_mixed=0;
+   for ( int k_jet=1 ; k_jet<=njet-1 ; k_jet+=2 ) {
+     if ((type[k_jet]%100==1) &&
+	(k[fafp[k_jet]][4] !=  k[fafp[k_jet+1]][4]) &&
+         ( !( ( k[fafp[k_jet]][2] > 0 && k[fafp[k_jet]][7] ==  k[fafp[k_jet+1]][8])  || 
+              ( k[fafp[k_jet]][2] < 0 && k[fafp[k_jet]][8] ==  k[fafp[k_jet+1]][7] )) ) &&
+          (k[fafp[k_jet]][3] !=  k[fafp[k_jet+1]][3]) ) {
 
-         for ( int kk=0 ; kk <= 1 ; kk++ ) {
-           ipi=first_top+kk ;
-           this_fla[1]=k[ipi][2]; this_fla[2]= ( k[ipi][2] > 0 ? 5 : -5 ) ;
-           while (abs(k[ipi][2]) != 5 ) { // ! ie. not yet at the b quark
-              // ! move forward, either to ...
-             if ( k[k[ipi][4]][2] == 94 ) {
-                 // ! a 94
-               ipi = k[ipi][4] ;
-             } else {
-                // ! or a t or b quark of the right sign
-                //    this_fla=[k(ipi,2), sign(5,k(ipi,2))]
-               if ( k[k[ipi][4]][2] == this_fla[1] ||  k[k[ipi][4]][2] == this_fla[2]  ) {
-                 ipi = k[ipi][4];
-               } else if  ( k[k[ipi][5]][2] == this_fla[1] ||  k[k[ipi][5]][2] == this_fla[2]  ) {
-                 ipi = k[ipi][5];
-               } else {
-                 streamlog_out(ERROR)<< " CA, alors ! " << std::endl ;
-                 streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
-                 streamlog_out(ERROR) << std::endl ; 
- 
-               }
-             }
-             if (  abs(k[ipi][2]) != 5 &&  abs(k[ipi][2]) != 6 &&  abs(k[ipi][2]) != 94 ) {
-               streamlog_out(ERROR)<< " Where IS the quark ?  " << std::endl ;
-               streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
-               streamlog_out(ERROR) << std::endl ; 
-             }
-           }
-             //! we should now be at the b (no pun intended), and the next line
-             //! is the W
-           if ( abs(k[ipi+1][2]) == 24 ) {
-             k[ipi+1][3]=k[ipi][3];
-             k[ipi+1][4]=k[ipi][4];
-             k[ipi+1][5]=k[ipi][5];
-           } else {
-             streamlog_out(ERROR) << " Not a W ?! " << std::endl;
-             streamlog_out(ERROR) << " Event: " << evt->getEventNumber() << ",   run:  " << evt->getRunNumber() << std::endl ;
-             streamlog_out(ERROR) << std::endl ; 
-
+       int ii =  fafp[k_jet];
+       while (  ii <= nlund ) {
+         if ( ii ==  elementon[k_jet] ) {
+           break;
+         }  else  {
+           ii = k[ii][4] ;
+           if ( ii >  elementon[k_jet] ) {
+             n_mixed++; 
+             break ;
            }
          }
-      } else {
-         //! first top didn't go into a 94: add a correct 94-structure
-         //! at the end of pyjets: first tops goes into the added 94.
-         //! the 94 goes into a copy - after first correcting k(...,5) to
-         //! be k(...,4)+1 (ie. the W rather than the b) - of the original top, 
-         //! with mother changed to the 94. The mother of the original products
-         //! of the top (b and W) are changed to the new copy. The new 94 gets
-         //! it's p from the sum of the two tops, and k=[ 11, 94, first_top, nlund+2, nlund+3 ]
-         //! the mother of the original tops are changed from 0 to 3.
- 
-        for(int kk=first_top; kk<=first_top+1 ; kk++ ) {
-            //! W as second daughter 
-          k[kk][5]=k[kk][4]+1;
-            //! W goes to same 94 as the b:
-          k[k[kk][5]][4]=k[k[kk][4]][4];
-          k[k[kk][5]][5]=k[k[kk][4]][5];
-    
-            //! copy to end
-          for ( int jj=1 ; jj<=5 ; jj++ ) {
-            p[nlund+(2-first_top+kk)][jj]=p[kk][jj];
-            k[nlund+(2-first_top+kk)][jj]=k[kk][jj];
-          }
-          k[nlund+(2-first_top+kk)][6]=0;
-            // ! adjust mother
-          k[nlund+(2-first_top+kk)][3]=nlund+1 ;
-            // ! change mother of decendants to be the copy
-          k[k[kk][4]][3] = nlund+(2-first_top+kk) ;
-          k[k[kk][5]][3] = nlund+(2-first_top+kk) ;
-            // ! change daughters of original to be the copy
-          k[kk][4] = nlund+1;
-          k[kk][5] = nlund+1;
-            // ! mother of original = 3
-          k[kk][3] = 3;
-        }
- 
-          // ! construct the 94-object
-           //  p(nlund+1,1:4)=p(nlund+2,1:4)+p(nlund+3,1:4)
-           //  p(nlund+1,5)= sqrt(p(nlund+1,4)**2-SUM(p(nlund+1,1:3)**2))
-           //  k(nlund+1,1:5)= [ 11, 94, first_top, nlund+2, nlund+3 ]
-        double sum_psq=0.0;
-        for ( int jj=1 ; jj<=4 ; jj++ ) {
-          p[nlund+1][jj]=p[nlund+2][jj]+p[nlund+3][jj];
-          if ( jj <= 3 ) {
-            sum_psq+= p[nlund+1][jj]* p[nlund+1][jj];
-          } 
-        }
-        k[nlund+1][1]= 11;
-        k[nlund+1][2]= 94;
-        k[nlund+1][3]= first_top;
-        k[nlund+1][4]= nlund+2;
-        k[nlund+1][5]= nlund+3 ;
-        k[nlund+1][6]= 0 ;
-        p[nlund+1][5]= sqrt(p[nlund+1][4]*p[nlund+1][4]-sum_psq);
-        nlund=nlund+3;
-      } 
-      first_line=first_top;
-  
-  streamlog_out(DEBUG1) << " HEPEVT relation table (after fixtop)"  <<std::endl;
-  streamlog_out(DEBUG1) << "       line      status    pdg       parent    first     last     second " << std::endl;
-  streamlog_out(DEBUG1) << "                                             daughter daugther    parent " << std::endl;
-  for ( int j=1 ; j<=nlund ; j++ ) {
-    streamlog_out(DEBUG1) << std::setw(10) << j << std::setw(10) <<  k[j][1] << 
-                 std::setw(10) <<  k[j][2] << std::setw(10) <<  k[j][3] << 
-                 std::setw(10) <<  k[j][4] << std::setw(10) << k[j][5]  << std::setw(10) << k[j][6] <<std::endl;
-  }
-    } else {
-      first_line=1;
-    }
-}
+       }
+     }
+   }  
+    //   jsum=jets_summary_t(njet,n_djb,n_dje,2*nstr, n_hard_lepton, nboson,  2*nclu,nisr , n_mixed,  n_jetless, n_2jet_clu, n_0_E_jets,jt(1:njet),dijb(1:n_djb),dije(1:n_dje)) 
 
+}
 
 void TrueJet::check( LCEvent *  /*evt*/ ) { 
     // nothing to check here - could be used to fill checkplots in reconstruction processor

--- a/Analysis/TrueJet_Parser/README.md
+++ b/Analysis/TrueJet_Parser/README.md
@@ -1,0 +1,141 @@
+##TrueJet_Parser:
+
+class to help to interpret the collections created by `TrueJet`.
+ 
+>  **Usage**:
+>
+>   Compile as any marlin-processor, add the created shared library to MARLIN_DLL.
+
+
+In the processor using it, three things are needed:
+
+  - Make the class inherit TrueJet_Parser
+  - Add the definitions of the collections names of TrueJet to the c'tor of your processor.
+  - Implement the method get_recoMCTruthLink.
+  - make sure TrueJet_Parser.h is included (and is found in the path)
+
+
+Specifically:
+
+ In the header of your processor:
+
+```
+
+    .
+    .
+    .
+#include "TrueJet_Parser.h"
+
+    .
+    .
+    .
+
+class yourprocessor : public Processor , public TrueJet_Parser {
+
+ public
+
+    .
+    .
+    .
+  std::string get_recoMCTruthLink(){ return _recoMCTruthLink  ; } ;
+    .
+    .
+
+
+```
+
+(This assumes that your processor already has the name of the _RecoMCTruthLink_
+collection as an input parameter and that it is stored in the
+variable `_recoMCTruthLink` . I guess that that is the case for almost
+any processor used for analysis !)
+
+ Then in the source file:
+
+Modify the c'tor this way:
+
+```
+
+yourprocessor::yourprocessor() : Processor("yourprocessor") {
+
+    .
+    .
+    .
+ registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                           "TrueJets" ,
+                           "Name of the TrueJetCollection input collection"  ,
+                           _trueJetCollectionName ,
+                           std::string("TrueJets") ) ;
+
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                           "FinalColourNeutrals" ,
+                           "Name of the FinalColourNeutralCollection input collection"  ,
+                           _finalColourNeutralCollectionName ,
+                           std::string("FinalColourNeutrals") ) ;
+
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                           "InitialColourNeutrals" ,
+                           "Name of the InitialColourNeutralCollection input collection"  ,
+                           _initialColourNeutralCollectionName ,
+                           std::string("InitialColourNeutrals") ) ;
+
+
+  registerInputCollection( LCIO::LCRELATION,
+                            "TrueJetPFOLink" , 
+                            "Name of the TrueJetPFOLink input collection"  ,
+                            _trueJetPFOLink,
+                            std::string("TrueJetPFOLink") ) ;
+
+  registerInputCollection( LCIO::LCRELATION,
+                            "TrueJetMCParticleLink" , 
+                            "Name of the TrueJetMCParticleLink input collection"  ,
+                            _trueJetMCParticleLink,
+                            std::string("TrueJetMCParticleLink") ) ;
+
+  registerInputCollection( LCIO::LCRELATION,
+                            "FinalElementonLink rueJetMCParticleLink" , 
+                            "Name of the  FinalElementonLink input collection"  ,
+                            _finalElementonLink,
+                            std::string("FinalElementonLink") ) ;
+
+  registerInputCollection( LCIO::LCRELATION,
+                            "InitialElementonLink" , 
+                            "Name of the  InitialElementonLink input collection"  ,
+                            _initialElementonLink,
+                            std::string("InitialElementonLink") ) ;
+
+  registerInputCollection( LCIO::LCRELATION,
+                            "FinalColourNeutralLink" , 
+                            "Name of the  FinalColourNeutralLink input collection"  ,
+                            _finalColourNeutralLink,
+                            std::string("FinalColourNeutralLink") ) ;
+
+  registerInputCollection( LCIO::LCRELATION,
+                            "InitialColourNeutralLink" , 
+                            "Name of the  InitialColourNeutralLink input collection"  ,
+                            _initialColourNeutralLink,
+                            std::string("InitialColourNeutralLink") ) ;
+
+
+    .
+    .
+    .
+}
+
+```
+
+The you are ready to use the methods of TrueJet_Parser:
+somewhere at the beginning of processEvent(), add
+
+```
+
+    // tj is a pointer to a Trujet_Parser, with the data of this processor object:
+    TrueJet_Parser* tj= this ;
+    // this method gets all the collections needed + initialises a few convenient variables.
+    tj->getall(evt);
+
+```
+
+That's it !
+
+
+For a working example, look in examples/Use_TrueJet !

--- a/Analysis/TrueJet_Parser/examples/Use_TrueJet/src/Use_TrueJet.cc
+++ b/Analysis/TrueJet_Parser/examples/Use_TrueJet/src/Use_TrueJet.cc
@@ -20,7 +20,6 @@ using namespace lcio ;
 using namespace marlin ;
 using namespace std ;
 
-
 Use_TrueJet aUse_TrueJet ;
 
 Use_TrueJet::Use_TrueJet() : Processor("Use_TrueJet") {
@@ -145,25 +144,38 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
     streamlog_out(MESSAGE) << " ==================================================== " << std::endl ;
     streamlog_out(MESSAGE) << std::endl ;
 
+    LCCollection* rmclcol = NULL;
+    try{
+        rmclcol = evt->getCollection( _recoMCTruthLink );
+    }
+    catch( lcio::DataNotAvailableException e )
+    {
+        rmclcol = NULL;
+    }
     // tj is a pointer to a Trujet_Parser, with the data of this processor object:
     TrueJet_Parser* tj= this ;
     // this method gets all the collections needed + initialises a few convienent variables.
     tj->getall(evt);
+    if ( tjcol == NULL ) { return ; }
 
     streamlog_out(DEBUG5) << " Number of jets is " << tj->njets() << endl;
+    if ( tj->njets() == 0 ) { return ; }
     int njets=tj->njets();
     IntVec sibl[50] ;   // This will be used to store siblings of each jet
     double total_Etrue=0;
     double total_Eisr=0;
     double total_Eowl=0;
     int leptons=0;
-
-     
+    bool cluster_in_event = false;  
+    bool top_in_event = false;  
+    bool gluonsplit_in_event = false;  
     for (int ijet=0 ; ijet< njets; ijet++ ) { // start jet loop
 
          // enery, moemtum, type of the jets. Choose between true, seen or true-of-seen values
          // type: 1 string, 2 lepton, 3 cluster, 4 ISR, 5 overlay.
-
+      if ( abs(type_jet(ijet)%100) == 3 ) { cluster_in_event = true; }
+      if ( abs(type_jet(ijet)) > 100 ) { gluonsplit_in_event = true; }
+      if ( abs((initial_elementon(ijet) != NULL ? initial_elementon(ijet)->getPDG() : 0 )) == 6 ) { top_in_event = true; }
       streamlog_out(DEBUG5)<<endl;
       streamlog_out(DEBUG5)<< " jet " << ijet << " has type " << type_jet(ijet) << endl;
       streamlog_out(DEBUG5)<< " Seen :         " << Eseen(ijet) ; 
@@ -178,12 +190,14 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
       streamlog_out(DEBUG4)<< "               ";
            for (int jj=0 ; jj<4 ; jj++ ) { streamlog_out(DEBUG4) << " " << p4true(ijet)[jj] ;}   ;
            streamlog_out(DEBUG4)<< endl;
+      if ( rmclcol != NULL ) {
       streamlog_out(DEBUG5)<< " True of seen : " << Etrueseen(ijet) ; 
            for (int jj=0 ; jj<3 ; jj++ ) { streamlog_out(DEBUG5) << " " << ptrueseen(ijet)[jj] ;} ; 
            streamlog_out(DEBUG5) << " "  << Mtrueseen(ijet) << endl;
       streamlog_out(DEBUG4)<< "               ";
            for (int jj=0 ; jj<4 ; jj++ ) { streamlog_out(DEBUG4) << " " << p4trueseen(ijet)[jj] ;}  ; 
            streamlog_out(DEBUG4)<< endl;
+      }   
       streamlog_out(DEBUG5)<< " elementon :    " << Equark(ijet) ; 
            for (int jj=0 ; jj<3 ; jj++ ) { streamlog_out(DEBUG5) << " " << pquark(ijet)[jj] ;} ; 
            streamlog_out(DEBUG5) << " "  << Mquark(ijet) << endl;
@@ -193,7 +207,7 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
       streamlog_out(DEBUG5) << endl;
 
       // make some global sums:
-      if ( abs(type_jet(ijet))%100 < 4 ) {
+      if ( abs(type_jet(ijet))%100 < 4 || abs(type_jet(ijet))%100 == 6 ) {
         total_Etrue+=  Etrue(ijet);
         if (  abs(type_jet(ijet))%100 == 2 ){
           leptons++;
@@ -201,20 +215,30 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
       } else if  ( abs(type_jet(ijet))%100 == 4 ) {
         total_Eisr+=Etrue(ijet);
       } else if  ( abs(type_jet(ijet))%100 == 5 ) {
-        total_Eowl+= Etrueseen(ijet);
+        if ( rmclcol != NULL ) {total_Eowl+= Etrueseen(ijet);}
       }
 
       // get reco particles of the jet, as a ReconstructedParticleVec.
       streamlog_out(DEBUG5) << " Number of PFOs used : " << seen_partics(ijet).size()   << endl;
       if (  seen_partics(ijet).size() > 0 ) {
-        streamlog_out(DEBUG4)  << " list of PFOs with energy " << endl;
+        streamlog_out(DEBUG4)  << " list of PFOs with energy and jet number " << endl;
         ReconstructedParticleVec recos =  seen_partics(ijet) ;   // note syntax.
         double recoE=0;
         for ( unsigned kk=0 ; kk<recos.size()  ; kk++ ) {
-          streamlog_out(DEBUG4) << recos[kk] << " " << recos[kk]->getEnergy() << endl;
+          streamlog_out(DEBUG4) << recos[kk] << " " << recos[kk]->getEnergy() << " " << recojet(recos[kk]) << endl;
           recoE+= recos[kk]->getEnergy();
         }
         streamlog_out(DEBUG5) << " Total energy: " << recoE << endl;
+      }
+
+      // get true particles of the jet, as a MCParticleVec.
+      streamlog_out(DEBUG5) << " Number of MCPs used : " << true_partics(ijet).size()   << endl;
+      if (  true_partics(ijet).size() > 0 ) {
+        streamlog_out(DEBUG4)  << " list of MCPs with energy and jet number " << endl;
+        MCParticleVec mcps =  true_partics(ijet) ;   // note syntax.
+        for ( unsigned kk=0 ; kk<mcps.size()  ; kk++ ) {
+          streamlog_out(DEBUG4) << mcps[kk] << " " << mcps[kk]->getEnergy() << " " << mcpjet(mcps[kk]) << endl;
+        }
       }
 
       // study the siblings, ie. the jet(s) that forms a colour neutral with the current one, either final (ie. at the end of the
@@ -223,8 +247,8 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
       // make a copy. final_siblings clears the vector at each call. Note syntax. aibl is IntVec sibl[50].
 
       sibl[ijet]=final_siblings(ijet );
+ 
 
-  
       // print from sibl
       streamlog_out(DEBUG3) << " Number final Siblings to this jet :" << sibl[ijet].size() << endl;
       if (  sibl[ijet].size() > 0 ) {
@@ -254,6 +278,9 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
       streamlog_out(DEBUG5) << " flavour of final and initial quark, lepton or photon  "  
 			    << ( final_elementon(ijet) != NULL ? final_elementon(ijet)->getPDG() : 0) << " " 
                             << (initial_elementon(ijet) != NULL ? initial_elementon(ijet)->getPDG() : 0 ) <<  endl;
+
+
+
     }  // end of jet loop
 
 
@@ -268,6 +295,11 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
       }
     }
 
+    double total_Ecn=0;
+    int _nicn=nicn();
+    for (int iicn=0 ; iicn< _nicn; iicn++ ) { 
+      total_Ecn+=E_icn(iicn);
+    }
     // 
     streamlog_out(DEBUG5) << " Number of final colour-neutrals is " << nfcn()<< endl;
     int _nfcn=nfcn();
@@ -312,18 +344,27 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
         // consitancy check: Is Eand p calculated in different ways (sum of true particles, or from the colour-neutral itself) the same ?
         double M =  sqrt(p4_fr_jets[0]*p4_fr_jets[0] - p4_fr_jets[1]*p4_fr_jets[1]- p4_fr_jets[2]*p4_fr_jets[2]- p4_fr_jets[3]*p4_fr_jets[3]) ;
         streamlog_out(DEBUG5) << " true p4 and mass of these:      " ; 
-              for ( int jj=0 ; jj<4 ; jj++ ) { streamlog_out(DEBUG5) << " " <<  p4_fr_jets[jj] ; } ; 
+        for ( int jj=0 ; jj<4 ; jj++ ) { streamlog_out(DEBUG5) << " " <<  p4_fr_jets[jj] ; } ; 
               streamlog_out(DEBUG5) << " " <<  M << endl;
-        if ( abs ( M- M_fcn(ifcn))/M > 0.001 ) {
             // Normally, the mass should be identical. However, due to the B-field, decyas of longlived charged 
             // particles have their momentum *direction* changed, so check energy as well
-          if ( abs ( p4_fr_jets[0]- E_fcn(ifcn))/E_fcn(ifcn) > 0.001 ) {
-            streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
-                << ", final cn " <<   ifcn << ": mass of cn: " << M_fcn(ifcn) << " mass of jets : " << M << endl;
-            streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
+	   float margin=0.007 ;
+           // If this is a tau cn, be more forgiving. The theory is that there is an issue with the
+           // the crossing-angle boost that becomes too big in aa/BB events which effects tau:s most
+           if ( abs(pdg_fcn_parent(ifcn)) == 15 ||  abs(pdg_fcn_parent(ifcn)) == 16 ) { margin =  0.02 ; }
+           if ( abs ( p4_fr_jets[0]- E_fcn(ifcn))/E_fcn(ifcn) > margin  && p4_fr_jets[0] > 0.5 ) {
+	     if ( ( ( ! cluster_in_event ) && ( ! top_in_event ) )    || 
+               ( abs(( total_Ecn- total_Eisr ) - total_Etrue)/total_Etrue > 0.001 )) {
+              streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
                 << ", final cn " <<   ifcn << ": E of cn:    " << E_fcn(ifcn) << " E of jets :    " <<  p4_fr_jets[0] << endl;
+              streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
+                << ", final cn " <<   ifcn << ": mass of cn: " << M_fcn(ifcn) << " mass of jets : " << M << endl;
+              streamlog_out(WARNING)  << " event/run " << " cluster_in_event : " << cluster_in_event 
+				      << " gluonsplit_in_event : " <<  gluonsplit_in_event  <<  "  top_in_event : " << top_in_event << endl;
+              streamlog_out(WARNING)  << " event/run " <<  " Totals : all non-isr initials = " 
+                                  << total_Ecn- total_Eisr << " all final non-ISR " << total_Etrue << endl;
+            }
           }
-        }
       }
       { 
         // now do it again, this time with the seen values.
@@ -339,6 +380,7 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
             sqrt(p4_fr_jets[0]*p4_fr_jets[0] - p4_fr_jets[1]*p4_fr_jets[1]- p4_fr_jets[2]*p4_fr_jets[2]- p4_fr_jets[3]*p4_fr_jets[3]) << endl;
       }
       {
+        if ( rmclcol != NULL ) {
         // and again, with the true values of seen particles.
         double p4_fr_jets[4] = { 0,0,0,0 };
         for ( unsigned kk=0 ; kk<fcn_jets.size() ; kk++ ) {
@@ -350,11 +392,12 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
             for ( int jj=0 ; jj<4 ; jj++ ) { streamlog_out(DEBUG5) << " " <<  p4_fr_jets[jj] ; } ; 
             streamlog_out(DEBUG5) << " " << 
             sqrt(p4_fr_jets[0]*p4_fr_jets[0] - p4_fr_jets[1]*p4_fr_jets[1]- p4_fr_jets[2]*p4_fr_jets[2]- p4_fr_jets[3]*p4_fr_jets[3]) << endl;
+        }
       }
 
 
-      streamlog_out(DEBUG5) << " Number of elementons making this cn:" << elementons_final_cn(ifcn).size()  << endl;
-      streamlog_out(DEBUG5) << " Pdg of the parent " << pdg_fcn_parent(ifcn) << endl;
+      streamlog_out(DEBUG5) << " Number of elementons making this cn:" << elementons_final_cn(ifcn).size()  ;
+      streamlog_out(DEBUG5) << " Pdg of the parent " << pdg_fcn_parent(ifcn) ;
       streamlog_out(DEBUG5) << " Pdgs of all elementons making this cn: " ;
            for ( unsigned ipid=0 ; ipid <pdg_fcn_comps(ifcn).size() ; ipid++ ) { streamlog_out(DEBUG5)  <<pdg_fcn_comps(ifcn)[ipid] << " " ;}
            streamlog_out(DEBUG5)  << endl;
@@ -363,9 +406,7 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
    } // end loop over final colour neutrals
 
 
-   double total_Ecn=0;
    streamlog_out(DEBUG5) << " Number of initial  colour-neutrals is " << nicn()<< endl;
-   int _nicn=nicn();
    for (int iicn=0 ; iicn< _nicn; iicn++ ) { // loop over initial colour neutrals
 
       // E/P/type of initial colour neutrals.
@@ -378,8 +419,6 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
             for (int jj=0 ; jj<4 ; jj++ ) { streamlog_out(DEBUG4) << " " << p4_icn(iicn)[jj] ;}  ; 
             streamlog_out(DEBUG4)<< endl;
 
-      // Sum up the true energy of the hard system/      
-      total_Ecn+=E_icn(iicn);
 
       // get and list the jets, once again as an IntVec with inicies into the ets ReconstructedParticleVec.
       streamlog_out(DEBUG5) << " Number of jets from this cn:" << jets_of_initial_cn( iicn ).size() << endl;
@@ -402,21 +441,30 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
         }
       }
 
-      // Consiency check: is the sume-of-true and the E/P of the colour neutral the same ?
+      // Consiency check: is the sum-of-true and the E/P of the colour neutral the same ?
       double M =  sqrt(p4_fr_jets[0]*p4_fr_jets[0] - p4_fr_jets[1]*p4_fr_jets[1]- p4_fr_jets[2]*p4_fr_jets[2]- p4_fr_jets[3]*p4_fr_jets[3]) ;
       streamlog_out(DEBUG5) << " true p4 and mass of these: " ; 
             for ( int jj=0 ; jj<4 ; jj++ ) { streamlog_out(DEBUG5) << " " <<  p4_fr_jets[jj] ; } ; 
             streamlog_out(DEBUG5) << " " << M << endl;
-      if ( abs ( M- M_icn(iicn))/M > 0.001 ) {
           // Normally, the mass should be identical. However, due to the B-field, decyas of longlived 
           // charged particles have their momentum *direction* changed, so check energy as well
-        if ( abs ( p4_fr_jets[0]- E_icn(iicn))/E_icn(iicn) > 0.001 ) {
-          streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
-                << " , initial cn " <<   iicn << " mass of cn: " << M_icn(iicn) << " mass of jets : " << M << endl;
-          streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
+	float margin=0.007 ;
+           // If this is a tau cn, be more forgiving. The theory is that there is an issue with the
+           // the crossing-angle boost that becomes too big in aa/BB events which effects tau:s most
+        if ( abs( pdg_icn_comps(iicn)[0]) == 15 ||  abs(pdg_icn_comps(iicn)[0]) == 16 ) { margin =  0.02 ; }
+        if ( abs ( p4_fr_jets[0]- E_icn(iicn))/E_icn(iicn) > margin ) {
+          if ( ( ( ! cluster_in_event )  && ( ! top_in_event ) )|| 
+               ( abs(( total_Ecn- total_Eisr ) - total_Etrue)/total_Etrue > 0.001 )) {
+            streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
                 << " , initial cn " <<   iicn << " E of cn:    " << E_icn(iicn) << " E of jets :    " <<  p4_fr_jets[0] << endl;
+            streamlog_out(WARNING) << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() 
+                << " , initial cn " <<   iicn << " mass of cn: " << M_icn(iicn) << " mass of jets : " << M << endl;
+            streamlog_out(WARNING)  << " event/run " << " cluster_in_event : " << cluster_in_event 
+                                     << " gluonsplit_in_event : " <<  gluonsplit_in_event  <<  "  top_in_event : " << top_in_event  << endl;
+            streamlog_out(WARNING)  << " event/run " <<  " Totals : all non-isr initials = " 
+                                  << total_Ecn- total_Eisr << " all final non-ISR " << total_Etrue << endl;
+          }
         }
-      }
       
 
       // get the list (MCParticleVec) of the elementons making the colour-neutral, and print their PDG.
@@ -432,47 +480,87 @@ void Use_TrueJet::processEvent( LCEvent * evt ) {
               << jets_of_initial_cn( iicn )[jj] <<  setw(4) <<  type_icn_comps(iicn)[jj]/100-1  <<  setw(4) <<  type_icn_comps(iicn)[jj]%100 << endl;
         }
       } ; streamlog_out(DEBUG5)  << endl;
-
    }
-
    // consitency check: Did the sum of MCParticles really add up to the initial energy ?!
-   streamlog_out(DEBUG5) << " Total energies : " << " E(physics event)= " <<  total_Ecn 
-            << " E(sum true parts)= " <<total_Etrue << " E(isr)= " << total_Eisr << " E(overlay,seen)= " << total_Eowl << endl;
-   if ( abs(total_Ecn-total_Etrue)/total_Etrue > 0.0001 ) {
+   streamlog_out(DEBUG5) << " Total energies : " << " E(physics event)= " <<  total_Ecn
+			 << " E(physics event) - E(isr)= " <<  total_Ecn - total_Eisr 
+            << " E(sum non-isr true parts)= " <<total_Etrue << " E(isr)= " << total_Eisr << " E(overlay,seen)= " << total_Eowl << endl;
+   if ( abs(total_Ecn- total_Eisr - total_Etrue)/total_Etrue > 0.009 ) {
      streamlog_out(WARNING)  << " event/run " << evt->getEventNumber() << "/" << evt->getRunNumber() << 
                ": Mis-match in energy between initial elementons and sum of true particles: " << " E(physics event)= " 
-               <<  total_Ecn << " E(sum true parts)= " <<total_Etrue << endl;
+               <<  total_Ecn - total_Eisr << " E(sum true parts)= " <<total_Etrue << endl;
    }
 
 
-   // Now the other way round: Get the PFOs, and check which jet each one belongs to:
+   // Now the other way round: Get the PFOs or MCPs and check which jet each one belongs to:
    LCCollection* pfocol = NULL;
    try{
      pfocol = evt->getCollection( _recoParticleCollectionName );
    }
    catch( lcio::DataNotAvailableException e ){
-     streamlog_out(WARNING) <<  _recoParticleCollectionName   << " collection not available" << std::endl;
+     //streamlog_out(WARNING) <<  _recoParticleCollectionName   << " collection not available" << std::endl;
      pfocol = NULL;
    }
    
    if ( pfocol != NULL ){
      int nPFO = pfocol->getNumberOfElements()  ;
      streamlog_out(DEBUG4) << " list of pfos and their true jets  "  << endl ;
-     // Loop the PFOs
+     // Loop the PFOs : the complicated way showing use of the navigators
      for(int j=0; j< nPFO ; j++){
        ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( pfocol->getElementAt( j ) ) ;
        LCObjectVec jetvec = reltjreco->getRelatedFromObjects( pfo );
        // jet the PFO belongs to, as a ReconstructedParticle*. jetindex() gives the index in the jets  
        // ReconstructedParticleVec, which is the language
        // of all the printing above.
-       streamlog_out(DEBUG4) << pfo << " " ; 
+       streamlog_out(DEBUG3) << pfo << " " ; 
              for ( unsigned kk=0 ; kk<jetvec.size() ; kk++ ) { 
-                  streamlog_out(DEBUG4) << " " 
-                  <<  jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[kk])); ; } ; 
-             streamlog_out(DEBUG4)<<endl;
+                  streamlog_out(DEBUG3) << " " 
+                  <<  jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[kk])) ;
+             }
+             streamlog_out(DEBUG3)<<endl;
      }
+     // Same thing, the easy way. In addition, shows the initial and final cn:s of each PFO
+     for(int j=0; j< nPFO ; j++){
+       ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( pfocol->getElementAt( j ) ) ;
+       streamlog_out(DEBUG4) << pfo << " " << recojet(pfo) << " " << recoicn(pfo) <<" " << recofcn(pfo) <<std::endl;
+     }
+  }
+   LCCollection* mcpcol = NULL;
+   try{
+     mcpcol = evt->getCollection(  _MCParticleColllectionName );
    }
- 
+   catch( lcio::DataNotAvailableException e ){
+     mcpcol = NULL;
+   }
+   
+   if ( mcpcol != NULL ){
+     int nMCP = mcpcol->getNumberOfElements()  ;
+     streamlog_out(DEBUG4) << " list of mcps and their true jets  "  << endl ;
+     // Loop the MCPs : the complicated way showing use of the navigators
+     for(int j=0; j< nMCP ; j++){
+       MCParticle* mcp = dynamic_cast<MCParticle*>( mcpcol->getElementAt( j ) ) ;
+       LCObjectVec jetvec = reltjmcp->getRelatedFromObjects( mcp );
+       // jet the MCP belongs to, as a ReconstructedParticle*. jetindex() gives the index in the jets  
+       // ReconstructedParticleVec, which is the language
+       // of all the printing above.
+       streamlog_out(DEBUG3) << mcp << " " ; 
+             for ( unsigned kk=0 ; kk<jetvec.size() ; kk++ ) { 
+                  streamlog_out(DEBUG3) << " " 
+                  <<  jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[kk])) ;
+             }
+             streamlog_out(DEBUG3)<<endl;
+     }
+     // Same thing, the easy way. In addition, shows the initial and final cn:s of each MCP
+     for(int j=0; j< nMCP ; j++){
+       MCParticle* mcp = dynamic_cast<MCParticle*>( mcpcol->getElementAt( j ) ) ;
+       if (  mcpjet(mcp) > -1000 ) {  // -1000 for mcp not included in any jet - the case for e.g. the incomming particles
+         streamlog_out(DEBUG4) << mcp << " " << mcpjet(mcp) << " " << mcpicn(mcp) <<" " << mcpfcn(mcp) <<std::endl;
+       }
+     }
+
+  }
+
+   
    if ( tj ) {
      delall();  // clean up
    }

--- a/Analysis/TrueJet_Parser/include/TrueJet_Parser.h
+++ b/Analysis/TrueJet_Parser/include/TrueJet_Parser.h
@@ -34,82 +34,246 @@ class TrueJet_Parser {
 
   virtual    std::string get_recoMCTruthLink(){ return _recoMCTruthLink  ;};
  
-  ReconstructedParticleVec* getJets();
-  ReconstructedParticleVec* getFinalcn();
-  ReconstructedParticleVec* getInitialcn();
+  ReconstructedParticleVec* getJets();       // get all true jets in event
+  ReconstructedParticleVec* getFinalcn();    // get all final colour neutrals in event
+  ReconstructedParticleVec* getInitialcn();  // get all initial colour neutrals in event
 
-  void getall(LCEvent* event)  ;
+  void getall(LCEvent* event)  ;  // Convenient method to get all collections needed: no need to call
+                                  // the three above individually. Also all navigators are set up
+                                  // with this call - See below.
 
-  void delall() ;
-  int njets() { return tjcol->getNumberOfElements(); };
+  void delall() ;                 // Tidy up, to be called at end of each event.
+
+  int njets() { return tjcol->getNumberOfElements(); };  
+                                  // Get the total number of true jets in the event
+
   int jetindex(ReconstructedParticle* jet ) { return jet->ext<JetIndex>() ; };
+                                  // Get the index of jet in various arrays. That is, ijet in the
+                                  // methods below.
+
+  const ReconstructedParticle* jet(int ijet) {return jets->at(ijet); }
+                                  // Get the jet object that is jet-number ijet.
 
   double Eseen(int ijet) { return jets->at(ijet)->getEnergy(); };
+                                  // Seen energy of jet ijet
+
   double Mseen(int ijet) { return jets->at(ijet)->getMass(); };
+                                  // Seen mass of jet ijet
+
   const double* pseen(int ijet) { return jets->at(ijet)->getMomentum(); };
+                                  // Seen 3-momentum of jet ijet
+
   const double* p4seen(int ijet) ;
+                                  // Seen 4-momentum of jet ijet (component 0 is E)
+
   const ReconstructedParticleVec& seen_partics(int ijet) { return jets->at(ijet)->getParticles(); };
+                                  // Get all PFOs in jet ijet. 
+
+  const MCParticleVec& true_partics(int ijet) ;
+                                  // Get all MCPs in jet ijet.
 
   int type_jet(int ijet) { return jets->at(ijet)->getParticleIDs()[0]->getType() ; };
+                                  // Get the type jet ijet: 1 = hadronic, from string
+                                  //                        2 = leptonic
+                                  //                        3 = hadronic, from cluster
+                                  //                        4 = ISR
+                                  //                        5 = overlay
+                                  //                        6 = M.E. photon
+                                  // If the jet is completely unseen, the type is negated.
+                                  // If the jet originates from a gluon-splitting, the type is
+                                  // modified to type + (jet# radiating the gluon)*100
 
   double Etrue(int ijet) ; 
+                                  // True energy of jet ijet
+
   double Mtrue(int ijet) ;
+                                  // True mass of jet ijet
+
   const double* ptrue(int ijet) ;
+                                  // True 3-momentum of jet ijet
+
   const double* p4true(int ijet) ;
+                                  // True 4-momentum of jet ijet (component 0 is E)
 
   double Equark(int ijet) {return ( final_elementon(ijet) != NULL ? final_elementon(ijet)->getEnergy() : 0.);}; 
+                                  // Energy of the last quark/lepton before "hadronisation" jet ijet
+
   double Mquark(int ijet) {return ( final_elementon(ijet) != NULL ? final_elementon(ijet)->getMass() : 0 );};
+                                 // Mass of the last quark/lepton before "hadronisation" jet ijet
+
   const double* pquark(int ijet);
+                                 // 3-momentum of the last quark/lepton before "hadronisation" jet ijet
+
   const double* p4quark(int ijet) ;
+                                 // 4-momentum of the last quark/lepton before "hadronisation" jet ijet 
 
   double Etrueseen(int ijet) ; 
+                                  // Sum of true energy of all the particles of jet ijet, that were detected
+
   double Mtrueseen(int ijet) ;
+                                  // Sum of true mass of all the particles of jet ijet, that were detected
+
   const double* ptrueseen(int ijet) ;
+                                  // Sum of true 3-momentum of all the particles of jet ijet, that were detected
+
   const double* p4trueseen(int ijet) ;
+                                  // Sum of true 4-momentum of all the particles of jet ijet, that were detected 
+                                  // (component 0 is E)
 
   const IntVec& final_siblings( int ijet ); 
+                                  // list of jets grouped with jet ijet at the end of the parton-shower
+
   const IntVec& initial_siblings( int ijet ); 
+                                  // list of jets grouped with jet ijet seen from the  beginning of the parton-shower
+                                  // (i.e. those that, together with jet ijet, belong to the same initial colour neutral)
+
+  int mcpjet( MCParticle* mcp);
+  int mcpicn( MCParticle* mcp);
+  int mcpfcn( MCParticle* mcp);
+                                  // Get jetnumber, initial or final colour neutral of true particle
+                                  // mcp
+
+  int recojet( ReconstructedParticle* reco);
+  int recoicn( ReconstructedParticle* reco);
+  int recofcn( ReconstructedParticle* reco);
+                                  // Get jetnumber, initial or final colour neutral of reconstructed 
+                                  // particle reco.
+
 
   int final_cn( int ijet ); 
+                                  // the id of the final colour-neutral that jet ijet comes form
+
   int initial_cn( int ijet ); 
+                                  // the id of the initial colour-neutral that jet ijet comes form
 
   const IntVec& jets_of_final_cn( int ifcn ); 
+                                  // the list of the jets final colour-neutral ifcn gives rise to
+
   const IntVec& jets_of_initial_cn( int iicn ); 
+                                  // the list of the jets initial colour-neutral iicn gives rise to
 
   int nicn() { return icncol->getNumberOfElements(); };
+                                  // Number of initial colour neutrals
+
   int type_icn_parent(int iicn) { return initialcns->at(iicn)->getParticleIDs()[0]->getType() ; };
+                                 // type of initial colour neutral iicn:  1 or 3 : c.n. is a quark pair
+                                 //                                            2 : c.n. is a lepton pair
+                                 //                                            4 : c.n. is an ISR
+                                 //                                            6 : c.n. is a ME photon
+                                 
+
   const IntVec& type_icn_comps(int iicn) ;
+                                 // types of each of the quarks/leptons constituting this
+                                 // initial colour neutral = type of the corresponding jet
+
   int pdg_icn_parent(int iicn) { return initialcns->at(iicn)->getParticleIDs()[0]->getPDG() ; };
+                                 // PDG of parent of initial colour neutral iicn, i.e. the boson (23=Z, 24=W, 25=H ...)
+  
   const IntVec& pdg_icn_comps(int iicn) ;
-  double E_icn(int iicn) { return initialcns->at(iicn)->getEnergy();}; 
+                                 // PDGs of each of the quarks/leptons constituting this
+                                 // initial colour neutral
+
+  double E_icn(int iicn) { return initialcns->at(iicn)->getEnergy();};
+                                 // Energy of initial colour neutral iicn.
+
   double M_icn(int iicn) {; return initialcns->at(iicn)->getMass();};
+                                 // Mass of initial colour neutral iicn.
+
   const double* p_icn(int iicn){ return initialcns->at(iicn)->getMomentum();} ;
+                                 // 3-momentum of initial colour neutral iicn.
+
   const double* p4_icn(int iicn) ;
+                                 // 4-momentum  of initial colour neutral iicn (component 0 is E).
 
   int nfcn() { return fcncol->getNumberOfElements(); };
+                                  // Number of final colour neutrals
+
   int type_fcn_parent(int ifcn) { return finalcns->at(ifcn)->getParticleIDs()[0]->getType() ; };
+                                 // type of parent of final colour neutral ifcn. Same as that of the
+                                 // two jets constituting the c.n. (bare type, i.e. always positive,
+                                 // no gluon-splitting indication)
+
   const IntVec& type_fcn_comps(int ifcn) ;
+                                 // types of the quarks/leptons constituting this final colour neutral.
+                                 // Equal to the type of the corresponding jet.
+
   int pdg_fcn_parent(int ifcn) { return finalcns->at(ifcn)->getParticleIDs()[0]->getPDG() ; };
+                                 // PDG of parent of final colour neutral ifcn:  (92=string, 91=cluster,
+                                 // 22=photon (ISR or ME), any lepton PDG=lepton pair)
+
   const IntVec& pdg_fcn_comps(int ifcn) ;
+                                 // PDGs of the quarks/leptons constituting this final colour neutral
+
   double E_fcn(int ifcn){return finalcns->at(ifcn)->getEnergy(); } ; 
+                                 // Energy of final colour neutral ifcn.
+
   double M_fcn(int ifcn){return finalcns->at(ifcn)->getMass();} ;
+                                 // Mass of final colour neutral ifcn.
+
   const double* p_fcn(int ifcn){return finalcns->at(ifcn)->getMomentum(); } ;
+                                 // 3-momentum of final colour neutral ifcn.
+
   const double* p4_fcn(int ifcn) ;
+                                 // 4-momentum  of final colour neutral ifcn (component 0 is E). 
 
   MCParticle* initial_elementon(int ijet) ;
+                                 // The MCParticle that is at the beginning of the parton shower
+                                 // leading to jet ijet
+
   MCParticle* final_elementon(int ijet) ;
+                                 // The MCParticle that is at the end of the parton shower
+                                 // leading to jet ijet
 
   const MCParticleVec& elementons_final_cn(int ifcn) ;
+                                 // list of MCParticles constituting the final colour neutral
+
   const MCParticleVec& elementons_initial_cn(int ifcn) ;
+                                 // list of MCParticles constituting the initial colour neutral
+
+                                 // All the following navigators are set up by a call to getall ...
+                                 // Note that most, if not all, information one can get using
+                                 // these navigators can already be obtained in a simpler way using
+                                 // the method above!
+
+                                 // We list what they connect like so:
+                                 // "a xxx -> yyys" means that navigator relzzz gives
+                                 //
+                                 // yyyvec = relzzz->getRelated T o Objects( a xxx ) , 
+                                 //
+                                 // and, consequently, that the relation in the other direction is gotten by
+                                 //
+                                 // xxxvec = relzzz->getRelated F r o m Objects( a yyy ) 
+                                 //
+                                 // In [] the LCIO type of the vector-elements are given. a truejet is a
+                                 // ReconstructedParticle, and  jets->at(ijet) gives the truejet object
+                                 // at index ijet (i.e. the identifier used in all the other methods),
+                                 // while in the other way jetindex( truejet-object ) gives the index.
 
 
-    LCRelationNavigator* relfcn{};
-    LCRelationNavigator* relicn{};
-    LCRelationNavigator* relfp{};
-    LCRelationNavigator* relip{};
-    LCRelationNavigator* reltjreco{};
-    LCRelationNavigator* reltjmcp{};
-    LCRelationNavigator* reltrue_tj{};
+    LCRelationNavigator* relfcn{};      // a truejet to final colour neutral(s)    [ ReconstructedParticle:s ]
+    LCRelationNavigator* relicn{};      // a truejet to initial colour neutral(s)   [ ReconstructedParticle:s ]
+
+    LCRelationNavigator* relfp{};       // a truejet to its final quarks/leptons   [ MCParticle:s ]
+    LCRelationNavigator* relip{};       // a truejet to its initial quarks/leptons [ MCParticle:s ]
+
+
+    LCRelationNavigator* reltjreco{};   // a truejet to all seen particles in it    [ ReconstructedParticle:s ]
+    LCRelationNavigator* reltjmcp{};    // a truejet to all true particles in it   [ MCParticle:s ]
+
+
+                                 // Example:
+
+//       ReconstructedParticle* pfo = dynamic_cast<ReconstructedParticle*>( pfocol->getElementAt( j ) ) ;
+//       LCObjectVec jetvec = reltjreco->getRelatedFromObjects( pfo );
+//       int ijet = jetindex( dynamic_cast<ReconstructedParticle*>(jetvec[0]));
+
+                                // will give you the jetnumber (ijet) that PFO j belongs to
+                                // (Note that there is a method above for the opposite operation:
+                                //  seen_partics(ijet) returns a ReconstructedParticlVec of all
+                                //  PFOs belonging to jet ijet)
+
+    LCRelationNavigator* reltrue_tj{};  // = RecoMCTruthLink
+
     LCCollection* tjcol{};
     LCCollection* fcncol{};
     LCCollection* icncol{};


### PR DESCRIPTION
BEGINRELEASENOTES

Heavily reworked version of TrueJet
===========================

From the outside, little has changed:
New jet-type (6) for non-isr photon from the hard interaction.
Does not require recoparticles (nor recomctruthlink), so also works
on generator-output lcio-files.
Boolean steering flag to indicate Whizard1 (GDE) or Whizard2 (LCC) input
(false by default, i.e. input is Whizard2)

Internally, heavily re-worked.

- removed methods fix94 and fix_top
- New method (stdhep_reader_bug_workaround) called if _whiz1 is true  
- New method - photon - added to treat the new jet type 6 (M.E. photon).
- New boolean data-members _whiz1 (steering flag),  _higgs_to_glue_glue
and _top_event (the latter two set at run-time event by event)
- Handle the case if no reconstructed information (generator input). 
- In top events, define the initial colour-neutral as  the top 
- Default collectionnames changed to the mc2020 ones.

Changes and enhancemts to TrueJet_Parser and Use_TrueJet to go with new TrueJet
=================================================================

TrueJet_Parser.

- added  MCPseen : LCIntExtension<MCPseen>, used to avoid
double counting of *true* particles (decay-in-flight ...) for true-of-seen.

- New methods: mcpjet, mcpicn,mcpfcn, recojet, recoicn and recofcn to 
returns the  corresponding jet, icn or fcn number of MCPs or PFOs.
true_partics, to return the list of all mcps in a jet (reco_particle
already existed).

Use_TrueJet:

- Gracefully handle case with no recoMCTruthLink. 

- Exercise the new methods in TrueJet_Parser.


ENDRELEASENOTES