### PR TITLE
Featured edx angularcorr

### DIFF
--- a/Analysis/PIDTools/include/AngularCorrection_dEdxProcessor.hh
+++ b/Analysis/PIDTools/include/AngularCorrection_dEdxProcessor.hh
@@ -1,0 +1,56 @@
+#ifndef AngularCorrection_dEdxProcessor_hh
+#define AngularCorrection_dEdxProcessor_hh 1
+
+#include <string>
+#include <vector>
+#include <random>
+#include <marlin/Processor.h>
+#include <EVENT/LCCollection.h>
+#include <TH2.h>
+
+using namespace lcio ;
+using namespace marlin ;
+
+/** AngularCorrection_dEdxProcessor <br>
+ *  This processor calculates an extra correction to be applied to the computed dE/dx for every track.<br>
+ * <h4>Input collections and prerequisites</h4>
+ *  The processor requires a MarlinTrk Collection.<br>
+ *  <h4>Output</h4>
+ *  The calculated dE/dx is rewritten (brute force) in the track collection.<br>
+ *  This is only possible if Marlin setting AllowToModifyEvent is set to true.<br>
+ *  @param _LDCTrackCollection - name of the input track collection <br>
+ *  default: MarlinTrkTracks
+ *  @param _writedEdx - flag indicating if calculated dE/dx should be attached to track<br>
+ *  If fully reconstructed tracks are used as input collection this can be switched off to only generate histograms.<br>
+ *  default: false<br>
+ *  @param _par - parameter for angular correction<br>
+ *  @author A. Irles, IFIC
+ *  @version $Id$
+ */
+
+class AngularCorrection_dEdxProcessor : public Processor{
+public:
+  virtual Processor*  newProcessor() { return new AngularCorrection_dEdxProcessor ; }
+  AngularCorrection_dEdxProcessor();
+  virtual void init() ;
+  virtual void processRunHeader( LCRunHeader* run);
+  virtual void processEvent( LCEvent * evt );
+  virtual void check( LCEvent * evt );
+  virtual void end();
+ 
+private:
+  AngularCorrection_dEdxProcessor(const AngularCorrection_dEdxProcessor&) = delete;
+  AngularCorrection_dEdxProcessor& operator=(const AngularCorrection_dEdxProcessor&) = delete;
+
+  //std::pair<float,float> getExtraCorrection(float dedx, float dedx_error, float trkcos);
+
+  std::string _description = "";
+  std::string _LDCTrackCollection = "";
+  LCCollection* _LDCCol = NULL;
+  bool _writedEdx = true;
+
+  std::vector<float> _par = {};
+
+};
+
+#endif

--- a/Analysis/PIDTools/include/AngularCorrection_dEdxProcessor.hh
+++ b/Analysis/PIDTools/include/AngularCorrection_dEdxProcessor.hh
@@ -1,12 +1,16 @@
 #ifndef AngularCorrection_dEdxProcessor_hh
 #define AngularCorrection_dEdxProcessor_hh 1
 
+#include "marlin/Processor.h"
+#include "marlin/EventModifier.h"
+#include "lcio.h"
 #include <string>
-#include <vector>
-#include <random>
-#include <marlin/Processor.h>
+#include <IMPL/LCEventImpl.h>
 #include <EVENT/LCCollection.h>
-#include <TH2.h>
+#include <EVENT/Track.h>
+#include <IMPL/TrackImpl.h>
+
+#include <marlin/Global.h>
 
 using namespace lcio ;
 using namespace marlin ;
@@ -16,28 +20,30 @@ using namespace marlin ;
  * <h4>Input collections and prerequisites</h4>
  *  The processor requires a MarlinTrk Collection.<br>
  *  <h4>Output</h4>
- *  The calculated dE/dx is rewritten (brute force) in the track collection.<br>
- *  This is only possible if Marlin setting AllowToModifyEvent is set to true.<br>
+ *  The calculated dE/dx is rewritten (ATTENTION) in the track collection.<br>
  *  @param _LDCTrackCollection - name of the input track collection <br>
  *  default: MarlinTrkTracks
- *  @param _writedEdx - flag indicating if calculated dE/dx should be attached to track<br>
- *  If fully reconstructed tracks are used as input collection this can be switched off to only generate histograms.<br>
- *  default: false<br>
  *  @param _par - parameter for angular correction<br>
  *  @author A. Irles, IFIC
  *  @version $Id$
  */
 
