### PR TITLE
IsolatedLeptonTagging: Always fill expected output collections if inputs are empty

### DIFF
--- a/Analysis/IsolatedLeptonTagging/include/IsolatedLeptonTaggingProcessor.h
+++ b/Analysis/IsolatedLeptonTagging/include/IsolatedLeptonTaggingProcessor.h
@@ -44,6 +44,11 @@ class IsolatedLeptonTaggingProcessor : public marlin::Processor {
   
  protected:
 
+  /**
+   * Add the expected output collections
+   */
+  virtual void addOutputColls(LCEvent* evt, LCCollection* pfosWithoutIsoLepColl, LCCollection* isoLepColl);
+
   /** Input collection name.
    */
   std::string _colPFOs{};

--- a/Analysis/TauFinder/src/TaJetClustering.cc
+++ b/Analysis/TauFinder/src/TaJetClustering.cc
@@ -183,8 +183,7 @@ bool compareEnergy( ReconstructedParticle * const &p1, ReconstructedParticle * c
 void TaJetClustering::processEvent( LCEvent * evt ) { 
 
   // obtain Reconstructed Particles
-  LCCollection* col = evt->getCollection( _pfoCollectionName );
-  if( !col ){ /*cout << "Failed to obtain PFO collection!" << endl;*/ return; }
+  LCCollection* col = evt->getCollection(_pfoCollectionName);
   int nPart = col->getNumberOfElements();
   
   // output collection
@@ -457,12 +456,12 @@ void TaJetClustering::processEvent( LCEvent * evt ) {
     pRemainCol->addElement(p);
   }
   evt->addCollection( pRemainCol, _remainCollectionName );
-  
+
   //-- note: this will not be printed if compiled w/o MARLINDEBUG=1 !
-  streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber() 
-		       << "   in run:  " << evt->getRunNumber() 
+  streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber()
+		       << "   in run:  " << evt->getRunNumber()
 		       << std::endl ;
-  
+
   _nEvt ++ ;
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the IsolatedLeptonTagging processor always produce the expected output collections, even for empty input collections, i.e. if the inputs are empty:
  - the `OutputPFOsWithoutIsoLepCollection` will simply have the same content as the `InputPandoraPFOsCollection`
  -  the `OutputIsoLeptonsCollection` will be empty. 
- On the other hand actually missing input collections will now no longer be handled as these point to a real problem (e.g. typo in the collection name). Fixes #93

ENDRELEASENOTES