### PR TITLE
fix units in TPC parameters

### DIFF
--- a/Tracking/KinkFinder/src/KinkFinder.cc
+++ b/Tracking/KinkFinder/src/KinkFinder.cc
@@ -195,9 +195,9 @@ void KinkFinder::init() {
   dd4hep::DetElement tpcDE = theDet.detector("TPC") ;
   const dd4hep::rec::FixedPadSizeTPCData* tpc = tpcDE.extension<dd4hep::rec::FixedPadSizeTPCData>() ;
 
-  _tpcInnerR = tpc->rMinReadout; 
-  _tpcOuterR = tpc->rMaxReadout;
-  _tpcZmax   = tpc->driftLength;
+  _tpcInnerR = tpc->rMinReadout/dd4hep::mm;
+  _tpcOuterR = tpc->rMaxReadout/dd4hep::mm;
+  _tpcZmax   = tpc->driftLength/dd4hep::mm;
   _tpcMaxRow = tpc->maxRow;
 
 

--- a/Tracking/KinkFinder/src/KinkFinder.cc
+++ b/Tracking/KinkFinder/src/KinkFinder.cc
@@ -206,7 +206,7 @@ void KinkFinder::init() {
   _nLayersVTX=vtx->layers.size(); 
 
   for(int iL=0;iL<_nLayersVTX;iL++){
-    _rVTX.push_back( vtx->layers[iL].distanceSensitive );
+    _rVTX.push_back( vtx->layers[iL].distanceSensitive/dd4hep::mm );
   }
 
   dd4hep::DetElement sitDE = theDet.detector("SIT");
@@ -214,7 +214,7 @@ void KinkFinder::init() {
   _nLayersSIT=sit->layers.size(); 
 
   for(int iL=0;iL<_nLayersSIT;iL++){
-    _rSIT.push_back( sit->layers[iL].distanceSensitive );
+    _rSIT.push_back( sit->layers[iL].distanceSensitive/dd4hep::mm );
   }
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- apply the correct units for TPC parameters from DD4hep
     - fixes #97
-  apply correct units for VXD and SIT layers
     -   need cross check of efficiency for kink finding 
     -  (how could this have worked before ?)

ENDRELEASENOTES