-class AngularCorrection_dEdxProcessor : public Processor{
+class AngularCorrection_dEdxProcessor : public Processor, public EventModifier  {
+
 public:
+
   virtual Processor*  newProcessor() { return new AngularCorrection_dEdxProcessor ; }
   AngularCorrection_dEdxProcessor();
+  virtual const std::string & name() const { return Processor::name() ; }
+
+  virtual void modifyEvent( LCEvent * evt ) ;
+
   virtual void init() ;
   virtual void processRunHeader( LCRunHeader* run);
-  virtual void processEvent( LCEvent * evt );
+  //  virtual void processEvent( LCEvent * evt );
   virtual void check( LCEvent * evt );
   virtual void end();
- 
+
 private:
   AngularCorrection_dEdxProcessor(const AngularCorrection_dEdxProcessor&) = delete;
   AngularCorrection_dEdxProcessor& operator=(const AngularCorrection_dEdxProcessor&) = delete;
@@ -47,10 +53,10 @@ private:
   std::string _description = "";
   std::string _LDCTrackCollection = "";
   LCCollection* _LDCCol = NULL;
-  bool _writedEdx = true;
 
   std::vector<float> _par = {};
 
 };
+
 
 #endif

--- a/Analysis/PIDTools/include/Compute_dEdxProcessor2021.hh
+++ b/Analysis/PIDTools/include/Compute_dEdxProcessor2021.hh
@@ -1,0 +1,130 @@
+#ifndef Compute_dEdxProcessor2021_hh
+#define Compute_dEdxProcessor2021_hh 1
+
+
+#include <string>
+#include <vector>
+#include <random>
+#include <marlin/Processor.h>
+#include <EVENT/LCCollection.h>
+#include <TH2.h>
+
+using namespace lcio ;
+using namespace marlin ;
+
+/** Compute dE/dx Processor2021 <br>
+ *  This processor calculates the dE/dx for every track.<br>
+ * <h4>Input collections and prerequisites</h4>
+ *  The processor requires a collection of tracks that contains the corresponding track hits.<br>
+ *  Every track hit that lies within the boundaries of the TPC is used.<br>
+ *  dE is the deposited energy of the hit.<br>
+ *  dx is the distance between the hits and can be calculated in 3 different ways.<br>
+ *  A truncation of the hits with the lowest and highest dE7Dx values is performed.<br>
+ *  Then the mean is calculated (truncation-mean method).<br>
+ *  The dEdx is smeared according to test beam results .<br>
+ *  Finally, the dEdx is corrected for angular effects (in the previous versions of this processor, before 2021, this was performed before smearing..<br>
+ *  <h4>Output</h4>
+ *  The calculated dE/dx is attached to the track.<br>
+ *  This is only possible if the the track collection allows write access.<br>
+ *  Bethe-Bloch histograms (root TH2D) can be generated for every dx strategy.<br>
+ *  Both outputs are optional.<br>
+ *  @param _LDCTrackCollection - name of the input track collection <br>
+ *  default: MarlinTrkTracks
+ *  @param _writedEdx - flag indicating if calculated dE/dx should be attached to track<br>
+ *  If fully reconstructed tracks are used as input collection this can be switched off to only generate histograms.<br>
+ *  default: true<br>
+ *  @param _energyLossErrorTPC - the dE/dx resolution<br>
+ *  default: 0.054  (5.4%)<br>
+ *  @param _lowerTrunFrac - lower truncation fraction for truncated-mean method<br>
+ *  The hits with the lowest <_lowerTrunFrac> dE/dx values are rejected.<br>
+ *  default: 0.08  (8%; ALEPH: 8%)<br>
+ *  @param _upperTrunFrac - upper truncation fraction for truncated-mean method<br>
+ *  The hits with the highest <_upperTrunFrac> dE/dx values are rejected.<br>
+ *  default: 0.3  (30%; ALEPH: 40%)<br>
+ *  @param _isSmearing - flag indicating if additional smearing should be applied<br>
+ *  This compensates for a 'too good' processor outcome, compared to test beam results.<br>
+ *  default: false<br>
+ *  @param _smearingFactor - width of the Gaussian function used for the additional smearing<br>
+ *  default: 0.035  (3.5%)<br>
+ *  @param _errexp - scaling exponents of the dE/dx error for path length and number of hits, respectively<br>
+ *  default: {-0.34, -0.45}<br>
+ *  @param _dxStrategy - ID specifying which strategy for calculating dx should be used<br>
+ *  Strategy 1: hit-to-hit distance<br>
+ *  Strategy 2: hit-to-hit path length of projected hits  (do not use at the moment)<br>
+ *  Strategy 3: path over hit row<br>
+ *  default: 1<br>
+ *  If none of the above is chosen, the processor defaults to 1.<br>
+ *  @param _StratCompHist - flag indicating if Bethe-Bloch histograms for each dx strategy should created.<br>
+ *  default: false<br>
+ *  @param _StratCompHistWeight - flag indicating if Bethe-Bloch histograms (if chosen) should be filled with a sqrt(number-of-track-hits) weighting.<br>
+ *  default: false (-> weight for each track = 1)<br>
+ *  @param _StratCompHistFiles - file names of the generated dx strategy comparison histograms (if chosen).<br>
+ *  The respective strategy number and '.png' is added.<br>
+ *  default: dEdx_Histo_Strategy  (-> "dEdx_Histo_Strategy1.png", etc.)<br>
+ *  @param  _angularcorrdEdx  - flag indicating if the dEdx will be corrected for angular correction
+ *  default=true
+ *  @param _par{} - floats indication the parametrization of the correction:  f3 = 1 / (_par[0] + _par[1] * lambda  + _par[2] * pow(lambda,2) + _par[3] * pow(lambda,3) )
+ *  @author M. Kurata, KEK
+ *  adapted by U. Einhaus, DESY
+ *  readapted by A. Irles, IFIC
+ *  @version $Id$
+ */
+
+class Compute_dEdxProcessor2021 : public Processor{
+public:
+  virtual Processor*  newProcessor() { return new Compute_dEdxProcessor2021 ; }
+  Compute_dEdxProcessor2021();
+  virtual void init() ;
+  virtual void processRunHeader( LCRunHeader* run);
+  virtual void processEvent( LCEvent * evt );
+  virtual void check( LCEvent * evt );
+  virtual void end();
+ 
+private:
+  Compute_dEdxProcessor2021(const Compute_dEdxProcessor2021&) = delete;
+  Compute_dEdxProcessor2021& operator=(const Compute_dEdxProcessor2021&) = delete;
+
+  std::pair<double,double> CalculateEnergyLoss(TrackerHitVec& hitVec, Track* trk);
+  //  double getNormalization(double dedx, float hit, double trkcos);
+  double getSmearing(double dEdx);
+
+
+  std::string _description = "";
+  std::string _LDCTrackCollection = "";
+  LCCollection* _LDCCol = NULL;
+  bool _writedEdx = true;
+
+  float _energyLossErrorTPC = 0;
+  float _lowerTrunFrac = 0;
+  float _upperTrunFrac = 0;
+  std::vector<float> _errexp = {};
+  int _dxStrategy = 0;
+  bool _StratCompHist = false;
+  bool _StratCompHistWeight = false;
+  std::string _StratCompHistFiles = "";
+
+  // smearing
+  std::random_device seed_gen{};
+  std::default_random_engine *engine = NULL;
+  std::uniform_real_distribution<> dist{};
+  bool _isSmearing = 0;
+  float _smearingFactor = 0;
+
+  // geometry
+  float _TPC_inner = 0;
+  float _TPC_outer = 0;
+  float _TPC_padHeight = 0;
+  float _bField = 0;
+
+  // root histograms for dx strategy comparison
+  TH2* _BBHist_Strategy1{};
+  TH2* _BBHist_Strategy2{};
+  TH2* _BBHist_Strategy3{};
+
+  // angular correction
+  bool _angularcorrdEdx = false;
+  std::vector<float> _par{};
+  double get_Corrected_dEdx(float dedx, float trklambda);
+};
+
+#endif

--- a/Analysis/PIDTools/include/LikelihoodPID.hh
+++ b/Analysis/PIDTools/include/LikelihoodPID.hh
@@ -38,7 +38,7 @@ public:
   void CalculateDeltaPosition(float charge, TVector3 p, const float* calpos);
 
 private:
-  double get_Norm( double dedx, float hit,  double trkcos);
+  double get_Norm( double dedx);
   double BetheBloch( double x,  double mass,  double *pars);
   
   int Class_electron(TLorentzVector pp, EVENT::Track* trk, EVENT::ClusterVec& cluvec);

--- a/Analysis/PIDTools/include/LikelihoodPIDProcessor.hh
+++ b/Analysis/PIDTools/include/LikelihoodPIDProcessor.hh
@@ -4,6 +4,10 @@
 #include <string>
 #include <vector>
 #include <marlin/Processor.h>
+#include <iostream>
+#include <cstring>
+#include <fstream>
+#include <signal.h>
 
 #include <EVENT/LCCollection.h>
 
@@ -31,6 +35,10 @@ private:
   std::string _inputPFOsCollection{};
   std::string _PDFName{};
   std::vector<std::string> _weightFileName{};
+ 
+  std::vector<std::string> _methodstorun{};
+  std::string _methodstorun_version{};
+
   EVENT::FloatVec _energyBoundary{};
   LCCollection* _pfoCol{};
   std::vector<int> _pdgTable{};
@@ -47,7 +55,7 @@ private:
   LowMomentumMuPiSeparationPID_BDTG *_mupiPID{};
 
   bool _basicFlg{}, _dEdxFlg{}, _showerShapesFlg{};
-  int _UseBayes{},_UseCorr{};
+  int _UseBayes{};
   bool _UseMVA{};
   float _dEdxNormalization{}, _dEdxErrorFactor{};
 };

--- a/Analysis/PIDTools/src/AngularCorrection_dEdxProcessor.cc
+++ b/Analysis/PIDTools/src/AngularCorrection_dEdxProcessor.cc
@@ -1,0 +1,133 @@
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <utility>
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include <math.h>
+
+#include <marlin/Global.h>
+#include <marlin/Processor.h>
+#include <marlin/AIDAProcessor.h>
+
+#include <lcio.h>
+#include <EVENT/LCCollection.h>
+#include <EVENT/Track.h>
+#include <EVENT/TrackerHit.h>
+#include <IMPL/TrackImpl.h>
+
+#include <DD4hep/Detector.h>
+#include <DDRec/DetectorData.h>
+#include <DD4hep/DD4hepUnits.h>
+
+#include <UTIL/BitField64.h>
+#include "UTIL/LCTrackerConf.h"
+
+// MarlinUtil                                                                                                                                                                                             
+#include "LCGeometryTypes.h"
+#include "SimpleHelix.h"
+#include "HelixClass.h"
+
+#include "signal.h"
+
+#include "AngularCorrection_dEdxProcessor.hh"
+
+AngularCorrection_dEdxProcessor aAngularCorrection_dEdxProcessor ;
+
+AngularCorrection_dEdxProcessor::AngularCorrection_dEdxProcessor()
+  : Processor("AngularCorrection_dEdxProcessor") {
+  
+  // Processor description
+  _description = "Correct_AngularCorrection_dEdxProcessor: Makes a hard angular-based correction of dEdx for all the Tracks in the event. ATTENTION: this processor rewrites the MarlinTrk Collection and it is to be used only for simulations produced with ILCSoft from v02 to v02-02-01" ;
+  
+  registerInputCollection(LCIO::TRACK,
+			  "LDCTrackCollection",
+			  "LDC track collection name",
+			  _LDCTrackCollection,
+			  std::string("MarlinTrkTracks"));
+
+  registerProcessorParameter( "Write_dEdx",
+			      "If set, the calculated dEdx value will be rewritten in the its corresponding track (default: false).",
+			      _writedEdx,
+			      bool(false));
+
+  std::vector<float> _newpar = {  0.970205,
+				  0.0007506,  
+				  4.41781e-8,
+				  5.8222e-8};
+
+  // ***************************************
+  // Fit of NormLamdaFullAll_1 (dEdxAnalyser) using single particle samples recosntructed with v02-02-01
+  // 2021/04
+  // (including the default previous angular correction)
+  //Minimizer is Linear
+  //Chi2                      =      807.398
+  //NDf                       =           27
+  //p0                        =     0.970205   +/-   0.000127468 
+  //p1                        =   0.00075065   +/-   1.55853e-05 
+  //p2                        =  4.41781e-08   +/-   5.09662e-07 
+  //p3                        =   5.8222e-08   +/-   4.71913e-09 
+  //
+  registerProcessorParameter( "AngularCorrectionParameters",
+			      "parameter for new angular correction dedx= uncorrected_dedx  / f, with f= pol3(lambda)",
+			      _par,
+			      _newpar);
+
+
+
+} 
+
+void AngularCorrection_dEdxProcessor::init() { 
+  streamlog_out(DEBUG) << "   init called  " << std::endl ;
+  // it's usually a good idea to
+  printParameters();
+  
+}
+
+void AngularCorrection_dEdxProcessor::processRunHeader( LCRunHeader* ) { 
+} 
+
+void AngularCorrection_dEdxProcessor::processEvent( LCEvent * evt ) { 
+
+  //fill values
+  if (_writedEdx)
+    {
+      _LDCCol = evt->getCollection( _LDCTrackCollection ) ;
+      int nTrkCand = _LDCCol->getNumberOfElements();
+      
+      for (int iTRK=0;iTRK<nTrkCand;++iTRK) {
+	
+	TrackImpl * trkCand = (TrackImpl*) _LDCCol->getElementAt( iTRK );
+	
+	float dedx=trkCand->getdEdx();
+	float dedx_error=trkCand->getdEdxError();
+	float trklambda = trkCand->getTanLambda();
+
+	float lambda = fabs(atan(trklambda)*180./M_PI);
+	double  f3 = 1 / (_par[0] + _par[1] * lambda  + _par[2] * pow(lambda,2) + _par[3] * pow(lambda,3) );
+	
+	double new_dedx = dedx*f3;
+	
+	streamlog_out(DEBUG) << "Original dEdx: " <<dedx <<" Error: "<<dedx_error <<std::endl;
+	streamlog_out(DEBUG) << "NeW dEdx: " <<new_dedx <<" Error: "<<dedx_error <<std::endl;
+	
+	//fill values
+	trkCand->setdEdx(new_dedx);
+	trkCand->setdEdxError(dedx_error);
+      }
+    }   else 
+    {
+      streamlog_out(ERROR) << " Why do you use this processor and not re-write dEdx ?? Check your steering file." <<std::endl;
+      raise(SIGSEGV);
+    }
+}
+
+void AngularCorrection_dEdxProcessor::check( LCEvent * ) { 
+}
+
+void AngularCorrection_dEdxProcessor::end() { 
+}
+
+

--- a/Analysis/PIDTools/src/Compute_dEdxProcessor2021.cc
+++ b/Analysis/PIDTools/src/Compute_dEdxProcessor2021.cc
@@ -1,0 +1,504 @@
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <utility>
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include <math.h>
+
+#include <marlin/Global.h>
+#include <marlin/Processor.h>
+#include <marlin/AIDAProcessor.h>
+
+#include <lcio.h>
+#include <EVENT/LCCollection.h>
+#include <EVENT/Track.h>
+#include <EVENT/TrackerHit.h>
+#include <IMPL/TrackImpl.h>
+
+#include <DD4hep/Detector.h>
+#include <DDRec/DetectorData.h>
+#include <DD4hep/DD4hepUnits.h>
+
+#include <UTIL/BitField64.h>
+#include "UTIL/LCTrackerConf.h"
+
+// MarlinUtil
+#include "LCGeometryTypes.h"
+#include "SimpleHelix.h"
+#include "HelixClass.h"
+
+#include "TCanvas.h"
+#include "TImage.h"
+#include "TStyle.h"
+
+#include "Compute_dEdxProcessor2021.hh"
+
+Compute_dEdxProcessor2021 aCompute_dEdxProcessor2021 ;
+
+Compute_dEdxProcessor2021::Compute_dEdxProcessor2021()
+  : Processor("Compute_dEdxProcessor2021") {
+  
+  // Processor description
+  _description = "dE/dx calculation using truncation method, angular correction applied after smearing" ;
+  
+  registerInputCollection(LCIO::TRACK,
+			  "LDCTrackCollection",
+			  "LDC track collection name",
+			  _LDCTrackCollection,
+			  std::string("MarlinTrkTracks"));
+
+  registerProcessorParameter( "Write_dEdx",
+			      "If set, the calculated dEdx value will be attached to its corresponding track (default: true).",
+			      _writedEdx,
+			      bool(true));
+
+  registerProcessorParameter( "EnergyLossErrorTPC",
+			      "Fractional error of dEdx in the TPC",
+			      _energyLossErrorTPC,
+			      float(0.054));
+  
+  registerProcessorParameter( "LowerTruncationFraction",
+			      "Lower truncation fraction, default: 0.08 (8%)",
+			      _lowerTrunFrac,
+			      float(0.08));
+
+  registerProcessorParameter( "UpperTruncationFraction",
+			      "Upper truncation fraction, default: 0.3 (30%)",
+			      _upperTrunFrac,
+			      float(0.3));
+
+  registerProcessorParameter( "isSmearing",
+			      "Flag for dEdx Smearing",
+			      _isSmearing,
+			      bool(0));
+
+  registerProcessorParameter( "smearingFactor",
+			      "Smearing factor for dEdx smearing",
+			      _smearingFactor,
+			      float(0.035));
+
+  std::vector<float> errexp = {-0.34, -0.45};
+  registerProcessorParameter( "dEdxErrorScalingExponents",
+			      "scaling exponents of the dE/dx error for path length and number of hits, respectively",
+			      _errexp,
+			      errexp);
+  
+  registerProcessorParameter( "dxStrategy",
+			      "ID of the track length calculation: 1 - hit-to-hit distance; 2 - hit-to-hit path length of projected hits; 3 - path over hit row",
+			      _dxStrategy,
+			      int(1));
+
+  registerProcessorParameter( "StrategyCompHist",
+			      "If set, an AIDA root file will be generated with Bethe-Bloch histograms (dE/dx over momentum) for each dx strategy (default: false).",
+			      _StratCompHist,
+			      bool(false));
+
+  registerProcessorParameter( "StrategyCompHistWeight",
+			      "If set, the Bethe-Bloch histograms will have a sqrt(nHits) weighting (default: false).",
+			      _StratCompHistWeight,
+			      bool(false));
+
+  registerProcessorParameter( "StrategyCompHistFiles",
+			      "File names of the generated dx strategy comparison histograms (if chosen). The respective strategy number and '.png' is added.",
+			      _StratCompHistFiles,
+			      std::string("dEdx_Histo_Strategy"));
+
+  registerProcessorParameter( "doAngularCorr_dEdx",
+			      "If set, the calculated dEdx value is corrected as function of a pol3(lambda)",
+			      _angularcorrdEdx,
+			      bool(false));
+
+  std::vector<float> _newpar = {  0.948185, 
+                                  0.000520502,  
+                                  3.33231e-5,
+				  -1.51052e-7};
+  registerProcessorParameter( "AngularCorrectionParameters",
+			      "parameter for new angular correction dedx= uncorrected_dedx  / f, with f= pol3(lambda)",
+			      _par,
+			      _newpar);
+
+
+
+} 
+
+void Compute_dEdxProcessor2021::init() { 
+  streamlog_out(DEBUG) << "   init called  " << std::endl ;
+  
+  // it's usually a good idea to
+  printParameters();
+  
+  //get TPC radii, pad height and B field
+  dd4hep::Detector& lcdd = dd4hep::Detector::getInstance();
+  dd4hep::DetElement tpcDE = lcdd.detector("TPC") ;
+  const dd4hep::rec::FixedPadSizeTPCData* tpc = tpcDE.extension<dd4hep::rec::FixedPadSizeTPCData>() ;
+  _TPC_inner = tpc->rMinReadout/dd4hep::mm;
+  _TPC_outer = tpc->rMaxReadout/dd4hep::mm;
+  _TPC_padHeight = tpc->padHeight/dd4hep::mm;
+  double bfieldV[3] ;
+  lcdd.field().magneticField( { 0., 0., 0. }  , bfieldV  ) ;
+  _bField = bfieldV[2]/dd4hep::tesla ;
+
+  engine = new std::default_random_engine();
+
+  streamlog_out(MESSAGE) << "TPC inner radius = " << _TPC_inner << " mm   TPC outer radius = " << _TPC_outer << " mm"<< std::endl;
+  streamlog_out(MESSAGE) << "TPC pad height = " << _TPC_padHeight << " mm   B field = " << _bField << " T" <<std::endl;
+  streamlog_out(DEBUG) << "dd4hep::mm = " << dd4hep::mm << "   dd4hep::cm = " << dd4hep::cm << std::endl;
+
+  if (_StratCompHist)
+  {
+    // prepare the histogram bins - this could also be implemented as processor parameters
+    const int nBinsX=1000, nBinsY=300;
+    double minBinX=-1, maxBinX=2;  // log10(min/max momentum / GeV)
+    double minBinY= 0, maxBinY=1e-6;
+    double histbinsX[nBinsX+1], histbinsY[nBinsY+1];
+    for (int i=0; i<nBinsX+1; i++) histbinsX[i] = pow( 10, minBinX + (maxBinX-minBinX)*i/(float)(nBinsX) );
+    for (int i=0; i<nBinsY+1; i++) histbinsY[i] = minBinY + (maxBinY-minBinY)*i/(float)(nBinsY);
+
+    // create the histograms
+    AIDAProcessor::tree(this);
+    _BBHist_Strategy1 = new TH2D("BBHist_Strategy1","Bethe-Bloch curve for dx strategy 1: hit-to-hit distance",nBinsX,histbinsX,nBinsY,histbinsY);
+    _BBHist_Strategy2 = new TH2D("BBHist_Strategy2","Bethe-Bloch curve for dx strategy 2: hit-to-hit path length of projected hits",nBinsX,histbinsX,nBinsY,histbinsY);
+    _BBHist_Strategy3 = new TH2D("BBHist_Strategy3","Bethe-Bloch curve for dx strategy 3: path over hit row",nBinsX,histbinsX,nBinsY,histbinsY);
+  }
+}
+
+void Compute_dEdxProcessor2021::processRunHeader( LCRunHeader* ) { 
+} 
+
+void Compute_dEdxProcessor2021::processEvent( LCEvent * evt ) { 
+  _LDCCol = evt->getCollection( _LDCTrackCollection ) ;
+  int nTrkCand = _LDCCol->getNumberOfElements();
+
+  for (int iTRK=0;iTRK<nTrkCand;++iTRK) {
+    
+    TrackImpl * trkCand = (TrackImpl*) _LDCCol->getElementAt( iTRK );
+    TrackerHitVec trkHits = trkCand->getTrackerHits();
+    
+    //calculate dEdx here when the subtrack is the TPC track!
+    //silicon dE/dx can also be calculated. is it necessary??
+    float dedx=0.0;
+    float unum=0.0;
+    
+    //get tpc hits only
+    TrackerHitVec tpcHitVec;
+    for(unsigned int sdet=0;sdet<trkHits.size(); sdet++){
+      if(trkHits[sdet]->getType() == 0){   //it is very suspicious condition...
+        //check whether this hit is in TPC
+        float x=trkHits[sdet]->getPosition()[0];
+        float y=trkHits[sdet]->getPosition()[1];
+        if(sqrt(x*x+y*y)>=_TPC_inner && sqrt(x*x+y*y)<=_TPC_outer) tpcHitVec.push_back(trkHits[sdet]);  // add hit
+        else streamlog_out(DEBUG) << "hit not in TPC: " << x << " " << y << " " << trkHits[sdet]->getPosition()[2] << " " << sqrt(x*x+y*y) << std::endl;
+      }
+    }
+
+    std::pair<double,double> dummy = CalculateEnergyLoss(tpcHitVec, trkCand);
+    dedx = dummy.first;
+    unum = dummy.second*_energyLossErrorTPC;
+
+    if(_angularcorrdEdx==true) {
+      float trklambda = trkCand->getTanLambda();
+      dedx = get_Corrected_dEdx(dedx,trklambda);
+	
+    }
+
+    //fill values
+    if (_writedEdx)
+    {
+      trkCand->setdEdx(dedx);
+      trkCand->setdEdxError(unum);
+    }
+  }
+}
+
+void Compute_dEdxProcessor2021::check( LCEvent * ) { 
+}
+
+void Compute_dEdxProcessor2021::end() { 
+
+  if (_StratCompHist)
+  {
+    TCanvas *can = new TCanvas;
+    TImage *img = TImage::Create();
+    gStyle->SetPalette(kBird);
+    can->SetGrid();
+    can->SetLogx();
+    _BBHist_Strategy1->SetXTitle("momentum / GeV");
+    _BBHist_Strategy1->SetYTitle("dE/dx / (GeV/mm)");
+    _BBHist_Strategy2->SetXTitle("momentum / GeV");
+    _BBHist_Strategy2->SetYTitle("dE/dx / (GeV/mm)");
+    _BBHist_Strategy3->SetXTitle("momentum / GeV");
+    _BBHist_Strategy3->SetYTitle("dE/dx / (GeV/mm)");
+
+    std::string StratCompHistFiles2 = _StratCompHistFiles;
+    _BBHist_Strategy1->Draw("colz");
+    img->FromPad(can);
+    _StratCompHistFiles.append("1.png");
+    img->WriteImage(_StratCompHistFiles.c_str());
+    _BBHist_Strategy2->Draw("colz");
+    img->FromPad(can);
+    _StratCompHistFiles.replace(_StratCompHistFiles.end()-5,_StratCompHistFiles.end()-4,"2");
+    img->WriteImage(_StratCompHistFiles.c_str());
+    _BBHist_Strategy3->Draw("colz");
+    img->FromPad(can);
+    _StratCompHistFiles.replace(_StratCompHistFiles.end()-5,_StratCompHistFiles.end()-4,"3");
+    img->WriteImage(_StratCompHistFiles.c_str());
+
+    delete can;
+    delete img;
+  }
+
+  delete engine;
+}
+
+
+std::pair<double,double> Compute_dEdxProcessor2021::CalculateEnergyLoss(TrackerHitVec& hitVec, Track* trk){
+  int tH=hitVec.size();
+
+  // fill the track into a SimpleHelix and also into a HelixClass to make use of their specific geometric utilities
+  const float* refPoint = trk->getReferencePoint();
+  LCVector3D refPointV3D = LCVector3D(refPoint[0],refPoint[1],refPoint[2]);  // MarlinUtil::LCVector3D is CLHEP::Hep3Vector
+  SimpleHelix trkHelix = SimpleHelix(trk->getD0(),trk->getPhi(),trk->getOmega(),trk->getZ0(),trk->getTanLambda(),refPointV3D);
+  HelixClass trkHelixC;
+  trkHelixC.Initialize_Canonical(trk->getPhi(),trk->getD0(),trk->getZ0(),trk->getOmega(),trk->getTanLambda(),_bField);
+
+  // set up some variables
+  std::vector<double> dEdxVec1, dEdxVec2, dEdxVec3;  // one vector per dx strategy
+  double dx=0, dy=0, dz=0, length=0, totlength=0;
+  double dxy=0, r=0, theta=0, l=0;
+  double path=0, totpath=0, cpath=0;
+  double over=0, totover=0, cover=0;
+  double hitX =0, hitY =0, hitZ =0;
+  double hit0X=0, hit0Y=0, hit0Z=0;
+
+  for(int iH=0; iH<tH; iH++){
+    TrackerHit * hit  = hitVec[iH];
+    hitX  = hit ->getPosition()[0];
+    hitY  = hit ->getPosition()[1];
+    hitZ  = hit ->getPosition()[2];
+
+    if (iH>0)
+    {
+      if (_dxStrategy==1 || _dxStrategy==2 || _StratCompHist)
+      {
+        TrackerHit * hit0 = hitVec[iH-1];
+        hit0X = hit0->getPosition()[0];
+        hit0Y = hit0->getPosition()[1];
+        hit0Z = hit0->getPosition()[2];
+
+        if (_dxStrategy==1 || _StratCompHist)
+        { // strategy 1: dx = distance between 2 hits
+          dx=hitX-hit0X;
+          dy=hitY-hit0Y;
+          dz=hitZ-hit0Z;
+
+          //cal. length of curvature
+          dxy=sqrt(dx*dx+dy*dy);
+          r=1.0/trk->getOmega();
+          theta=2.0*asin(0.5*dxy/r);
+          l=r*theta;
+          //total helix length
+          length=sqrt(l*l+dz*dz);
+
+          //sum of flight length
+          totlength += length;
+          dEdxVec1.push_back(hit->getEDep()/length);
+        }
+
+        if (_dxStrategy==2 || _StratCompHist)
+        { // strategy 2: dx = path difference on the track via SimpleHelix
+          double path1 = trkHelix.getPathAt(LCVector3D(hitX ,hitY ,hitZ ));
+          double path2 = trkHelix.getPathAt(LCVector3D(hit0X,hit0Y,hit0Z));
+          path = fabs(path2-path1);
+          totpath += path;
+          dEdxVec2.push_back(hit->getEDep()/path);
+          cpath++;
+        }
+      }
+    }
+
+    if (_dxStrategy==3 || _StratCompHist)
+    { // strategy 3: dx = path of track over the hit's row via SimpleHelix and HelixClass
+      // since this strategy does not require a distance between two hits, it can be used for every single hit
+      double hitRadius = sqrt(hitX*hitX + hitY*hitY);
+
+      // create cylinders of the row's inner and outer edge, check if the track crosses both, then get the path difference of these crossing points
+      double cyl1_radius = hitRadius - _TPC_padHeight*.5;  // assuming the radial hit position is always in the center of the row
+      double cyl2_radius = hitRadius + _TPC_padHeight*.5;
+      float trkRefP[3];
+        trkRefP[0] = (trkHelixC.getReferencePoint())[0];
+        trkRefP[1] = (trkHelixC.getReferencePoint())[1];
+        trkRefP[2] = (trkHelixC.getReferencePoint())[2];
+      float cross1[6], cross2[6];
+      float time1 = trkHelixC.getPointOnCircle(cyl1_radius, trkRefP, cross1);
+      float time2 = trkHelixC.getPointOnCircle(cyl2_radius, trkRefP, cross2);
+
+      bool rejected = false;
+      if (fabs(time1)<1e+10 && fabs(time2)<1e+10) {  // getPointOnCircle returns -1e+20 when the helix doesn't cross the cylinder
+        if (sqrt(pow(cross1[0]-cross1[3],2) + pow(cross1[1]-cross1[4],2) + pow(cross1[2]-cross1[5],2)) < 2*_TPC_padHeight) rejected = true;  // curler protection
+        if (sqrt(pow(cross2[0]-cross2[3],2) + pow(cross2[1]-cross2[4],2) + pow(cross2[2]-cross2[5],2)) < 2*_TPC_padHeight) rejected = true;
+      }
+      else rejected = true;
+
+      if (!rejected)
+      {
+        float* cross_1 = cross1;  // check which crossing point is the correct one by comparing to the hit position
+        double dist1 = sqrt(pow(cross1[0]-hitX,2) + pow(cross1[1]-hitY,2) + pow(cross1[2]-hitZ,2));
+        double dist2 = sqrt(pow(cross1[3]-hitX,2) + pow(cross1[4]-hitY,2) + pow(cross1[5]-hitZ,2));
+        if (dist2 < dist1) cross_1 = &cross1[3];
+        float* cross_2 = cross2;
+        dist1 = sqrt(pow(cross2[0]-hitX,2) + pow(cross2[1]-hitY,2) + pow(cross2[2]-hitZ,2));
+        dist2 = sqrt(pow(cross2[3]-hitX,2) + pow(cross2[4]-hitY,2) + pow(cross2[5]-hitZ,2));
+        if (dist2 < dist1) cross_2 = &cross2[3];
+
+        // again correct for curvature
+        dxy = sqrt(pow(cross_1[0]-cross_2[0],2) + pow(cross_1[1]-cross_2[1],2));
+        r   = 1./trk->getOmega();
+        l   = r*2.*asin(0.5*dxy/r);
+        over= sqrt(l*l + pow(cross_1[2]-cross_2[2],2));
+
+        totover += over;
+        cover++;
+        dEdxVec3.push_back(hit->getEDep()/over);
+      }
+    }
+
+    streamlog_out(DEBUG3) << "1: " << length << "  2: " << path << "  3: " << over << "  EDep: " << hit->getEDep() << std::endl;
+    if (length/over>1.5 || over/length>1.5) streamlog_out(DEBUG2) << "  " << hitX << " " << hitY << " " << hitZ << " " << sqrt(hitX*hitX + hitY*hitY) << std::endl;
+  }
+  streamlog_out(DEBUG4) << "1: " << totlength << "  2: " << totpath  << " of " << cpath << "  3: " << totover << " of " << cover << std::endl;
+
+
+  int nTruncate=0;  // number of remaining track hits after truncation
+  double normdedx=0, totway=0;
+  // double trkcos = sqrt(trk->getTanLambda()*trk->getTanLambda()/(1.0+trk->getTanLambda()*trk->getTanLambda()));
+
+  // if comparison plots should be made, the dE/dx for all three strategies is calculated, filled in histograms,
+  // and the one of the chosen strategy is also transferred to be returned
+  if (_StratCompHist)
+  {
+    double dedx1=0, dedx2=0, dedx3=0;
+    int nTruncate1=0, nTruncate2=0, nTruncate3=0;
+
+    std::sort(dEdxVec1.begin(),dEdxVec1.end());
+    std::sort(dEdxVec2.begin(),dEdxVec2.end());
+    std::sort(dEdxVec3.begin(),dEdxVec3.end());
+
+    for (int idE=dEdxVec1.size()*_lowerTrunFrac; idE<dEdxVec1.size()*(1-_upperTrunFrac); idE++) {dedx1 += dEdxVec1[idE]; nTruncate1++;}
+    for (int idE=dEdxVec2.size()*_lowerTrunFrac; idE<dEdxVec2.size()*(1-_upperTrunFrac); idE++) {dedx2 += dEdxVec2[idE]; nTruncate2++;}
+    for (int idE=dEdxVec3.size()*_lowerTrunFrac; idE<dEdxVec3.size()*(1-_upperTrunFrac); idE++) {dedx3 += dEdxVec3[idE]; nTruncate3++;}
+
+    //cal. truncated mean
+    dedx1 = dedx1/(float)(nTruncate1);
+    dedx2 = dedx2/(float)(nTruncate2);
+    dedx3 = dedx3/(float)(nTruncate3);
+    streamlog_out(DEBUG4) << "  check dedx: " << dedx1 << " " << dedx2 << " " << dedx3 << std::endl;
+
+    double normdedx1 = dedx1;//getNormalization(dedx1, (float)nTruncate1, trkcos);
+    double normdedx2 = dedx2;//getNormalization(dedx2, (float)nTruncate2, trkcos);
+    double normdedx3 = dedx3;//getNormalization(dedx3, (float)nTruncate3, trkcos);
+    if(_isSmearing)
+    {
+      normdedx1 += getSmearing(normdedx1);
+      normdedx2 += getSmearing(normdedx2);
+      normdedx3 += getSmearing(normdedx3);
+    }
+
+    double lmom = sqrt(pow(trkHelixC.getMomentum()[0],2) + pow(trkHelixC.getMomentum()[1],2) + pow(trkHelixC.getMomentum()[2],2));
+
+    if (_StratCompHistWeight) {
+      _BBHist_Strategy1->Fill(lmom,normdedx1,sqrt(nTruncate1));
+      _BBHist_Strategy2->Fill(lmom,normdedx2,sqrt(nTruncate2));
+      _BBHist_Strategy3->Fill(lmom,normdedx3,sqrt(nTruncate3));
+    }
+    else {
+      _BBHist_Strategy1->Fill(lmom,normdedx1);
+      _BBHist_Strategy2->Fill(lmom,normdedx2);
+      _BBHist_Strategy3->Fill(lmom,normdedx3);
+    }
+
+    switch (_dxStrategy)
+    {
+    case  1: normdedx = normdedx1; nTruncate = nTruncate1; totway = totlength; break;
+    case  2: normdedx = normdedx2; nTruncate = nTruncate2; totway = totpath;   break;
+    case  3: normdedx = normdedx3; nTruncate = nTruncate3; totway = totover;   break;
+    }
+  }
+  else   // to if (_StratCompHist)
+  {
+    double dedx=0;
+    std::vector<double> dEdxVec;
+    switch (_dxStrategy)
+    {
+    case  1: dEdxVec = dEdxVec1; totway = totlength; break;
+    case  2: dEdxVec = dEdxVec2; totway = totpath;   break;
+    case  3: dEdxVec = dEdxVec3; totway = totover;   break;
+    }
+
+    std::sort(dEdxVec.begin(),dEdxVec.end());
+    for (int idE=dEdxVec.size()*_lowerTrunFrac; idE<dEdxVec.size()*(1-_upperTrunFrac); idE++) {dedx += dEdxVec[idE]; nTruncate++;}
+    dedx = dedx/(float)(nTruncate);
+    normdedx = dedx;//getNormalization(dedx, (float)nTruncate, trkcos);
+    if(_isSmearing) normdedx += getSmearing(normdedx);
+  }
+
+
+  std::pair<double,double> ret;
+  if(std::isnan(normdedx))
+  {
+    ret.first =0;
+    ret.second=0;
+    streamlog_out(DEBUG4) << "NAN!" << std::endl;
+  }
+  else
+  {
+    ret.first =normdedx;
+    ret.second=normdedx*std::pow(0.001*totway, _errexp[0])*std::pow(nTruncate, _errexp[1]);   //todo: what is gas pressure in TPC?
+  }
+
+  return ret;
+}
+
+
+//create smearing factor
+double Compute_dEdxProcessor2021::getSmearing(double dEdx){
+  double z=sqrt( -2.0*std::log(dist(*engine)) ) * std::sin( 2.0*M_PI*dist(*engine) ); // 3.141592
+
+  //std::cout << dist(*engine) << " " << z << std::endl;
+
+  return 0.0 + dEdx * _smearingFactor * z;
+}
+
+double Compute_dEdxProcessor2021::get_Corrected_dEdx(float dedx, float trklambda){
+
+  // // DEFAULT CORRECTION APPLIED FOR THE MC2020 production obtained using versions v02-02-01 and previous
+  // //cal. hit dep.
+  //double f1 = 1 + std::exp(-nHit/_ncorrpar);
+  // //cal. polar angle dep.
+  // // double c=1.0/sqrt(1.0-trkcos*trkcos);
+  // // double f2=1.0/(1.0-0.08887*std::log(c)); 
+
+  // //cal. polar angle dep.   20160702
+  // //double c = std::acos(trkcos);
+  // //if(c>3.141592/2.0) c= 3.141592-c;
+  // //double f2 = 1.0/std::pow(c, 0.0703);
+
+  // //change polar angle dep. 20170901
+  // double f2 = _acorrpar[0] / (_acorrpar[0] + _acorrpar[1] * trkcos * trkcos);
+  // return dedx/(f1*f2);
+  
+  // ****************************************
+  // NEW CORRECTION
+  //Parametrization by A. Irles, U. Einhaus  2021/04
+  //Using single particle mc2020 samples v02-02-01
+  //Analyzed with dEdxAnalyser, fitting histogram NormLambdaFullAll_1
+  float lambda = fabs(atan(trklambda)*180./M_PI);
+  double  f3 = 1 / (_par[0] + _par[1] * lambda  + _par[2] * pow(lambda,2) + _par[3] * pow(lambda,3) );
+
+  return dedx*f3;
+
+}
+
+

--- a/Analysis/PIDTools/src/LikelihoodPID.cc
+++ b/Analysis/PIDTools/src/LikelihoodPID.cc
@@ -55,7 +55,6 @@ LikelihoodPID::LikelihoodPID(double *pars){
   _usebayes=(int)pars[25];
   _dEdxnorm=(float)pars[26];
   _dEdxerrfact=pars[27];
-  _usecorr=(int)pars[28];
 
   //set mass
   emass=0.000510998;
@@ -90,7 +89,6 @@ LikelihoodPID::LikelihoodPID(string fname, double *pars, std::vector<float> cost
   _usebayes=(int)pars[25];
   _dEdxnorm=(float)pars[26];
   _dEdxerrfact=pars[27];
-  _usecorr=(int)pars[28];
 
   //set mass
   emass=0.000510998;
@@ -395,7 +393,7 @@ double LikelihoodPID::get_dEdxChi2(int parttype, TVector3 p, float hit, double d
   double trkcos=p.CosTheta();
 
   //get nomalized dEdx
-  double dEdx_Norm=get_Norm(dEdx, hit, trkcos);
+  double dEdx_Norm=get_Norm(dEdx);
 
   //get expected dE/dx
   double ExpdEdx=BetheBloch(p.Mag(),tmpmass,tmppar);
@@ -437,7 +435,7 @@ double LikelihoodPID::get_dEdxFactor(int parttype, TVector3 p, float hit, double
   double trkcos=p.CosTheta();
 
   //get nomalized dEdx
-  double dEdx_Norm=get_Norm(dEdx, hit, trkcos);
+  double dEdx_Norm=get_Norm(dEdx);
 
   //cout << "check " << emass << " " << tmpmass << " " << trkcos << " " << dEdx_Norm << " " << ExpdEdx << endl;
   double dEdx_Error = _dEdxerrfact * dEdx_Norm * hit/dEdx;    //change 20151218
@@ -458,26 +456,8 @@ double LikelihoodPID::get_dEdxDist(int parttype){
   return dedxdist;
 }
 
-double LikelihoodPID::get_Norm(double dedx, float hit, double trkcos){
-  //cal. hit dep.
-  double f1=1.0;   //1.0+TMath::Exp(-hit/1.468);   //already corrected
-  //cal. polar angle dep.
-  //double c=1.0/sqrt(1.0-trkcos*trkcos);
-  double f2=1.0;   //1.0/(1.0-0.08887*TMath::Log(c));    //already corrected
-
-  //For dEdx angle correction
-  if(_usecorr==1){
-    //make pdep
-    double ss = 1.0/sqrt(1.0-trkcos*trkcos);
-    f1=f1*(1.0-0.08887*std::log(ss)); 
-    //*(8.11120e-01+5.99762e-02*ss+1.11261e-01*ss*ss);
-    
-    double theta = std::cos(trkcos);
-    if(theta>3.141592/2.0) theta = 3.141592-theta;
-    f1 = f1*TMath::Power(theta,0.0703);
-  }
-
-  return dedx*f1*f2/_dEdxnorm;
+double LikelihoodPID::get_Norm(double dedx){
+  return dedx/_dEdxnorm;
 }
 
 double LikelihoodPID::BetheBloch(double x, double mass, double *pars){

--- a/Analysis/PIDTools/steer/DSTcorrection_dEdx_and_LikelihoodPID.xml
+++ b/Analysis/PIDTools/steer/DSTcorrection_dEdx_and_LikelihoodPID.xml
@@ -1,0 +1,97 @@
+<!-- 
+Example of steering file to correct the angular dependence of dEdx in
+2020 DST samples (and all generated with v02-02, v02-02-01..)
+It requires rewriting the track info  -> <parameter name="AllowToModifyEvent" value="true" />  
+
+Author: A. Irles 2021/04
+
+-->
+
+<marlin>
+
+ <constants>
+    <constant name="productionfolder" value="/cvmfs/ilc.desy.de/sw/ILDConfig/v02-02/StandardConfig/production" />
+  </constants>
+
+  <!--########  Execute  ######################################## -->
+  <execute>
+    <processor name="InitDD4hep"/>
+    <processor name="MyCorrect_Compute_dEdxProcessor"/>  
+    <processor name="MyLikelihoodPID" />
+    <processor name="DSTOutput"/>
+  </execute>
+
+  <!--########  Global  ######################################## -->
+  <global>
+    <parameter name="LCIOInputFiles">
+      /lustre/ific.uv.es/prj/ific/flc/mc-2020/250-SetA/2f_hadronic_eL_pR/ILD_l5_o1_v02/v02-02/00015161/000/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.n000.d_dstm_15161_0.slcio
+    </parameter>
+    <parameter name="AllowToModifyEvent" value="true" />  
+    <parameter name="MaxRecordNumber" value="0"/>  
+    <!--parameter name="GearXMLFile" value="GearOutput.xml"/-->
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> SILENT </parameter>
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+
+    <processor name="InitDD4hep" type="InitializeDD4hep">
+    <parameter name="DD4hepXMLFile" type="string">
+      /cvmfs/ilc.desy.de/sw/x86_64_gcc82_centos7/v02-02/lcgeo/v00-16-06/ILD/compact/ILD_o1_v05/ILD_o1_v05.xml
+    </parameter>
+  </processor>
+
+
+  <processor name="DSTOutput" type="LCIOOutputProcessor">
+    <!--DST output: drop all hits, skim MCParticles and keep final Tracks, Clusters and  ReconstructedParticles-->
+    <parameter name="LCIOOutputFile" type="string" > out.slcio </parameter>
+    <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
+    <!--parameter name="SplitFileSizekB" type="int" value="1992294"/-->
+  </processor>
+
+   <processor name="MyCorrect_Compute_dEdxProcessor" type="AngularCorrection_dEdxProcessor">
+    <!-- description not set by author -->
+    <!--parameter for new angular correction dedx= uncorrected_dedx  / f, with f= pol3(lambda)-->
+    <!-- Parameters for 2020 DST (and all generated with v02-02 and v02-02-01 -->
+    <parameter name="AngularCorrectionParameters" type="FloatVec"> 0.970205 0.0007506 4.41781e-8 5.8222e-8 </parameter>
+    <!--LDC track collection name-->
+    <parameter name="LDCTrackCollection" type="string" lcioInType="Track">MarlinTrkTracks </parameter>
+    <!--parameters used in the outdated angular correction outdated_dedx= uncorrected_dedx / f, with f = 1. / ( 1.0+[1]*cos(theta)*cos(theta)/[0] )-->
+    <parameter name="Write_dEdx" type="bool">true </parameter>
+  </processor>
+
+  <!-- Post reconstruction related : PID, Vertexing, Particle finding, cluster topology -->
+  <processor name="MyLikelihoodPID" type="LikelihoodPIDProcessor">
+    <!--Performs particle identification-->
+    <!--Debugging?-->
+    <parameter name="Debug" type="int">0</parameter>
+    <!--Boundaries for energy binning-->
+    <parameter name="EnergyBoundaries" type="FloatVec">0 1.0e+07</parameter>
+    <!--Name of files containing pdfs for charged particles-->
+    <parameter name="FilePDFName" type="StringVec"> ${productionfolder}/HighLevelReco/PIDFiles/LikelihoodPID_Standard_l5_v01.root </parameter>
+    <!--Whether MVA low momentum mu/pi is used or not-->
+    <parameter name="UseLowMomentumMuPiSeparation" type="bool">true</parameter>
+    <!--The BDTG weights files for low momentum mu/pi separation-->
+    <parameter name="FileWeightFormupiSeparationName" type="StringVec">${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_02GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_03GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_04GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_05GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_06GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_07GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_08GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_09GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_10GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_11GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_12GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_13GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_14GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_15GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_16GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_17GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_18GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_19GeVP_clusterinfo.weights.xml ${productionfolder}/HighLevelReco/PIDFiles/LowMomMuPiSeparation/TMVAClassification_BDTG_l5_20GeVP_clusterinfo.weights.xml </parameter>
+    <!--dE/dx parameters for each particle-->
+    <!-- Parameters for 2020 DST (and all generated with v02-02 and v02-02-01 -->
+    <parameter name="dEdxParameter_electron" type="FloatVec"> -0.00232937 -3.88424e+13 -37881.1 -1.56837 0 </parameter>
+    <parameter name="dEdxParameter_muon" type="FloatVec"> 0.0717375 -16596.5 -4.84028e+07 0.356728 0.000371431 </parameter>
+    <parameter name="dEdxParameter_pion" type="FloatVec"> 0.0733683 51678.4 8.19644e+07 0.453505 0.000404984 </parameter>
+    <parameter name="dEdxParameter_kaon" type="FloatVec"> 0.0792784 3798.12 4.06952e+07 0.450671 0.00050169 </parameter>
+    <parameter name="dEdxParameter_proton" type="FloatVec"> 0.0770318 1053.24 4.95076e+06 0.281489 0.000168616 </parameter>
+    <!--dE/dx normalization-->
+    <parameter name="dEdxNormalization" type="float">1.350e-7</parameter>
+    <!--dE/dx error factor(7.55 for l5, 8.53 for s5)--> 
+    <parameter name="dEdxErrorFactor" type="float">7.55</parameter>
+    <!-- Method: Maximum Likelihood(0), Bayesian(1), or risk based Bayesian(2)-->
+    <parameter name="UseBayesian" type="int">2</parameter>
+    <!-- Cost Matrix for risk based Bayesian(2)-->
+    <parameter name="CostMatrix" type="FloatVec">1.0e-50 1.0 1.5 1.0 1.5 1.0 1.0e-50 3.0 1.0 1.0 1.0 1.0 1.0e-50 1.0 3.0 1.0 1.0 4.0 1.0e-50 2.0 1.0 1.0 5.0 1.0 1.0e-50</parameter>
+    <!--Version to be added to the name of the calculated methods-->
+    <parameter name="PIDMethodsToRun_version" type="string"> v2 </parameter>
+    <!--Name of the PFO collection-->
+    <parameter name="RecoParticleCollection" type="string"> PandoraPFOs </parameter>
+  </processor> 
+
+</marlin>

--- a/Analysis/PIDTools/steer/DSTcorrection_dEdx_and_LikelihoodPID.xml
+++ b/Analysis/PIDTools/steer/DSTcorrection_dEdx_and_LikelihoodPID.xml
@@ -1,7 +1,6 @@
 <!-- 
 Example of steering file to correct the angular dependence of dEdx in
 2020 DST samples (and all generated with v02-02, v02-02-01..)
-It requires rewriting the track info  -> <parameter name="AllowToModifyEvent" value="true" />  
 
 Author: A. Irles 2021/04
 
@@ -26,7 +25,6 @@ Author: A. Irles 2021/04
     <parameter name="LCIOInputFiles">
       /lustre/ific.uv.es/prj/ific/flc/mc-2020/250-SetA/2f_hadronic_eL_pR/ILD_l5_o1_v02/v02-02/00015161/000/rv02-02.sv02-02.mILD_l5_o1_v02.E250-SetA.I500010.P2f_z_h.eL.pR.n000.d_dstm_15161_0.slcio
     </parameter>
-    <parameter name="AllowToModifyEvent" value="true" />  
     <parameter name="MaxRecordNumber" value="0"/>  
     <!--parameter name="GearXMLFile" value="GearOutput.xml"/-->
     <parameter name="SkipNEvents" value="0"/>
@@ -57,7 +55,6 @@ Author: A. Irles 2021/04
     <!--LDC track collection name-->
     <parameter name="LDCTrackCollection" type="string" lcioInType="Track">MarlinTrkTracks </parameter>
     <!--parameters used in the outdated angular correction outdated_dedx= uncorrected_dedx / f, with f = 1. / ( 1.0+[1]*cos(theta)*cos(theta)/[0] )-->
-    <parameter name="Write_dEdx" type="bool">true </parameter>
   </processor>
 
   <!-- Post reconstruction related : PID, Vertexing, Particle finding, cluster topology -->

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,3 +1,15 @@
+# v01-31
+* 2021-04-23 A. Irles ([Discussion](https://agenda.linearcollider.org/event/9197/))
+  - PIDTools: 
+  	- LikelihoodPID modified to be able to accept as arguments the name and type of method to run and store (allowing for versioning)
+  	- AngularCorrection_dEdxProcessor created to use with DST samples generated with v02-02 and v02-02-01. The dEdx is corrected for angular effects.
+  	- Compute_dEdxProcessor2021, modifictation of the default Compute_dEdxProcessor t
+  		- The angular correction is optional
+  		- The function of this correction is a pol3(lambda)
+  		- It is applied AFTER smearing
+	- Example steering files are added.
+
+
 # v01-30
 
 * 2021-03-03 Remi Ete ([PR#83](https://github.com/iLCSoft/MarlinReco/pull/83))

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,15 +1,3 @@
-# v01-31
-* 2021-04-23 A. Irles ([Discussion](https://agenda.linearcollider.org/event/9197/))
-  - PIDTools: 
-  	- LikelihoodPID modified to be able to accept as arguments the name and type of method to run and store (allowing for versioning)
-  	- AngularCorrection_dEdxProcessor created to use with DST samples generated with v02-02 and v02-02-01. The dEdx is corrected for angular effects.
-  	- Compute_dEdxProcessor2021, modifictation of the default Compute_dEdxProcessor t
-  		- The angular correction is optional
-  		- The function of this correction is a pol3(lambda)
-  		- It is applied AFTER smearing
-	- Example steering files are added.
-
-
 # v01-30
 
 * 2021-03-03 Remi Ete ([PR#83](https://github.com/iLCSoft/MarlinReco/pull/83))


### PR DESCRIPTION
Pull request for the dEdxAngular correction issues discussed in https://agenda.linearcollider.org/event/9197/
Related to Issue #90 

The ee-> bb/cc/ss (250GeV) analysis team ( @airqui  @yuichiok) have validated the steering files and processor and checked that the dEdx performance is recovered

@tmadlener @gaede 
Note: I did modify manually the ReleaseNotes.md file in my private branch... I am not sure if the information will be double-written or not.

BEGINRELEASENOTES
  - PIDTools: 
  	- LikelihoodPID modified to be able to accept as arguments the name and type of method to run and store (allowing for versioning)
  	- AngularCorrection_dEdxProcessor created to use with DST samples generated with v02-02 and v02-02-01. The dEdx is corrected for angular effects.
  	- Compute_dEdxProcessor2021, modifictation of the default Compute_dEdxProcessor
  		- The angular correction is optional
  		- The function of this correction is a pol3(lambda)
  		- It is applied AFTER smearing
	- Example steering files are added.

ENDRELEASENOTES