### PR TITLE
Fix all warnings inside MarlinReco and enable -Werror in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
+          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " ..
           ninja -k0
           ctest --output-on-failure
           ninja install

--- a/Analysis/CLICPfoSelector/include/PfoUtilities.h
+++ b/Analysis/CLICPfoSelector/include/PfoUtilities.h
@@ -47,7 +47,7 @@ namespace PfoUtil {
 
   typedef std::vector<EVENT::ReconstructedParticle*> PfoList;
 
-  static bool PfoSortFunction(EVENT::ReconstructedParticle* lhs, EVENT::ReconstructedParticle* rhs) {
+  inline bool PfoSortFunction(EVENT::ReconstructedParticle* lhs, EVENT::ReconstructedParticle* rhs) {
     //  true if lhs goes before
 
     const float             lhs_energy       = lhs->getEnergy();

--- a/Analysis/EventShapes/include/jama_eig.h
+++ b/Analysis/EventShapes/include/jama_eig.h
@@ -18,7 +18,7 @@ class Eigenvalue
  private:
 
    /** Row and column dimension (square matrix).  */
-   int n{};
+   int _n{};
    int issymmetric{}; /* boolean*/
    float d[3]{};
    float e[3]{};
@@ -33,13 +33,13 @@ class Eigenvalue
    //  Auto. Comp., Vol.ii-Linear Algebra, and the corresponding
    //  Fortran subroutine in EISPACK.
 
-      for (int j = 0; j < n; j++) {
-         d[j] = V[n-1][j];
+      for (int j = 0; j < _n; j++) {
+         d[j] = V[_n-1][j];
       }
 
       // Householder reduction to tridiagonal form.
    
-      for (int i = n-1; i > 0; i--) {
+      for (int i = _n-1; i > 0; i--) {
    
          // Scale to avoid under/overflow.
    
@@ -111,8 +111,8 @@ class Eigenvalue
    
       // Accumulate transformations.
    
-      for (int i = 0; i < n-1; i++) {
-         V[n-1][i] = V[i][i];
+      for (int i = 0; i < _n-1; i++) {
+         V[_n-1][i] = V[i][i];
          V[i][i] = 1.0;
          float h = d[i+1];
          if (h != 0.0) {
@@ -133,11 +133,11 @@ class Eigenvalue
             V[k][i+1] = 0.0;
          }
       }
-      for (int j = 0; j < n; j++) {
-         d[j] = V[n-1][j];
-         V[n-1][j] = 0.0;
+      for (int j = 0; j < _n; j++) {
+         d[j] = V[_n-1][j];
+         V[_n-1][j] = 0.0;
       }
-      V[n-1][n-1] = 1.0;
+      V[_n-1][_n-1] = 1.0;
       e[0] = 0.0;
    } 
 
@@ -150,15 +150,15 @@ class Eigenvalue
    //  Auto. Comp., Vol.ii-Linear Algebra, and the corresponding
    //  Fortran subroutine in EISPACK.
    
-      for (int i = 1; i < n; i++) {
+      for (int i = 1; i < _n; i++) {
          e[i-1] = e[i];
       }
-      e[n-1] = 0.0;
+      e[_n-1] = 0.0;
    
       float f = 0.0;
       float tst1 = 0.0;
       float eps = pow(2.0,-52.0);
-      for (int l = 0; l < n; l++) {
+      for (int l = 0; l < _n; l++) {
 
          // Find small subdiagonal element
    
@@ -166,7 +166,7 @@ class Eigenvalue
          int m = l;
 
         // Original while-loop from Java code
-         while (m < n) {
+         while (m < _n) {
             if (abs(e[m]) <= eps*tst1) {
                break;
             }
@@ -194,7 +194,7 @@ class Eigenvalue
                d[l+1] = e[l] * (p + r);
                float dl1 = d[l+1];
                float h = g - d[l];
-               for (int i = l+2; i < n; i++) {
+               for (int i = l+2; i < _n; i++) {
                   d[i] -= h;
                }
                f = f + h;
@@ -223,7 +223,7 @@ class Eigenvalue
    
                   // Accumulate transformation.
    
-                  for (int k = 0; k < n; k++) {
+                  for (int k = 0; k < _n; k++) {
                      h = V[k][i+1];
                      V[k][i+1] = s * V[k][i] + c * h;
                      V[k][i] = c * V[k][i] - s * h;
@@ -243,10 +243,10 @@ class Eigenvalue
      
       // Sort eigenvalues and corresponding vectors.
    
-      for (int i = 0; i < n-1; i++) {
+      for (int i = 0; i < _n-1; i++) {
          int k = i;
          float p = d[i];
-         for (int j = i+1; j < n; j++) {
+         for (int j = i+1; j < _n; j++) {
             if (d[j] < p) {
                k = j;
                p = d[j];
@@ -255,7 +255,7 @@ class Eigenvalue
          if (k != i) {
             d[k] = d[i];
             d[i] = p;
-            for (int j = 0; j < n; j++) {
+            for (int j = 0; j < _n; j++) {
                p = V[j][i];
                V[j][i] = V[j][k];
                V[j][k] = p;
@@ -274,7 +274,7 @@ class Eigenvalue
       //  Fortran subroutines in EISPACK.
    
       int low = 0;
-      int high = n-1;
+      int high = _n-1;
    
       for (int m = low+1; m <= high-1; m++) {
    
@@ -303,7 +303,7 @@ class Eigenvalue
             // Apply Householder similarity transformation
             // H = (I-u*u'/h)*H*(I-u*u')/h)
    
-            for (int j = m; j < n; j++) {
+            for (int j = m; j < _n; j++) {
                float f = 0.0;
                for (int i = high; i >= m; i--) {
                   f += ort[i]*H[i][j];
@@ -331,8 +331,8 @@ class Eigenvalue
    
       // Accumulate transformations (Algol's ortran).
 
-      for (int i = 0; i < n; i++) {
-         for (int j = 0; j < n; j++) {
+      for (int i = 0; i < _n; i++) {
+         for (int j = 0; j < _n; j++) {
             V[i][j] = (i == j ? 1.0 : 0.0);
          }
       }
@@ -362,17 +362,17 @@ class Eigenvalue
 
    float cdivr{}, cdivi{};
    void cdiv(float xr, float xi, float yr, float yi) {
-      float r,d;
+      float r,dd;
       if (abs(yr) > abs(yi)) {
          r = yi/yr;
-         d = yr + r*yi;
-         cdivr = (xr + r*xi)/d;
-         cdivi = (xi - r*xr)/d;
+         dd = yr + r*yi;
+         cdivr = (xr + r*xi)/dd;
+         cdivi = (xi - r*xr)/dd;
       } else {
          r = yr/yi;
-         d = yi + r*yr;
-         cdivr = (r*xr + xi)/d;
-         cdivi = (r*xi - xr)/d;
+         dd = yi + r*yr;
+         cdivr = (r*xr + xi)/dd;
+         cdivi = (r*xi - xr)/dd;
       }
    }
 
@@ -835,21 +835,21 @@ public:
    */
 
    Eigenvalue( float A[3][3]) {
-      n = 3;
+      _n = 3;
       issymmetric = 1;
 
-      for (int j = 0; (j < n) && issymmetric; j++) {
+      for (int j = 0; (j < _n) && issymmetric; j++) {
 	  d[j]=0.0;
           e[j]=0.0;
-         for (int i = 0; (i < n) && issymmetric; i++) {
+         for (int i = 0; (i < _n) && issymmetric; i++) {
             issymmetric = (A[i][j] == A[j][i]);
         
          }
       }
 
       if (issymmetric) {
-         for (int i = 0; i < n; i++) {
-            for (int j = 0; j < n; j++) {
+         for (int i = 0; i < _n; i++) {
+            for (int j = 0; j < _n; j++) {
                V[i][j] = A[i][j];
             }
          }
@@ -863,8 +863,8 @@ public:
       } else {
         
          
-         for (int j = 0; j < n; j++) {
-            for (int i = 0; i < n; i++) {
+         for (int j = 0; j < _n; j++) {
+            for (int i = 0; i < _n; i++) {
                H[i][j] = A[i][j];
             }
          }
@@ -946,8 +946,8 @@ public:
 	
 */
    void getD (float D[3][3]) {
-      for (int i = 0; i < n; i++) {
-         for (int j = 0; j < n; j++) {
+      for (int i = 0; i < _n; i++) {
+         for (int j = 0; j < _n; j++) {
             D[i][j] = 0.0;
          }
          D[i][i] = d[i];

--- a/Analysis/EventShapes/src/ThrustReconstruction.cc
+++ b/Analysis/EventShapes/src/ThrustReconstruction.cc
@@ -268,7 +268,8 @@ int ThrustReconstruction::JetsetThrust(){
   const float dConv=0.0001; // 0.0001
   int sgn;
   double theta=0,phi=0;
-  double thp,thps,tds,tmax,dOblateness;
+  double thp,thps,tds,tmax;
+  // double dOblateness;
   vector<Hep3Vector> TAxes(3),Fast(iFastMax+1),Workv(nwork);
   vector<double> Workf(nwork),dThrust(3);
   Hep3Vector tdi,tpr,mytest;
@@ -408,7 +409,7 @@ int ThrustReconstruction::JetsetThrust(){
       TAxes[i].rotateY(theta); 
       TAxes[i].rotateZ(phi); 
     }
-  dOblateness = dThrust[1] - dThrust[2];
+  // dOblateness = dThrust[1] - dThrust[2];
 
   _principleThrustValue = dThrust[0];
   _majorThrustValue     = dThrust[1];

--- a/Analysis/GammaGammaCandidateFinder/src/GammaGammaCandidateFinder.cc
+++ b/Analysis/GammaGammaCandidateFinder/src/GammaGammaCandidateFinder.cc
@@ -264,8 +264,8 @@ void GammaGammaCandidateFinder::FindGammaGammaCandidates(LCCollectionVec * recpa
              std::cout << "Fit probability = " << fit_probability << std::endl;
              std::cout << "Covariance matrix dimension " << cov_dim << std::endl;
              if(cov_dim==6){
-                for (unsigned int i=0; i<6*6; i++){
-                    std::cout << "Covariance matrix element " << i << " " << cov[i] << std::endl;                   
+                for (unsigned int k=0; k<6*6; k++){
+                    std::cout << "Covariance matrix element " << k << " " << cov[k] << std::endl;                   
                 }
              }
           }

--- a/Analysis/GammaGammaSolutionFinder/include/GammaGammaSolutionFinder.h
+++ b/Analysis/GammaGammaSolutionFinder/include/GammaGammaSolutionFinder.h
@@ -1,6 +1,9 @@
 // Boost Graph Library
 #include <boost/graph/adjacency_list.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <boost/graph/max_cardinality_matching.hpp>
+#pragma GCC diagnostic pop
 
 #include "marlin/Processor.h"
 #include "EVENT/ReconstructedParticle.h"

--- a/Analysis/GammaGammaSolutionFinder/src/GammaGammaSolutionFinder.cc
+++ b/Analysis/GammaGammaSolutionFinder/src/GammaGammaSolutionFinder.cc
@@ -473,8 +473,8 @@ void GammaGammaSolutionFinder::FindGammaGammaSolutions(LCCollectionVec * recparc
        nfirst_vertices++;     
        if(_printing>6)std::cout << std::setw(2) << i << " " << std::setw(2) << fvec[i].ivertex << " " 
                                 << std::setw(2) << fvec[i].nedges << " " << fvec[i].febits << "  { "; 
-       for (std::list<int>::iterator it=fvec[i].fvelist.begin(); it!=fvec[i].fvelist.end(); ++it){
-           if(_printing>6)std::cout << std::setw(2) << *it << " ";
+       for (std::list<int>::iterator iter=fvec[i].fvelist.begin(); iter!=fvec[i].fvelist.end(); ++iter){
+           if(_printing>6)std::cout << std::setw(2) << *iter << " ";
        } 
        if(_printing>6)std::cout << "}" << std::endl;
    }
@@ -556,9 +556,9 @@ void GammaGammaSolutionFinder::FindGammaGammaSolutions(LCCollectionVec * recparc
            std::vector<int> tmp;
            if(fvec[d[i]].nedges>1){    // Only do this for those first vertices with more than one edge
 // Iterate over the elements of the list associated with first vertex d[i]
-              for (std::list<int>::iterator it=fvec[d[i]].fvelist.begin(); it!=fvec[d[i]].fvelist.end(); ++it){
+              for (std::list<int>::iterator iter=fvec[d[i]].fvelist.begin(); iter!=fvec[d[i]].fvelist.end(); ++iter){
 //                std::cout << std::setw(2) << *it << " ";
-                  tmp.push_back(*it);
+                  tmp.push_back(*iter);
               }
 //            std::cout << std::endl;
               array.push_back(tmp);
@@ -587,9 +587,9 @@ void GammaGammaSolutionFinder::FindGammaGammaSolutions(LCCollectionVec * recparc
 
 // Check to see how many vertices are used in this edge set
        ored_vbits = evec[c[0]].vbits;
-       for (unsigned int i=1; i<r; ++i){
-            ored_vbits = (ored_vbits | evec[c[i]].vbits);
-            if(ored_vbits.count()!=2*(i+1))break;
+       for (unsigned int j=1; j<r; ++j){
+            ored_vbits = (ored_vbits | evec[c[j]].vbits);
+            if(ored_vbits.count()!=2*(j+1))break;
        }
        size_t nused = ored_vbits.count();
 
@@ -602,17 +602,17 @@ void GammaGammaSolutionFinder::FindGammaGammaSolutions(LCCollectionVec * recparc
           int npi0 = 0;
           int neta = 0;
           int netap = 0;
-          for (unsigned int i=0; i<r; ++i){
+          for (unsigned int j=0; j<r; ++j){
 /*              std::cout << "Assigned edge details" << std::endl;
               std::cout << std::setw(2) << c[i] << " " << evec[c[i]].vbits << " " << std::setw(2) << evec[c[i]].u << " " 
                         << std::setw(2) << evec[c[i]].v << " " << evec[c[i]].pdgid
                         << std::fixed << std::setw(10) << std::setprecision(5) << evec[c[i]].w << " " 
                         << std::fixed << std::setw(10) << std::setprecision(6) << evec[c[i]].edge_pvalue << std::endl;   */
-              ebits.flip(c[i]);                 // Set appropriate bit in the bitset for edge c[i]
-              wsum += evec[c[i]].w;
-              if(evec[c[i]].pdgid==111)npi0++;
-              if(evec[c[i]].pdgid==221)neta++;
-              if(evec[c[i]].pdgid==331)netap++;
+              ebits.flip(c[j]);                 // Set appropriate bit in the bitset for edge c[i]
+              wsum += evec[c[j]].w;
+              if(evec[c[j]].pdgid==111)npi0++;
+              if(evec[c[j]].pdgid==221)neta++;
+              if(evec[c[j]].pdgid==331)netap++;
           }
 // Store the CandidateSolution for later perusal
           svec.push_back(CandidateSolution());
@@ -775,4 +775,3 @@ bool GammaGammaSolutionFinder::PfoProbabilitySortFunction(ReconstructedParticle*
    return (lhs_particleType<rhs_particleType);                                          // Favor lower valued types (pi0s cf etas cf eta's)
 
 }
-

--- a/Analysis/GammaGammaSolutionFinder/src/GammaGammaSolutionFinder.cc
+++ b/Analysis/GammaGammaSolutionFinder/src/GammaGammaSolutionFinder.cc
@@ -487,7 +487,7 @@ void GammaGammaSolutionFinder::FindGammaGammaSolutions(LCCollectionVec * recparc
   // version, but has the advantage that it will return "false" if the
   // matching returned is not actually a maximum cardinality matching
   // in the graph.
-   bool success = checked_edmonds_maximum_cardinality_matching(g, &mate[0]);
+   bool success [[maybe_unused]] = checked_edmonds_maximum_cardinality_matching(g, &mate[0]);
    assert(success);
    if(_printing>6)std::cout << std::endl << "Found a matching of size " << matching_size(g, &mate[0]) << std::endl;
    if(_printing>6)std::cout << "The matching is:" << std::endl;

--- a/Analysis/GammaGammaSolutionFinder/src/GammaGammaSolutionFinder.cc
+++ b/Analysis/GammaGammaSolutionFinder/src/GammaGammaSolutionFinder.cc
@@ -473,8 +473,8 @@ void GammaGammaSolutionFinder::FindGammaGammaSolutions(LCCollectionVec * recparc
        nfirst_vertices++;     
        if(_printing>6)std::cout << std::setw(2) << i << " " << std::setw(2) << fvec[i].ivertex << " " 
                                 << std::setw(2) << fvec[i].nedges << " " << fvec[i].febits << "  { "; 
-       for (std::list<int>::iterator iter=fvec[i].fvelist.begin(); iter!=fvec[i].fvelist.end(); ++iter){
-           if(_printing>6)std::cout << std::setw(2) << *iter << " ";
+       for (const int elem : fvec[i].fvelist) {
+           if(_printing>6)std::cout << std::setw(2) << elem << " ";
        } 
        if(_printing>6)std::cout << "}" << std::endl;
    }
@@ -556,9 +556,9 @@ void GammaGammaSolutionFinder::FindGammaGammaSolutions(LCCollectionVec * recparc
            std::vector<int> tmp;
            if(fvec[d[i]].nedges>1){    // Only do this for those first vertices with more than one edge
 // Iterate over the elements of the list associated with first vertex d[i]
-              for (std::list<int>::iterator iter=fvec[d[i]].fvelist.begin(); iter!=fvec[d[i]].fvelist.end(); ++iter){
+              for (const int elem : fvec[d[i]].fvelist) {
 //                std::cout << std::setw(2) << *it << " ";
-                  tmp.push_back(*iter);
+                  tmp.push_back(elem);
               }
 //            std::cout << std::endl;
               array.push_back(tmp);

--- a/Analysis/IsolatedLeptonTagging/src/IsoLepTrainingProcessor.cc
+++ b/Analysis/IsolatedLeptonTagging/src/IsoLepTrainingProcessor.cc
@@ -181,14 +181,14 @@ void IsoLepTrainingProcessor::processEvent( LCEvent * evt ) {
     TLorentzVector lortz = TLorentzVector(pv,energy);
     //    Int_t orig = getOriginalPDGForIsoLep(mcPart);
     Int_t orig = getOriginalPDGForIsoLep(mcPart,colMC);    
-    Int_t status = mcPart->getGeneratorStatus();
+    // Int_t status = mcPart->getGeneratorStatus();
     if (i>=6 && i<=11) {
       if (TMath::Abs(pdg) == 11 || TMath::Abs(pdg) == 13 || TMath::Abs(pdg) == 15) {
 	pdgLepMC = pdg;
 	pdgLepMCv.push_back(pdgLepMC);
       }
     }
-    Int_t origw = pdgLepMC > 0? -24 : 24;
+    // Int_t origw = pdgLepMC > 0? -24 : 24;
     //    if ((TMath::Abs(pdg)==pdgLepMC) && (orig==24||orig==pdgLepMC) && status==1) {
     //    if (pdg==pdgLepMC && (orig==origw||orig==pdgLepMC) && status==1 && TMath::Abs(pdg)==_iso_lep_type && !(mcPart->isOverlay())) {
       //    if (status == 1 && TMath::Abs(pdg)==_iso_lep_type && TMath::Abs(orig) == 13 && !(mcPart->isOverlay())) {

--- a/Analysis/IsolatedLeptonTagging/src/IsolatedPhotonTaggingProcessor.cc
+++ b/Analysis/IsolatedLeptonTagging/src/IsolatedPhotonTaggingProcessor.cc
@@ -146,7 +146,7 @@ void IsolatedPhotonTaggingProcessor::processEvent( LCEvent * evt ) {
     Double_t charge = recPart->getCharge();
     TVector3 momentum = TVector3(recPart->getMomentum());
     TLorentzVector lortz = TLorentzVector(momentum,energy);
-    Double_t momentumMagnitude = momentum.Mag();
+    // Double_t momentumMagnitude = momentum.Mag();
     // get cone information
     // double cone based isolation algorithm
     Double_t coneEnergy0[3] = {0.,0.,0.};  // {total, neutral, charged} cone energy
@@ -156,11 +156,11 @@ void IsolatedPhotonTaggingProcessor::processEvent( LCEvent * evt ) {
     Double_t coneEC     = coneEnergy0[2];
     TLorentzVector lortzLargeCone = TLorentzVector(pLargeCone[0],pLargeCone[1],pLargeCone[2],pLargeCone[3]);
     TVector3 momentumLargeCone = lortzLargeCone.Vect();
-    Double_t cosThetaWithLargeCone = 1.;
-    if (momentumLargeCone.Mag() > 0.0000001) {
-      cosThetaWithLargeCone = momentum.Dot(momentumLargeCone)/momentumMagnitude/momentumLargeCone.Mag();
-    }
-    Double_t energyRatioWithLargeCone = energy/(energy+lortzLargeCone.E());
+    // Double_t cosThetaWithLargeCone = 1.;
+    // if (momentumLargeCone.Mag() > 0.0000001) {
+    //   cosThetaWithLargeCone = momentum.Dot(momentumLargeCone)/momentumMagnitude/momentumLargeCone.Mag();
+    // }
+    // Double_t energyRatioWithLargeCone = energy/(energy+lortzLargeCone.E());
     Double_t pandoraID = recPart->getType();
     if (TMath::Abs(charge) < 0.5 && pandoraID == 22) {
       if (energy < _minE) continue; // cut on the minimum energy
@@ -210,4 +210,3 @@ void IsolatedPhotonTaggingProcessor::end(){
   }
 
 }
-

--- a/Analysis/IsolatedLeptonTagging/src/Utilities.cc
+++ b/Analysis/IsolatedLeptonTagging/src/Utilities.cc
@@ -198,7 +198,7 @@ Int_t getOriginalSerial(MCParticle *mcPart, LCCollection *colMCP, Bool_t iHiggs)
   return originalSerial;
 }
 
-Int_t getOriginalSerial(ReconstructedParticle *recPart, LCCollection *colMCTL, LCCollection *colMCP, Bool_t iHiggs) {
+Int_t getOriginalSerial(ReconstructedParticle *recPart, LCCollection *colMCTL, LCCollection *colMCP, Bool_t /*iHiggs*/) {
   // get the serial number of the original particle where the PFO comes from
 
   Int_t originalSerial = -1;
@@ -930,7 +930,7 @@ void listMCParticles(LCCollection *colMC) {
   
 }
 
-  void dumpJetParticles(ReconstructedParticle *jet, LCCollection *colMC, LCCollection *colMCTL) {
+  void dumpJetParticles(ReconstructedParticle *jet, LCCollection* /*colMC*/, LCCollection *colMCTL) {
     // list the particles of jets
 
     LCRelationNavigator *navMCTL = new LCRelationNavigator(colMCTL);
@@ -979,7 +979,7 @@ void listMCParticles(LCCollection *colMC) {
 
   // *******************************************************
   // *******************************************************
-  Int_t getVertexComponents(LCCollection *colMC, LCCollection *colMCTL, ReconstructedParticle *vertex, Double_t energyComponents[2], Int_t nparticles[2]) {
+  Int_t getVertexComponents(LCCollection */*colMC*/, LCCollection *colMCTL, ReconstructedParticle *vertex, Double_t energyComponents[2], Int_t nparticles[2]) {
   // calculate energies from signal particles or overlay in a vertex
   // [0]: from signal; [1]: from overlay
 

--- a/Analysis/PIDTools/include/PIDParticles.hh
+++ b/Analysis/PIDTools/include/PIDParticles.hh
@@ -83,9 +83,9 @@ static const PIDParticle_base protonProperties("proton", 2212, .938272, BBparsPr
 class LLPIDHypothesis : public PIDParticle_base {
 public:
 
-  LLPIDHypothesis (const char *_name, int _pdg, double _mass,
-               float _prior, const double* _BBpars) :
-    PIDParticle_base(_name, _pdg, _mass, _BBpars),
+  LLPIDHypothesis (const char *name, int _pdg, double _mass,
+               float _prior, const double* BBpars) :
+    PIDParticle_base(name, _pdg, _mass, BBpars),
     prior(_prior), _posterior(0), _logL(0), _threshold(0)
   {  }
 
@@ -121,8 +121,11 @@ private:
 class MVAPIDHypothesis : public PIDParticle_base {
 public:
 
-  MVAPIDHypothesis (const char *_name, int _pdg, double _mass, const double* _BBpars, const float mvaCut=0.) :
-    PIDParticle_base(_name, _pdg, _mass, _BBpars),
+  MVAPIDHypothesis(const MVAPIDHypothesis&) = default;
+  MVAPIDHypothesis& operator=(const MVAPIDHypothesis&) = default;
+
+  MVAPIDHypothesis (const char *name, int _pdg, double _mass, const double* BBpars, const float mvaCut=0.) :
+    PIDParticle_base(name, _pdg, _mass, BBpars),
     _mva(0), _q(0), _sigAbove(0), _mvaCut(mvaCut), _reader(new TMVA::Reader("Silent")),
     _histoQ(NULL), _histoSig(NULL), _histoBkg(NULL)
   {  }

--- a/Analysis/PIDTools/src/CreatePDFProcessor.cc
+++ b/Analysis/PIDTools/src/CreatePDFProcessor.cc
@@ -455,10 +455,10 @@ void CreatePDFProcessor::processEvent( LCEvent * evt ) {
     //get deposit energy
     double ecal=0.0,hcal=0.0,mucal=0.0;
     if(cluvec.size()!=0){
-      for(unsigned int i=0;i<cluvec.size();i++){
-	ecal+=cluvec[i]->getSubdetectorEnergies()[0];
-	hcal+=cluvec[i]->getSubdetectorEnergies()[1];
-	mucal+=cluvec[i]->getSubdetectorEnergies()[2];
+      for(unsigned int j=0;j<cluvec.size();j++){
+	ecal+=cluvec[j]->getSubdetectorEnergies()[0];
+	hcal+=cluvec[j]->getSubdetectorEnergies()[1];
+	mucal+=cluvec[j]->getSubdetectorEnergies()[2];
       }
     }
     

--- a/Analysis/PIDTools/src/LikelihoodPID.cc
+++ b/Analysis/PIDTools/src/LikelihoodPID.cc
@@ -390,7 +390,7 @@ double LikelihoodPID::get_dEdxChi2(int parttype, TVector3 p, float hit, double d
   }
 
   //cal. polar angle
-  double trkcos=p.CosTheta();
+  // double trkcos=p.CosTheta();
 
   //get nomalized dEdx
   double dEdx_Norm=get_Norm(dEdx);
@@ -408,31 +408,31 @@ double LikelihoodPID::get_dEdxChi2(int parttype, TVector3 p, float hit, double d
   return chi2;
 }
 
-double LikelihoodPID::get_dEdxFactor(int parttype, TVector3 p, float hit, double dEdx){
+double LikelihoodPID::get_dEdxFactor(int /*parttype*/, TVector3 /*p*/, float hit, double dEdx){
   //get parameters for chi2
-  double tmppar[5],tmpmass=0.0;
-  for(int i=0;i<5;i++) tmppar[i]=par[parttype][i];
-  //getmass
-  switch(parttype){
-  case 0:
-    tmpmass=emass;
-    break;
-  case 1:
-    tmpmass=mmass;
-    break;
-  case 2:
-    tmpmass=pimass;
-    break;
-  case 3:
-    tmpmass=kmass;
-    break;
-  case 4:
-    tmpmass=pmass;
-    break;
-  }
+  // double tmppar[5],tmpmass=0.0;
+  // for(int i=0;i<5;i++) tmppar[i]=par[parttype][i];
+  // //getmass
+  // switch(parttype){
+  // case 0:
+  //   tmpmass=emass;
+  //   break;
+  // case 1:
+  //   tmpmass=mmass;
+  //   break;
+  // case 2:
+  //   tmpmass=pimass;
+  //   break;
+  // case 3:
+  //   tmpmass=kmass;
+  //   break;
+  // case 4:
+  //   tmpmass=pmass;
+  //   break;
+  // }
 
   //cal. polar angle
-  double trkcos=p.CosTheta();
+  // double trkcos=p.CosTheta();
 
   //get nomalized dEdx
   double dEdx_Norm=get_Norm(dEdx);
@@ -1104,153 +1104,153 @@ double LikelihoodPID::getValue(int type, int valtype, double value){
 }
 
 double LikelihoodPID::getPenalty(int ptype, int hypothesis, double p){
-  double par[3]={0.0,0.0,0.0};
+  double param[3]={0.0,0.0,0.0};
   //set parameters
   switch(ptype){
   case 0:  //electron
     if(hypothesis==0){
-      par[0]=0.0;
-      par[1]=1.0;
-      par[2]=1.00178;
+      param[0]=0.0;
+      param[1]=1.0;
+      param[2]=1.00178;
 
     }else if(hypothesis==1){
-      par[0]=0.101945;
-      par[1]=2.18719;
-      par[2]=0.990000;
+      param[0]=0.101945;
+      param[1]=2.18719;
+      param[2]=0.990000;
 
     }else if(hypothesis==2){
-      par[0]=0.104521;
-      par[1]=1.98490;
-      par[2]=0.990000;
+      param[0]=0.104521;
+      param[1]=1.98490;
+      param[2]=0.990000;
 
     }else if(hypothesis==3){
-      par[0]=0.234299;
-      par[1]=0.276835;
-      par[2]=0.965973;
+      param[0]=0.234299;
+      param[1]=0.276835;
+      param[2]=0.965973;
 
     }else{
-      par[0]=0.414613;
-      par[1]=-0.132530;
-      par[2]=0.949679;
+      param[0]=0.414613;
+      param[1]=-0.132530;
+      param[2]=0.949679;
 
     }
 
     break;
   case 1:   //muon
     if(hypothesis==0){
-      par[0]=-0.00512190;
-      par[1]=-0.211835;
-      par[2]=1.00024;
+      param[0]=-0.00512190;
+      param[1]=-0.211835;
+      param[2]=1.00024;
 
     }else if(hypothesis==1){
-      par[0]=0.0;
-      par[1]=1.00;
-      par[2]=0.999684;
+      param[0]=0.0;
+      param[1]=1.00;
+      param[2]=0.999684;
 
     }else if(hypothesis==2){
-      par[0]=0.00833283;
-      par[1]=9.99995;
-      par[2]=0.999027;
+      param[0]=0.00833283;
+      param[1]=9.99995;
+      param[2]=0.999027;
 
     }else if(hypothesis==3){
-      par[0]=0.0964021;
-      par[1]=-0.214469;
-      par[2]=0.989688;
+      param[0]=0.0964021;
+      param[1]=-0.214469;
+      param[2]=0.989688;
 
     }else{
-      par[0]=0.318674;
-      par[1]=-0.197755;
-      par[2]=0.968436;
+      param[0]=0.318674;
+      param[1]=-0.197755;
+      param[2]=0.968436;
     }
 
     break;
   case 2:   //pion
     if(hypothesis==0){
-      par[0]=-0.0123577;
-      par[1]=-0.141521;
-      par[2]=1.00273;
+      param[0]=-0.0123577;
+      param[1]=-0.141521;
+      param[2]=1.00273;
 
     }else if(hypothesis==1){
-      par[0]=-0.00558462;
-      par[1]=-0.136941;
-      par[2]=1.00135;
+      param[0]=-0.00558462;
+      param[1]=-0.136941;
+      param[2]=1.00135;
 
     }else if(hypothesis==2){
-      par[0]=0.0;
-      par[1]=1.0;
-      par[2]=1.00001;
+      param[0]=0.0;
+      param[1]=1.0;
+      param[2]=1.00001;
 
     }else if(hypothesis==3){
-      par[0]=0.122083;
-      par[1]=-0.1333923;
-      par[2]=0.976863;
+      param[0]=0.122083;
+      param[1]=-0.1333923;
+      param[2]=0.976863;
 
     }else{
-      par[0]=0.401111;
-      par[1]=-0.116807;
-      par[2]=0.930906;
+      param[0]=0.401111;
+      param[1]=-0.116807;
+      param[2]=0.930906;
     }
 
     break;
   case 3:    //kaon
     if(hypothesis==0){
-      par[0]=-0.102300;
-      par[1]=-0.139570;
-      par[2]=1.01362;
+      param[0]=-0.102300;
+      param[1]=-0.139570;
+      param[2]=1.01362;
 
     }else if(hypothesis==1){
-      par[0]=-0.0973257;
-      par[1]=-0.138932;
-      par[2]=1.01293;
+      param[0]=-0.0973257;
+      param[1]=-0.138932;
+      param[2]=1.01293;
 
     }else if(hypothesis==2){
-      par[0]=-0.0936450;
-      par[1]=-0.138469;
-      par[2]=1.01242;
+      param[0]=-0.0936450;
+      param[1]=-0.138469;
+      param[2]=1.01242;
 
     }else if(hypothesis==3){
-      par[0]=0.0;
-      par[1]=1.0;
-      par[2]=0.999865;
+      param[0]=0.0;
+      param[1]=1.0;
+      param[2]=0.999865;
 
     }else{
-      par[0]=0.223317;
-      par[1]=-0.101273;
-      par[2]=0.973484;
+      param[0]=0.223317;
+      param[1]=-0.101273;
+      param[2]=0.973484;
     }
 
     break;
   case 4:   //proton
     if(hypothesis==0){
-      par[0]=-0.260150;
-      par[1]=-0.0990612;
-      par[2]=1.02854;
+      param[0]=-0.260150;
+      param[1]=-0.0990612;
+      param[2]=1.02854;
 
     }else if(hypothesis==1){
-      par[0]=-0.256503;
-      par[1]=-0.0976728;
-      par[2]=1.02811;
+      param[0]=-0.256503;
+      param[1]=-0.0976728;
+      param[2]=1.02811;
 
     }else if(hypothesis==2){
-      par[0]=-0.253788;
-      par[1]=-0.0966732;
-      par[2]=1.02779;
+      param[0]=-0.253788;
+      param[1]=-0.0966732;
+      param[2]=1.02779;
 
     }else if(hypothesis==3){
-      par[0]=-0.183031;
-      par[1]=-0.0742123;
-      par[2]=1.01965;
+      param[0]=-0.183031;
+      param[1]=-0.0742123;
+      param[2]=1.01965;
 
     }else{
-      par[0]=0.0;
-      par[1]=1.0;
-      par[2]=0.999791;
+      param[0]=0.0;
+      param[1]=1.0;
+      param[2]=0.999791;
     }
 
     break;
   }
 
-  return par[0]/sqrt(p*p+par[1])+par[2]; 
+  return param[0]/sqrt(p*p+param[1])+param[2]; 
 }
 
 void LikelihoodPID::CalculateDeltaPosition(float charge, TVector3 p, const float* calpos){
@@ -1310,4 +1310,3 @@ void LikelihoodPID::CalculateDeltaPosition(float charge, TVector3 p, const float
   //cout << "result: " << delpos[0] << " " << delpos[1] << " " << delpos[2] << endl; 
   return;
 }
-

--- a/Analysis/PIDTools/src/LikelihoodPID.cc
+++ b/Analysis/PIDTools/src/LikelihoodPID.cc
@@ -409,35 +409,8 @@ double LikelihoodPID::get_dEdxChi2(int parttype, TVector3 p, float hit, double d
 }
 
 double LikelihoodPID::get_dEdxFactor(int /*parttype*/, TVector3 /*p*/, float hit, double dEdx){
-  //get parameters for chi2
-  // double tmppar[5],tmpmass=0.0;
-  // for(int i=0;i<5;i++) tmppar[i]=par[parttype][i];
-  // //getmass
-  // switch(parttype){
-  // case 0:
-  //   tmpmass=emass;
-  //   break;
-  // case 1:
-  //   tmpmass=mmass;
-  //   break;
-  // case 2:
-  //   tmpmass=pimass;
-  //   break;
-  // case 3:
-  //   tmpmass=kmass;
-  //   break;
-  // case 4:
-  //   tmpmass=pmass;
-  //   break;
-  // }
-
-  //cal. polar angle
-  // double trkcos=p.CosTheta();
-
   //get nomalized dEdx
   double dEdx_Norm=get_Norm(dEdx);
-
-  //cout << "check " << emass << " " << tmpmass << " " << trkcos << " " << dEdx_Norm << " " << ExpdEdx << endl;
   double dEdx_Error = _dEdxerrfact * dEdx_Norm * hit/dEdx;    //change 20151218
 
   //get likelihood factor

--- a/Analysis/PIDTools/src/LowMomentumMuPiSeparationPID_BDTG.cc
+++ b/Analysis/PIDTools/src/LowMomentumMuPiSeparationPID_BDTG.cc
@@ -141,12 +141,12 @@ Int_t LowMomentumMuPiSeparationPID_BDTG::MuPiSeparation(TLorentzVector pp, EVENT
    float clpox=0;
    float clpoy=0;
    float clpoz=0;
-   float chene[10000]={0};
+   // float chene[10000]={0};
    float chpox[10000]={0};
    float chpoy[10000]={0};
-   float chpoz[10000]={0};
+   // float chpoz[10000]={0};
 
-   int nhit=0;
+   // int nhit=0;
 
   float Rhits_clu = 0;
   float Rhits2_clu = 0;
@@ -157,7 +157,7 @@ Int_t LowMomentumMuPiSeparationPID_BDTG::MuPiSeparation(TLorentzVector pp, EVENT
   float cosalphacluster=0;
   unsigned nch=0;
  
-  const EVENT::TrackStateVec & tss = trk->getTrackStates() ;
+  // const EVENT::TrackStateVec & tss = trk->getTrackStates() ;
   
   const lcio::TrackState* ts ;
   
@@ -181,11 +181,11 @@ Int_t LowMomentumMuPiSeparationPID_BDTG::MuPiSeparation(TLorentzVector pp, EVENT
           
           nch =tempvec.size();
           for( unsigned jhit=0; jhit < nch ; ++jhit ) {
-              nhit = tempvec.size();
-              chene[jhit] =  tempvec[jhit]->getEnergy();
+              // nhit = tempvec.size();
+              // chene[jhit] =  tempvec[jhit]->getEnergy();
               chpox[jhit] =  tempvec[jhit]->getPosition()[0];
               chpoy[jhit] =  tempvec[jhit]->getPosition()[1];
-              chpoz[jhit] =  tempvec[jhit]->getPosition()[2];
+              // chpoz[jhit] =  tempvec[jhit]->getPosition()[2];
           }
       }
   }

--- a/Analysis/PIDTools/src/PIDVariables.cc
+++ b/Analysis/PIDTools/src/PIDVariables.cc
@@ -43,7 +43,7 @@ PID_CaloTotal::PID_CaloTotal() :
     PIDVariable_base("CaloTotal", "(ECAL+HCAL)/p", "")
 {}
 
-int PID_CaloTotal::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec trax, const TVector3 p3)
+int PID_CaloTotal::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec /*trax*/, const TVector3 p3)
 {
   float p = p3.Mag();
   if(p < pCut) {
@@ -77,7 +77,7 @@ PID_CaloEFrac::PID_CaloEFrac() :
     PIDVariable_base("CaloEFrac", "ECAL/(ECAL+HCAL)", "")
 {}
 
-int PID_CaloEFrac::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec trax, const TVector3 p3)
+int PID_CaloEFrac::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec /*trax*/, const TVector3 /*p3*/)
 {
   float ecal=0., hcal=0.;
   if(cluvec.size()>0){
@@ -112,7 +112,7 @@ PID_CaloMuSys::PID_CaloMuSys() :
     PIDVariable_base("CaloMuSys", "E_{#mu system}", "GeV")
 {}
 
-int PID_CaloMuSys::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec trax, const TVector3 p3)
+int PID_CaloMuSys::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec /*trax*/, const TVector3 /*p3*/)
 {
   float mucal=0.;
   if(cluvec.size()>0){
@@ -141,7 +141,7 @@ PID_CluShapeChi2::PID_CluShapeChi2() :
     PIDVariable_base("CluShapeChi2", "Cluster shape #chi^{2}", "")
 {}
 
-int PID_CluShapeChi2::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec trax, const TVector3 p3)
+int PID_CluShapeChi2::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec /*trax*/, const TVector3 /*p3*/)
 {
   if (cluvec.size() < 1) {
     SetOutOfRange();
@@ -168,7 +168,7 @@ PID_CluShapeLDiscr::PID_CluShapeLDiscr() :
     PIDVariable_base("DiscrepancyL", "d_{Shower max} / d_{EM shower max}", "")
 {}
 
-int PID_CluShapeLDiscr::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec trax, const TVector3 p3)
+int PID_CluShapeLDiscr::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec /*trax*/, const TVector3 /*p3*/)
 {
   if (cluvec.size() < 1) {
     SetOutOfRange();
@@ -190,7 +190,7 @@ PID_CluShapeTDiscr::PID_CluShapeTDiscr() :
     PIDVariable_base("DiscrepancyT", "Absorption length", "R_{m}")
 {}
 
-int PID_CluShapeTDiscr::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec trax, const TVector3 p3)
+int PID_CluShapeTDiscr::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec /*trax*/, const TVector3 /*p3*/)
 {
   if (cluvec.size() < 1) {
     SetOutOfRange();
@@ -212,7 +212,7 @@ PID_CluShapeXl20::PID_CluShapeXl20() :
     PIDVariable_base("Xl20", "xl20", "?")
 {}
 
-int PID_CluShapeXl20::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec trax, const TVector3 p3)
+int PID_CluShapeXl20::Update(const EVENT::ClusterVec cluvec, const EVENT::TrackVec /*trax*/, const TVector3 /*p3*/)
 {
   if (cluvec.size() < 1) {
     SetOutOfRange();
@@ -249,7 +249,7 @@ PID_dEdxChi2::~PID_dEdxChi2()
   delete _hypothesis;
 }
 
-int PID_dEdxChi2::Update(const EVENT::ClusterVec cluvec,
+int PID_dEdxChi2::Update(const EVENT::ClusterVec /*cluvec*/,
     const EVENT::TrackVec trax, const TVector3 p3)
 {
   int result = 0;
@@ -291,7 +291,7 @@ PID_dEdxLogChi2::~PID_dEdxLogChi2()
   delete _hypothesis;
 }
 
-int PID_dEdxLogChi2::Update(const EVENT::ClusterVec cluvec,
+int PID_dEdxLogChi2::Update(const EVENT::ClusterVec /*cluvec*/,
     const EVENT::TrackVec trax, const TVector3 p3)
 {
   int result = 0;
@@ -331,7 +331,7 @@ PIDVariables_base::PIDVariables_base() :
   _p(0.)
 {}
 
-PIDVariables_base::PIDVariables_base(EVENT::ReconstructedParticle* particle) :
+PIDVariables_base::PIDVariables_base(EVENT::ReconstructedParticle* /*particle*/) :
   _p(0.)
 {}
 

--- a/Analysis/RecoMCTruthLink/include/MCTruthJetEnergy.h
+++ b/Analysis/RecoMCTruthLink/include/MCTruthJetEnergy.h
@@ -41,6 +41,7 @@ class MCTruthJetEnergy : public Processor {
   MCTruthJetEnergy(const MCTruthJetEnergy&) = delete;
   MCTruthJetEnergy& operator=(const MCTruthJetEnergy&) = delete;
 
+
   virtual Processor*  newProcessor() { return new MCTruthJetEnergy ; }
   
   

--- a/Analysis/RecoMCTruthLink/include/MCTruthJetEnergy.h
+++ b/Analysis/RecoMCTruthLink/include/MCTruthJetEnergy.h
@@ -41,7 +41,6 @@ class MCTruthJetEnergy : public Processor {
   MCTruthJetEnergy(const MCTruthJetEnergy&) = delete;
   MCTruthJetEnergy& operator=(const MCTruthJetEnergy&) = delete;
 
-
   virtual Processor*  newProcessor() { return new MCTruthJetEnergy ; }
   
   

--- a/Analysis/RecoMCTruthLink/include/QuarkJetPairing.h
+++ b/Analysis/RecoMCTruthLink/include/QuarkJetPairing.h
@@ -48,17 +48,17 @@ class QuarkJetPairing : public Processor {
   int permutation[nJETS]{};
 
 
-  float jet_ptot[4]{};
-  float jet_px[4]{};
-  float jet_py[4]{};
-  float jet_pz[4]{};
-  float jet_ene[4]{};
+  // float jet_ptot[4]{};
+  // float jet_px[4]{};
+  // float jet_py[4]{};
+  // float jet_pz[4]{};
+  // float jet_ene[4]{};
 
-  float quark_ptot[4]{};
-  float quark_px[4]{};
-  float quark_py[4]{};
-  float quark_pz[4]{};
-  float quark_ene[4]{};
+  // float quark_ptot[4]{};
+  // float quark_px[4]{};
+  // float quark_py[4]{};
+  // float quark_pz[4]{};
+  // float quark_ene[4]{};
 
   float phi_jet_quark[4][4]{};
   float momentum[3]{}, jetenergy{};

--- a/Analysis/RecoMCTruthLink/include/QuarkJetPairing.h
+++ b/Analysis/RecoMCTruthLink/include/QuarkJetPairing.h
@@ -47,19 +47,6 @@ class QuarkJetPairing : public Processor {
 
   int permutation[nJETS]{};
 
-
-  // float jet_ptot[4]{};
-  // float jet_px[4]{};
-  // float jet_py[4]{};
-  // float jet_pz[4]{};
-  // float jet_ene[4]{};
-
-  // float quark_ptot[4]{};
-  // float quark_px[4]{};
-  // float quark_py[4]{};
-  // float quark_pz[4]{};
-  // float quark_ene[4]{};
-
   float phi_jet_quark[4][4]{};
   float momentum[3]{}, jetenergy{};
   int _nRun{};

--- a/Analysis/RecoMCTruthLink/src/QuarkJetPairing.cc
+++ b/Analysis/RecoMCTruthLink/src/QuarkJetPairing.cc
@@ -108,7 +108,6 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
 
   float energy = 0;
  
-  // float jet_ene[4];
   float quark_ene[4];
      
   float jet_theta[4];
@@ -131,7 +130,6 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
      
   for(int i=0; i<4; i++){
        
-    // jet_ene[i]=0;
     quark_ene[i]=0;
        
     jet_theta[i]=0;
@@ -169,8 +167,7 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
 	jet_px[i]=j->getMomentum()[0]; 
 	jet_py[i]=j->getMomentum()[1];
 	jet_pz[i]=j->getMomentum()[2];
-	// jet_ene[i]=j->getEnergy();
- 	    
+
       }  
       jet_ptot[i]=sqrt(pow(jet_px[i], 2)+pow(jet_py[i], 2)+pow(jet_pz[i], 2));
     }
@@ -203,8 +200,6 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
  
   int counter_jets = 0; 
    
-  // Float_t theta[4];
-  
   Float_t alpha[24];
   Float_t alpha_min = 9999; 
   int iperm_min = 0; 
@@ -263,7 +258,6 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
 	
 	  //////////////////////////////////////////// Determination of theta //////////////////////////
 	
-	  // theta[ijet]=0;
 	  quark_theta[ijet] = atan((sqrt((pow(quark_px[quark[ijet][iperm_min]],2))+(pow(quark_py[quark[ijet][iperm_min]],2))))/quark_pz[quark[ijet][iperm_min]]);
 	  jet_theta[ijet] = atan((sqrt((pow(jet_px[jet[ijet][iperm_min]],2))+(pow(jet_py[jet[ijet][iperm_min]],2))))/jet_pz[jet[ijet][iperm_min]]);
 	  if(quark_theta[ijet] < 0){

--- a/Analysis/RecoMCTruthLink/src/QuarkJetPairing.cc
+++ b/Analysis/RecoMCTruthLink/src/QuarkJetPairing.cc
@@ -108,7 +108,7 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
 
   float energy = 0;
  
-  float jet_ene[4];
+  // float jet_ene[4];
   float quark_ene[4];
      
   float jet_theta[4];
@@ -131,7 +131,7 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
      
   for(int i=0; i<4; i++){
        
-    jet_ene[i]=0;
+    // jet_ene[i]=0;
     quark_ene[i]=0;
        
     jet_theta[i]=0;
@@ -155,11 +155,11 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
    
   if (jetcol != 0) {
        
-    int nJETS = jetcol->getNumberOfElements()  ;
+    int numberOfJets = jetcol->getNumberOfElements()  ;
        
-    if (nJETS != 4) return; 
+    if (numberOfJets != 4) return; 
 
-    for(int i=0; i< nJETS ; i++){
+    for(int i=0; i< numberOfJets ; i++){
          
  
       ReconstructedParticle* j = dynamic_cast<ReconstructedParticle*>( jetcol->getElementAt( i ) ) ;
@@ -169,7 +169,7 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
 	jet_px[i]=j->getMomentum()[0]; 
 	jet_py[i]=j->getMomentum()[1];
 	jet_pz[i]=j->getMomentum()[2];
-	jet_ene[i]=j->getEnergy();
+	// jet_ene[i]=j->getEnergy();
  	    
       }  
       jet_ptot[i]=sqrt(pow(jet_px[i], 2)+pow(jet_py[i], 2)+pow(jet_pz[i], 2));
@@ -203,7 +203,7 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
  
   int counter_jets = 0; 
    
-  Float_t theta[4];
+  // Float_t theta[4];
   
   Float_t alpha[24];
   Float_t alpha_min = 9999; 
@@ -263,7 +263,7 @@ void QuarkJetPairing::processEvent( LCEvent * evt ) {
 	
 	  //////////////////////////////////////////// Determination of theta //////////////////////////
 	
-	  theta[ijet]=0;
+	  // theta[ijet]=0;
 	  quark_theta[ijet] = atan((sqrt((pow(quark_px[quark[ijet][iperm_min]],2))+(pow(quark_py[quark[ijet][iperm_min]],2))))/quark_pz[quark[ijet][iperm_min]]);
 	  jet_theta[ijet] = atan((sqrt((pow(jet_px[jet[ijet][iperm_min]],2))+(pow(jet_py[jet[ijet][iperm_min]],2))))/jet_pz[jet[ijet][iperm_min]]);
 	  if(quark_theta[ijet] < 0){

--- a/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
+++ b/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
@@ -440,7 +440,7 @@ void RecoMCTruthLinker::processEvent( LCEvent * evt ) {
 
   
 }
-void RecoMCTruthLinker::trackLinker(   LCEvent * evt, LCCollection* mcpCol ,  LCCollection* trackCol,  
+void RecoMCTruthLinker::trackLinker(   LCEvent * evt, LCCollection* /*mcpCol*/ ,  LCCollection* trackCol,  
                                        LCCollection** ttrlcol,  LCCollection** trtlcol) { 
 
 
@@ -474,7 +474,7 @@ void RecoMCTruthLinker::trackLinker(   LCEvent * evt, LCCollection* mcpCol ,  LC
   // loop over reconstructed tracks
   int nTrack = trackCol->getNumberOfElements() ;
   
-  int ifoundch =0;
+  // int ifoundch =0;
   
   streamlog_out( DEBUG6 ) << " *** Sorting out Track<->MCParticle using simHit<->MCParticle." << std::endl;
 
@@ -623,7 +623,7 @@ void RecoMCTruthLinker::trackLinker(   LCEvent * evt, LCCollection* mcpCol ,  LC
     
     }
     
-    ifoundch=ifound;
+    // ifoundch=ifound;
   } 
   //  seen-true relation complete. add the collection
 
@@ -951,7 +951,7 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
                     
 
                     int starts_in_tracker = 0 ;
-                    unsigned lll=0 ;
+                    // unsigned lll=0 ;
                     int has_pi0 = 0 ;
                     int oma_in_calo = 0;
                     double rdist =0.;
@@ -967,11 +967,11 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
                                                                                                     // take place (think delta-rays !)
  		      if ( sister->isBackscatter()) {
                         has_bs = 1 ; 
-                        lll=kkk;
+                        // lll=kkk;
                         break ;
 		      } else if ( sister->isDecayedInTracker() ) {
                         starts_in_tracker = 1 ;
-                        lll=kkk;
+                        // lll=kkk;
                         break ;
                       }
                       // any pi0:s at all ? (it doesn't matter that we break at the two cases above, 
@@ -1118,7 +1118,7 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
   
   std::vector<Cluster*> missingMC ;
   missingMC.reserve( nCluster ) ;
-  int ifoundclu =0;
+  // int ifoundclu =0;
   // now for the clusters
   
   
@@ -1496,7 +1496,7 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
       truthClusterRelNav.addRelation(   theMCPs[iii] , clu , weight ) ;
       
     }
-    ifoundclu=ifound;
+    // ifoundclu=ifound;
   } // cluster loop
   
   streamlog_out( DEBUG6 ) << " *** Sorting out Cluster<->MCParticle : DONE" << std::endl;

--- a/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
+++ b/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
@@ -474,8 +474,6 @@ void RecoMCTruthLinker::trackLinker(   LCEvent * evt, LCCollection* /*mcpCol*/ ,
   // loop over reconstructed tracks
   int nTrack = trackCol->getNumberOfElements() ;
   
-  // int ifoundch =0;
-  
   streamlog_out( DEBUG6 ) << " *** Sorting out Track<->MCParticle using simHit<->MCParticle." << std::endl;
 
   for(int i=0;i<nTrack;++i){
@@ -623,8 +621,7 @@ void RecoMCTruthLinker::trackLinker(   LCEvent * evt, LCCollection* /*mcpCol*/ ,
     
     }
     
-    // ifoundch=ifound;
-  } 
+  }
   //  seen-true relation complete. add the collection
 
   streamlog_out( DEBUG6 ) << " *** Sorting out Track<->MCParticle : DONE " << std::endl;
@@ -951,7 +948,6 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
                     
 
                     int starts_in_tracker = 0 ;
-                    // unsigned lll=0 ;
                     int has_pi0 = 0 ;
                     int oma_in_calo = 0;
                     double rdist =0.;
@@ -967,11 +963,9 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
                                                                                                     // take place (think delta-rays !)
  		      if ( sister->isBackscatter()) {
                         has_bs = 1 ; 
-                        // lll=kkk;
                         break ;
 		      } else if ( sister->isDecayedInTracker() ) {
                         starts_in_tracker = 1 ;
-                        // lll=kkk;
                         break ;
                       }
                       // any pi0:s at all ? (it doesn't matter that we break at the two cases above, 
@@ -1118,7 +1112,6 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
   
   std::vector<Cluster*> missingMC ;
   missingMC.reserve( nCluster ) ;
-  // int ifoundclu =0;
   // now for the clusters
   
   
@@ -1496,7 +1489,6 @@ void RecoMCTruthLinker::clusterLinker(  LCEvent * evt,  LCCollection* mcpCol ,  
       truthClusterRelNav.addRelation(   theMCPs[iii] , clu , weight ) ;
       
     }
-    // ifoundclu=ifound;
   } // cluster loop
   
   streamlog_out( DEBUG6 ) << " *** Sorting out Cluster<->MCParticle : DONE" << std::endl;

--- a/Analysis/TruthVertexFinder/include/MathOperator.hh
+++ b/Analysis/TruthVertexFinder/include/MathOperator.hh
@@ -64,7 +64,6 @@ namespace TTbarAnalysis
 		//
 		//	Private methods
 		//
-			// static double * castIntToDouble(int * array);
 	};
 			template<class T >
 			std::vector< T * > * MathOperator::MergeVectors(std::vector< T * > * vector1, std::vector< T * > * vector2)

--- a/Analysis/TruthVertexFinder/include/MathOperator.hh
+++ b/Analysis/TruthVertexFinder/include/MathOperator.hh
@@ -64,7 +64,7 @@ namespace TTbarAnalysis
 		//
 		//	Private methods
 		//
-			static double * castIntToDouble(int * array);
+			// static double * castIntToDouble(int * array);
 	};
 			template<class T >
 			std::vector< T * > * MathOperator::MergeVectors(std::vector< T * > * vector1, std::vector< T * > * vector2)

--- a/Analysis/TruthVertexFinder/src/MCOperator.cc
+++ b/Analysis/TruthVertexFinder/src/MCOperator.cc
@@ -545,8 +545,7 @@ namespace TTbarAnalysis
 			streamlog_out(MESSAGE)<<"WARNING: Long-lived noninteracting particle " << parent->getPDG() <<"!\n";
 			return result;
 		}
-		// bool finished = false;
-		for (unsigned int i = 0; i < daughters.size(); i++) 
+		for (unsigned int i = 0; i < daughters.size(); i++)
 		{
 			MCParticle * daughter = daughters[i];
 			if (CheckParticle(daughter, TRACKABLE_PARTICLES))
@@ -556,8 +555,7 @@ namespace TTbarAnalysis
 				{
 					//streamlog_out(MESSAGE)<<"CAUTION: Low momentum particle of " << MathOperator::getModule(daughter->getMomentum()) << " GeV!\n";
 				}
-				// finished = true;
-				if (selectReco && IsReconstructed(daughter)) 
+				if (selectReco && IsReconstructed(daughter))
 				{
 					result.push_back(daughter);
 				}

--- a/Analysis/TruthVertexFinder/src/MCOperator.cc
+++ b/Analysis/TruthVertexFinder/src/MCOperator.cc
@@ -545,7 +545,7 @@ namespace TTbarAnalysis
 			streamlog_out(MESSAGE)<<"WARNING: Long-lived noninteracting particle " << parent->getPDG() <<"!\n";
 			return result;
 		}
-		bool finished = false;
+		// bool finished = false;
 		for (unsigned int i = 0; i < daughters.size(); i++) 
 		{
 			MCParticle * daughter = daughters[i];
@@ -556,7 +556,7 @@ namespace TTbarAnalysis
 				{
 					//streamlog_out(MESSAGE)<<"CAUTION: Low momentum particle of " << MathOperator::getModule(daughter->getMomentum()) << " GeV!\n";
 				}
-				finished = true;
+				// finished = true;
 				if (selectReco && IsReconstructed(daughter)) 
 				{
 					result.push_back(daughter);

--- a/Analysis/TruthVertexFinder/src/MathOperator.cc
+++ b/Analysis/TruthVertexFinder/src/MathOperator.cc
@@ -214,21 +214,6 @@ namespace TTbarAnalysis
 		return result;
 	}
 
-
-	// double * MathOperator::castIntToDouble(int * array)
-	// {
-	// 	int size = (sizeof(array)/sizeof(*array));
-	// 	if (size < 1) 
-	// 	{
-	// 		return NULL;
-	// 	}
-	// 	double * arrPoint1 = new double[size];
-	// 	for (int i = 0; i < size; i++) 
-	// 	{
-	// 		arrPoint1[i] = array[i];
-	// 	}
-	// 	return arrPoint1;
-	// }
 	vector< vector< int > * > * MathOperator::GetMagicNumbers()
 	{
 		vector< vector< int > * > * result = new vector< vector< int > * >();

--- a/Analysis/TruthVertexFinder/src/MathOperator.cc
+++ b/Analysis/TruthVertexFinder/src/MathOperator.cc
@@ -215,20 +215,20 @@ namespace TTbarAnalysis
 	}
 
 
-	double * MathOperator::castIntToDouble(int * array)
-	{
-		int size = (sizeof(array)/sizeof(*array));
-		if (size < 1) 
-		{
-			return NULL;
-		}
-		double * arrPoint1 = new double[size];
-		for (int i = 0; i < size; i++) 
-		{
-			arrPoint1[i] = array[i];
-		}
-		return arrPoint1;
-	}
+	// double * MathOperator::castIntToDouble(int * array)
+	// {
+	// 	int size = (sizeof(array)/sizeof(*array));
+	// 	if (size < 1) 
+	// 	{
+	// 		return NULL;
+	// 	}
+	// 	double * arrPoint1 = new double[size];
+	// 	for (int i = 0; i < size; i++) 
+	// 	{
+	// 		arrPoint1[i] = array[i];
+	// 	}
+	// 	return arrPoint1;
+	// }
 	vector< vector< int > * > * MathOperator::GetMagicNumbers()
 	{
 		vector< vector< int > * > * result = new vector< vector< int > * >();

--- a/Analysis/TruthVertexFinder/src/TruthVertexFinder.cc
+++ b/Analysis/TruthVertexFinder/src/TruthVertexFinder.cc
@@ -498,10 +498,8 @@ namespace TTbarAnalysis
 			_bdistance = MathOperator::getDistance(verticies->at(1)->getPosition(), verticies->at(0)->getPosition());
 			_btotalnumber = _cnumber + _bnumber;
 			streamlog_out(MESSAGE) <<"Checking b-quark meson...\n";
-			// bool compatible = opera.CheckCompatibility(daughters, chain->Get(0), chain->Get(1)->getCharge());
-				
+
 			streamlog_out(MESSAGE) <<"Checking c-quark meson...\n";
-			// compatible = opera.CheckCompatibility(cdaughters, chain->Get(1));
 			_bptmiss = getMissingPt(daughters, cdaughters, verticies->at(0));
 			streamlog_out(MESSAGE) <<"Missing pt for b-quark hadron: " << _bptmiss << "\n";	
 			_ccharge = (int)chain->Get(1)->getCharge();

--- a/Analysis/TruthVertexFinder/src/TruthVertexFinder.cc
+++ b/Analysis/TruthVertexFinder/src/TruthVertexFinder.cc
@@ -237,7 +237,7 @@ namespace TTbarAnalysis
 		streamlog_out(MESSAGE) <<"|"<<particle->getPDG() <<"\t\t|"<<particle->getMass()<<"\t\t|"<<particle->getCharge()  <<"\t\t|"<<particle->getEnergy()<<"\t\t|"<<particle->getVertex()[0]<<"\t\t|"<<particle->getVertex()[1]<<"\t\t|"<<particle->getVertex()[2] <<"\t\t|\n";
 	
 	}
-	void TruthVertexFinder::Write(vector< Vertex * > * vertices, int & number)
+	void TruthVertexFinder::Write(vector< Vertex * > * vertices, int & /*number*/)
 	{
 		if (!vertices || vertices->size() < _pdgs.size()-1) 
 		{
@@ -498,10 +498,10 @@ namespace TTbarAnalysis
 			_bdistance = MathOperator::getDistance(verticies->at(1)->getPosition(), verticies->at(0)->getPosition());
 			_btotalnumber = _cnumber + _bnumber;
 			streamlog_out(MESSAGE) <<"Checking b-quark meson...\n";
-			bool compatible = opera.CheckCompatibility(daughters, chain->Get(0), chain->Get(1)->getCharge());
+			// bool compatible = opera.CheckCompatibility(daughters, chain->Get(0), chain->Get(1)->getCharge());
 				
 			streamlog_out(MESSAGE) <<"Checking c-quark meson...\n";
-			compatible = opera.CheckCompatibility(cdaughters, chain->Get(1));
+			// compatible = opera.CheckCompatibility(cdaughters, chain->Get(1));
 			_bptmiss = getMissingPt(daughters, cdaughters, verticies->at(0));
 			streamlog_out(MESSAGE) <<"Missing pt for b-quark hadron: " << _bptmiss << "\n";	
 			_ccharge = (int)chain->Get(1)->getCharge();

--- a/Analysis/ZFinder/src/ZFinder.cc
+++ b/Analysis/ZFinder/src/ZFinder.cc
@@ -240,15 +240,12 @@ void ZFinder::FindZmumu(LCCollectionVec * recparcol) {
   ReconstructedParticle* pMplus  = NULL;
   ReconstructedParticle* pMminus = NULL;
   float bestdmz = 999.;
-  // unsigned int   besti=0;
-  // unsigned int   bestj=0;
-  for(unsigned int i=0;i<pmuplus.size();i++){  
+  for(unsigned int i=0;i<pmuplus.size();i++){
     for(unsigned int j=0;j<pmuminus.size();j++){  
       LorentzVector pmumu = pmuplus[i]+pmuminus[j];
       float massmumu = pmumu.m();
       if( fabs(massmumu-91.2) < bestdmz){
 	bestdmz = fabs(massmumu-91.2);
-	// besti=i; bestj=j;
 	pMplus  = pMplusPfoVec[i];
 	pMminus = pMminusPfoVec[j];
       }
@@ -365,7 +362,6 @@ void ZFinder::FindZee(LCCollectionVec * recparcol) {
   ReconstructedParticle* pEplus  = NULL;
   ReconstructedParticle* pEminus = NULL;
   float bestdmz = 999.;
-  // unsigned int   besti = 999;
   unsigned int   bestj = 999;
   for(unsigned int i=0;i<peplus.size();i++){  
     for(unsigned int j=0;j<peminus.size();j++){  
@@ -373,8 +369,7 @@ void ZFinder::FindZee(LCCollectionVec * recparcol) {
       float massee = pee.m();
       if( fabs(massee-91.2) < bestdmz){
 	bestdmz = fabs(massee-91.2);
-	// besti=i;
-    bestj=j;
+        bestj=j;
 	pEplus = pEplusPfoVec[i];
 	pEminus = pEminusPfoVec[j];
       }

--- a/Analysis/ZFinder/src/ZFinder.cc
+++ b/Analysis/ZFinder/src/ZFinder.cc
@@ -240,15 +240,15 @@ void ZFinder::FindZmumu(LCCollectionVec * recparcol) {
   ReconstructedParticle* pMplus  = NULL;
   ReconstructedParticle* pMminus = NULL;
   float bestdmz = 999.;
-  unsigned int   besti=0;
-  unsigned int   bestj=0;
+  // unsigned int   besti=0;
+  // unsigned int   bestj=0;
   for(unsigned int i=0;i<pmuplus.size();i++){  
     for(unsigned int j=0;j<pmuminus.size();j++){  
       LorentzVector pmumu = pmuplus[i]+pmuminus[j];
       float massmumu = pmumu.m();
       if( fabs(massmumu-91.2) < bestdmz){
 	bestdmz = fabs(massmumu-91.2);
-	besti=i; bestj=j;
+	// besti=i; bestj=j;
 	pMplus  = pMplusPfoVec[i];
 	pMminus = pMminusPfoVec[j];
       }
@@ -365,7 +365,7 @@ void ZFinder::FindZee(LCCollectionVec * recparcol) {
   ReconstructedParticle* pEplus  = NULL;
   ReconstructedParticle* pEminus = NULL;
   float bestdmz = 999.;
-  unsigned int   besti = 999;
+  // unsigned int   besti = 999;
   unsigned int   bestj = 999;
   for(unsigned int i=0;i<peplus.size();i++){  
     for(unsigned int j=0;j<peminus.size();j++){  
@@ -373,7 +373,8 @@ void ZFinder::FindZee(LCCollectionVec * recparcol) {
       float massee = pee.m();
       if( fabs(massee-91.2) < bestdmz){
 	bestdmz = fabs(massee-91.2);
-	besti=i; bestj=j;
+	// besti=i;
+    bestj=j;
 	pEplus = pEplusPfoVec[i];
 	pEminus = pEminusPfoVec[j];
       }
@@ -570,4 +571,3 @@ void ZFinder::FindZee(LCCollectionVec * recparcol) {
 
   return;
 }
-

--- a/Calibration/AbsCalibration/src/AbsCalibr.cc
+++ b/Calibration/AbsCalibration/src/AbsCalibr.cc
@@ -295,7 +295,7 @@ double Balance(LCEvent * evt){
   int idpdg;
   const double* mom;
   float enr;
-  double mass;
+  // double mass;
   LCCollection* mcpCol = evt->getCollection("MCParticle" ) ;  
 //-----------------------------------------------------------------------
 // Calculate balance at IP taking into account everything
@@ -361,7 +361,7 @@ double Balance(LCEvent * evt){
     idpdg = imc-> getPDG (); 
     mom = imc-> getMomentum (); 
     enr = imc-> getEnergy (); 
-    mass = imc-> getMass (); 
+    // mass = imc-> getMass (); 
     if( imc-> getGeneratorStatus() == 1) { // stable particles only   
       px = mom[0]; 
       py = mom[1]; 

--- a/Calibration/AbsCalibration/src/AbsCalibr.cc
+++ b/Calibration/AbsCalibration/src/AbsCalibr.cc
@@ -295,8 +295,7 @@ double Balance(LCEvent * evt){
   int idpdg;
   const double* mom;
   float enr;
-  // double mass;
-  LCCollection* mcpCol = evt->getCollection("MCParticle" ) ;  
+  LCCollection* mcpCol = evt->getCollection("MCParticle" ) ;
 //-----------------------------------------------------------------------
 // Calculate balance at IP taking into account everything
 //-----------------------------------------------------------------------
@@ -361,8 +360,7 @@ double Balance(LCEvent * evt){
     idpdg = imc-> getPDG (); 
     mom = imc-> getMomentum (); 
     enr = imc-> getEnergy (); 
-    // mass = imc-> getMass (); 
-    if( imc-> getGeneratorStatus() == 1) { // stable particles only   
+    if( imc-> getGeneratorStatus() == 1) { // stable particles only
       px = mom[0]; 
       py = mom[1]; 
       pz = mom[2];

--- a/CaloDigi/LDCCaloDigi/include/SimpleFCalDigi.h
+++ b/CaloDigi/LDCCaloDigi/include/SimpleFCalDigi.h
@@ -50,7 +50,6 @@ class SimpleFCalDigi : public Processor {
 
   std::string _cellIDLayerString{};
 
-  std::string  _defaultEncoding{};
   std::string  _caloLayout{};
   std::string  _caloID{};
   std::string  _caloType{};
@@ -70,6 +69,3 @@ class SimpleFCalDigi : public Processor {
 } ;
 
 #endif
-
-
-

--- a/CaloDigi/LDCCaloDigi/src/ILDCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/ILDCaloDigi.cc
@@ -570,10 +570,6 @@ void ILDCaloDigi::init() {
   _strip_virt_cells=-999;
   _countWarnings=0;
 
-  //fg: need to set default encoding in for reading old files...
-  // dudarboh: does nothing anymore, default encoding spedified in the constructor
-  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
-
   const gear::GearParameters& pMokka = Global::GEAR->getGearParameters("MokkaParameters");
 
   // Calorimeter geometry from GEAR
@@ -882,34 +878,35 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
                 eCellInTime+=ecor;
               }
 
-              if(!used[i]){
+              if (!used[i]) {
                 // merge with other hits?
                 used[i] = true;
-                for(unsigned int j =i+1; j<n;j++){
-                    if(!used[j]){
-                        float timej   = hit->getTimeCont(j);
-                        float energyj = hit->getEnergyCont(j);
-                        float deltatij = fabs(timei-timej);
-		                if (_ecalSimpleTimingCut){
-                            float deltatTmp = _ecalCorrectTimesForPropagation?dt:0;
-                            if (timej-deltatTmp>_ecalTimeWindowMin && timej-deltatTmp<ecalTimeWindowMax){
-                                energySum += energyj;
-                                if (timej < timei) timei = timej;
-    			            }
-		                }
-                        else{
-                			if(deltatij<_ecalDeltaTimeHitResolution){
-                    			if(energyj>energyi) timei=timej;
-                    			energyi+=energyj;
-                    			used[j] = true;
-                			}
-		                }
+                for (unsigned int j = i + 1; j < n; j++) {
+                  if (!used[j]) {
+                    float timej    = hit->getTimeCont(j);
+                    float energyj  = hit->getEnergyCont(j);
+                    float deltatij = fabs(timei - timej);
+                    if (_ecalSimpleTimingCut) {
+                      float deltatTmp = _ecalCorrectTimesForPropagation ? dt : 0;
+                      if (timej - deltatTmp > _ecalTimeWindowMin && timej - deltatTmp < ecalTimeWindowMax) {
+                        energySum += energyj;
+                        if (timej < timei)
+                          timei = timej;
+                      }
+                    } else {
+                      if (deltatij < _ecalDeltaTimeHitResolution) {
+                        if (energyj > energyi)
+                          timei = timej;
+                        energyi += energyj;
+                        used[j] = true;
+                      }
                     }
+                  }
                 }
-		if (_ecalSimpleTimingCut){
-			used = vector<bool>(n, true); // mark everything as used to terminate for loop on next run
-			energyi += energySum; //fill energySum back into energyi to have rest of loop behave the same.
-		}
+                if (_ecalSimpleTimingCut) {
+                  used = vector<bool>(n, true);  // mark everything as used to terminate for loop on next run
+                  energyi += energySum;          //fill energySum back into energyi to have rest of loop behave the same.
+                }
                 if(_digitalEcal){
                   calibr_coeff = this->digitalEcalCalibCoeff(layer);
                   if(_mapsEcalCorrection){
@@ -1107,8 +1104,6 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
               float timei   = hit->getTimeCont(i); //absolute hit timing of current subhit
               float energyi = hit->getEnergyCont(i); //energy of current subhit
 	      float energySum = 0;
-              // float deltat = 0;
-              // if(_hcalCorrectTimesForPropagation)deltat=dt;  //deltat now carries hit timing correction.
 	      //std::cout <<"outer:" << i << " " << n << std::endl;
 
               //idea of the following section: 

--- a/CaloDigi/LDCCaloDigi/src/ILDCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/ILDCaloDigi.cc
@@ -571,7 +571,8 @@ void ILDCaloDigi::init() {
   _countWarnings=0;
 
   //fg: need to set default encoding in for reading old files...
-  CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
+  // dudarboh: does nothing anymore, default encoding spedified in the constructor
+  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
 
   const gear::GearParameters& pMokka = Global::GEAR->getGearParameters("MokkaParameters");
 
@@ -761,8 +762,8 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
   // * Reading Collections of ECAL Simulated Hits *
   //
 
-  for (unsigned int i(0); i < _ecalCollections.size(); ++i) {
-    std::string colName =  _ecalCollections[i] ;
+  for (unsigned int colIdx(0); colIdx < _ecalCollections.size(); ++colIdx) {
+    std::string colName =  _ecalCollections[colIdx] ;
 
     streamlog_out ( DEBUG ) << "looking for collection: " << colName << endl;
 
@@ -806,8 +807,8 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
       int numElements = col->getNumberOfElements();
       streamlog_out ( DEBUG ) << colName << " number of elements = " << numElements << endl;
 
-      for (int j(0); j < numElements; ++j) {
-        SimCalorimeterHit * hit = dynamic_cast<SimCalorimeterHit*>( col->getElementAt( j ) ) ;
+      for (int hitIdx(0); hitIdx < numElements; ++hitIdx) {
+        SimCalorimeterHit * hit = dynamic_cast<SimCalorimeterHit*>( col->getElementAt( hitIdx ) ) ;
         float energy = hit->getEnergy();
 
         // apply threshold cut
@@ -885,26 +886,25 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
                 // merge with other hits?
                 used[i] = true;
                 for(unsigned int j =i+1; j<n;j++){
-                  if(!used[j]){
-                    float timej   = hit->getTimeCont(j);
-                    float energyj = hit->getEnergyCont(j);
-                    float deltat = fabs(timei-timej);
-		    if (_ecalSimpleTimingCut){
-			    float deltat = _ecalCorrectTimesForPropagation?dt:0;
-			    if (timej-deltat>_ecalTimeWindowMin && timej-deltat<ecalTimeWindowMax){
-				    energySum += energyj;
-				    if (timej < timei){
-					    timei = timej;
-				    }
-			    }
-		    } else {
-			if(deltat<_ecalDeltaTimeHitResolution){
-			if(energyj>energyi)timei=timej;
-			energyi+=energyj;
-			used[j] = true;
-			}
-		    }
-                  }
+                    if(!used[j]){
+                        float timej   = hit->getTimeCont(j);
+                        float energyj = hit->getEnergyCont(j);
+                        float deltatij = fabs(timei-timej);
+		                if (_ecalSimpleTimingCut){
+                            float deltatTmp = _ecalCorrectTimesForPropagation?dt:0;
+                            if (timej-deltatTmp>_ecalTimeWindowMin && timej-deltatTmp<ecalTimeWindowMax){
+                                energySum += energyj;
+                                if (timej < timei) timei = timej;
+    			            }
+		                }
+                        else{
+                			if(deltatij<_ecalDeltaTimeHitResolution){
+                    			if(energyj>energyi) timei=timej;
+                    			energyi+=energyj;
+                    			used[j] = true;
+                			}
+		                }
+                    }
                 }
 		if (_ecalSimpleTimingCut){
 			used = vector<bool>(n, true); // mark everything as used to terminate for loop on next run
@@ -1008,7 +1008,7 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
       // add ECAL collection to event
       ecalcol->parameters().setValue(LCIO::CellIDEncoding,initString);
 
-      evt->addCollection(ecalcol,_outputEcalCollections[i].c_str());
+      evt->addCollection(ecalcol,_outputEcalCollections[colIdx].c_str());
     }
     catch(DataNotAvailableException &e){
       streamlog_out(DEBUG) << "could not find input ECAL collection " << colName << std::endl;
@@ -1041,9 +1041,9 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
   // * Reading HCAL Collections of Simulated Hits *
   //
 
-  for (unsigned int i(0); i < _hcalCollections.size(); ++i) {
+  for (unsigned int colIdx(0); colIdx < _hcalCollections.size(); ++colIdx) {
 
-    std::string colName =  _hcalCollections[i] ;
+    std::string colName =  _hcalCollections[colIdx] ;
 
     if ( colName.find("dummy")!=string::npos ) {
       streamlog_out ( DEBUG ) << "ignoring input HCAL collection name (looks like dummy name)" << colName << endl;
@@ -1056,14 +1056,14 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
 
 
     try{
-      LCCollection * col = evt->getCollection( _hcalCollections[i].c_str() ) ;
+      LCCollection * col = evt->getCollection( _hcalCollections[colIdx].c_str() ) ;
       string initString = col->getParameters().getStringVal(LCIO::CellIDEncoding);
       int numElements = col->getNumberOfElements();
       CellIDDecoder<SimCalorimeterHit> idDecoder(col);
       LCCollectionVec *hcalcol = new LCCollectionVec(LCIO::CALORIMETERHIT);
       hcalcol->setFlag(_flag.getFlag());
-      for (int j(0); j < numElements; ++j) { //loop over all SimCalorimeterHits in this collection
-        SimCalorimeterHit * hit = dynamic_cast<SimCalorimeterHit*>( col->getElementAt( j ) ) ;
+      for (int hitIdx(0); hitIdx < numElements; ++hitIdx) { //loop over all SimCalorimeterHits in this collection
+        SimCalorimeterHit * hit = dynamic_cast<SimCalorimeterHit*>( col->getElementAt( hitIdx ) ) ;
         float energy = hit->getEnergy();
 
         if (energy > _thresholdHcal[0]/2) { //preselect for SimHits with energySum>threshold. Doubtful at least, as lower energy hit might fluctuate up and still be counted
@@ -1107,8 +1107,8 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
               float timei   = hit->getTimeCont(i); //absolute hit timing of current subhit
               float energyi = hit->getEnergyCont(i); //energy of current subhit
 	      float energySum = 0;
-              float deltat = 0;
-              if(_hcalCorrectTimesForPropagation)deltat=dt;  //deltat now carries hit timing correction.
+              // float deltat = 0;
+              // if(_hcalCorrectTimesForPropagation)deltat=dt;  //deltat now carries hit timing correction.
 	      //std::cout <<"outer:" << i << " " << n << std::endl;
 
               //idea of the following section: 
@@ -1129,18 +1129,18 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
                   if(!used[j]){
                     float timej   = hit->getTimeCont(j);
                     float energyj = hit->getEnergyCont(j);
-                    float deltat = fabs(timei-timej);
+                    float deltatij = fabs(timei-timej);
                     //              std::cout << " HCAL  deltat : " << deltat << std::endl;
 		    if (_hcalSimpleTimingCut){
-			    float deltat = _hcalCorrectTimesForPropagation?dt:0;
-			    if (timej-deltat>_hcalTimeWindowMin && timej-deltat<hcalTimeWindowMax){
+			    float deltatTmp = _hcalCorrectTimesForPropagation?dt:0;
+			    if (timej-deltatTmp>_hcalTimeWindowMin && timej-deltatTmp<hcalTimeWindowMax){
 				    energySum += energyj;
 				    if (timej<timei){
 					    timei = timej; //use earliest hit time for simpletimingcut
 				    }
 			    }
 		    } else {
-			if(deltat<_hcalDeltaTimeHitResolution){ //if this subhit is close to current subhit, add this hit's energy to timecluster
+			if(deltatij<_hcalDeltaTimeHitResolution){ //if this subhit is close to current subhit, add this hit's energy to timecluster
 			if(energyj>energyi)timei=timej; //this is probably not what was intended. i guess this should find the largest hit of one timecluster and use its hittime for the cluster, but instead it compares the current hit energy to the sum of already found hit energies
 			//std::cout << timei << " - " << timej << std::endl;
 			//std::cout << energyi << " - " << energyj << std::endl;
@@ -1230,7 +1230,7 @@ void ILDCaloDigi::processEvent( LCEvent * evt ) {
       }
       // add HCAL collection to event
       hcalcol->parameters().setValue(LCIO::CellIDEncoding,initString);
-      evt->addCollection(hcalcol,_outputHcalCollections[i].c_str());
+      evt->addCollection(hcalcol,_outputHcalCollections[colIdx].c_str());
     }
     catch(DataNotAvailableException &e){
       streamlog_out(DEBUG) << "could not find input HCAL collection " << colName << std::endl;

--- a/CaloDigi/LDCCaloDigi/src/LDCCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/LDCCaloDigi.cc
@@ -169,10 +169,6 @@ void LDCCaloDigi::init() {
   _nRun = -1;
   _nEvt = 0;
 
-  //fg: need to set default encoding in for reading old files...
-  // dudarboh: does nothing anymore, default encoding spedified in the constructor
-  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
-
 }
 
 

--- a/CaloDigi/LDCCaloDigi/src/LDCCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/LDCCaloDigi.cc
@@ -170,7 +170,8 @@ void LDCCaloDigi::init() {
   _nEvt = 0;
 
   //fg: need to set default encoding in for reading old files...
-  CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
+  // dudarboh: does nothing anymore, default encoding spedified in the constructor
+  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
 
 }
 
@@ -506,4 +507,3 @@ void LDCCaloDigi::fillECALGaps( ) {
   return;
 
 }
-

--- a/CaloDigi/LDCCaloDigi/src/MokkaCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/MokkaCaloDigi.cc
@@ -221,14 +221,14 @@ void MokkaCaloDigi::init() {
     }
 
     if (z >= y_dim1_for_z && z < (y_dim1_for_z+y_dim2_for_z)) {
-      float z = 
+      float zTmp = 
 	_regularBarrelModuleLength-2*_lateralPlateThickness+(id*_hcalAbsorberThickness+(id-1)*_hcalSensitiveThickness-y_dim1_for_z)*(top_end_dim_z-_regularBarrelModuleLength)/y_dim2_for_z;
-      z_width = int(z/_virtualCellSizeZ)*_virtualCellSizeZ;
+      z_width = int(zTmp/_virtualCellSizeZ)*_virtualCellSizeZ;
     }
 
     if (z >= (y_dim1_for_z+y_dim2_for_z) ) {
-      float z = top_end_dim_z - 2*_lateralPlateThickness;
-      z_width = int(z/_virtualCellSizeZ)*_virtualCellSizeZ;
+      float zTmp = top_end_dim_z - 2*_lateralPlateThickness;
+      z_width = int(zTmp/_virtualCellSizeZ)*_virtualCellSizeZ;
     }
 
 
@@ -464,8 +464,8 @@ MyHit * MokkaCaloDigi::ProcessHitInBarrel( SimCalorimeterHit * hit ) {
   int I=(cellid & MASK_I) >> SHIFT_I; // I
 
   float zBegin = 0.;
-  float chamberLength = 0.;
-  float offsetMaxZ;
+  // float chamberLength = 0.;
+  // float offsetMaxZ;
 
   // calculation of the lower z coordinate of the sensitive part of barrel module
   if (Module == 1) {
@@ -483,14 +483,14 @@ MyHit * MokkaCaloDigi::ProcessHitInBarrel( SimCalorimeterHit * hit ) {
   if (Module == 5) {
     zBegin = 1.5*_regularBarrelModuleLength + 2*_modulesGap + _lateralPlateThickness;
   }
-  if (Module == 1 || Module == 5) {
-    chamberLength = _endBarrelChamberLength[Layer];
-    offsetMaxZ = _endBarrelOffsetMaxZ[Layer];
-  }
-  else {
-    chamberLength = _regularBarrelChamberLength;
-    offsetMaxZ = _regularBarrelOffsetMaxZ;
-  }
+  // if (Module == 1 || Module == 5) {
+  //   chamberLength = _endBarrelChamberLength[Layer];
+  //   offsetMaxZ = _endBarrelOffsetMaxZ[Layer];
+  // }
+  // else {
+  //   chamberLength = _regularBarrelChamberLength;
+  //   offsetMaxZ = _regularBarrelOffsetMaxZ;
+  // }
 
 
   float xBegin = -0.5*_barrelLateralWidth[Layer];
@@ -678,4 +678,3 @@ void MokkaCaloDigi::end(){
  	    << std::endl ;
 
 }
-

--- a/CaloDigi/LDCCaloDigi/src/MokkaCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/MokkaCaloDigi.cc
@@ -464,8 +464,6 @@ MyHit * MokkaCaloDigi::ProcessHitInBarrel( SimCalorimeterHit * hit ) {
   int I=(cellid & MASK_I) >> SHIFT_I; // I
 
   float zBegin = 0.;
-  // float chamberLength = 0.;
-  // float offsetMaxZ;
 
   // calculation of the lower z coordinate of the sensitive part of barrel module
   if (Module == 1) {
@@ -483,15 +481,6 @@ MyHit * MokkaCaloDigi::ProcessHitInBarrel( SimCalorimeterHit * hit ) {
   if (Module == 5) {
     zBegin = 1.5*_regularBarrelModuleLength + 2*_modulesGap + _lateralPlateThickness;
   }
-  // if (Module == 1 || Module == 5) {
-  //   chamberLength = _endBarrelChamberLength[Layer];
-  //   offsetMaxZ = _endBarrelOffsetMaxZ[Layer];
-  // }
-  // else {
-  //   chamberLength = _regularBarrelChamberLength;
-  //   offsetMaxZ = _regularBarrelOffsetMaxZ;
-  // }
-
 
   float xBegin = -0.5*_barrelLateralWidth[Layer];
   int Inew = I / _cellScaleX;

--- a/CaloDigi/LDCCaloDigi/src/NewLDCCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/NewLDCCaloDigi.cc
@@ -224,10 +224,6 @@ void NewLDCCaloDigi::init() {
   _nRun = -1;
   _nEvt = 0;
 
-  //fg: need to set default encoding in for reading old files...
-  //CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
-  // dudarboh: does nothing anymore, default encoding spedified in the constructor
-
   // Calorimeter geometry from GEAR
   const gear::CalorimeterParameters& pEcalBarrel = Global::GEAR->getEcalBarrelParameters();
   const gear::CalorimeterParameters& pEcalEndcap = Global::GEAR->getEcalEndcapParameters();

--- a/CaloDigi/LDCCaloDigi/src/NewLDCCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/NewLDCCaloDigi.cc
@@ -225,7 +225,8 @@ void NewLDCCaloDigi::init() {
   _nEvt = 0;
 
   //fg: need to set default encoding in for reading old files...
-  CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
+  //CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
+  // dudarboh: does nothing anymore, default encoding spedified in the constructor
 
   // Calorimeter geometry from GEAR
   const gear::CalorimeterParameters& pEcalBarrel = Global::GEAR->getEcalBarrelParameters();
@@ -641,4 +642,3 @@ void NewLDCCaloDigi::fillECALGaps( ) {
   return;
 
 }
-

--- a/CaloDigi/LDCCaloDigi/src/SimpleCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/SimpleCaloDigi.cc
@@ -140,10 +140,6 @@ void SimpleCaloDigi::init() {
   _nRun = -1;
   _nEvt = 0;
 
-  //fg: need to set default encoding in for reading old files...
-  // dudarboh: does nothing anymore, default encoding spedified in the constructor
-  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
-
 }
 
 

--- a/CaloDigi/LDCCaloDigi/src/SimpleCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/SimpleCaloDigi.cc
@@ -141,7 +141,8 @@ void SimpleCaloDigi::init() {
   _nEvt = 0;
 
   //fg: need to set default encoding in for reading old files...
-  CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
+  // dudarboh: does nothing anymore, default encoding spedified in the constructor
+  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
 
 }
 

--- a/CaloDigi/LDCCaloDigi/src/SimpleFCalDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/SimpleFCalDigi.cc
@@ -98,12 +98,6 @@ SimpleFCalDigi::SimpleFCalDigi() : Processor("SimpleFCalDigi") {
 			     std::string("endcap")
 			     );
 
-  registerProcessorParameter("DefaultEncoding" ,
-			     "string defining cell encoding" , 
-			     _defaultEncoding , 
-			     std::string("M:3,S-1:3,I:9,J:9,K-1:6")
-			     );
-
 }
 
 void SimpleFCalDigi::init() {

--- a/CaloDigi/LDCCaloDigi/src/SimpleFCalDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/SimpleFCalDigi.cc
@@ -105,10 +105,6 @@ void SimpleFCalDigi::init() {
   _nRun = -1;
   _nEvt = 0;
 
-  if (_defaultEncoding != "M:3,S-1:3,I:9,J:9,K-1:6") {
-    streamlog_out(WARNING) << "'_defaultEncoding' parameter set to a non-default value. This parameters is ignored" << std::endl;
-  }
-
   if ( ! _caloID.compare("lcal")  && // true if it is false ... 
                  _fixLCalHits          ) {  
             // parametrs for fixing wrong cellID to xyz coding in LCal Mokka

--- a/CaloDigi/LDCCaloDigi/src/SimpleMuonDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/SimpleMuonDigi.cc
@@ -99,7 +99,8 @@ void SimpleMuonDigi::init() {
   _nEvt = 0;
 
   //fg: need to set default encoding in for reading old files...
-  CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
+  // dudarboh: does nothing anymore, default encoding spedified in the constructor
+  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
 
 
   //Get the number of Layers in the Endcap

--- a/CaloDigi/LDCCaloDigi/src/SimpleMuonDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/SimpleMuonDigi.cc
@@ -98,11 +98,6 @@ void SimpleMuonDigi::init() {
   _nRun = -1;
   _nEvt = 0;
 
-  //fg: need to set default encoding in for reading old files...
-  // dudarboh: does nothing anymore, default encoding spedified in the constructor
-  // CellIDDecoder<SimCalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6") ;
-
-
   //Get the number of Layers in the Endcap
   int layersEndcap=0, layersBarrel=0;
 

--- a/CaloDigi/Realistic/src/RealisticCaloDigiScinPpd.cc
+++ b/CaloDigi/Realistic/src/RealisticCaloDigiScinPpd.cc
@@ -51,8 +51,8 @@ float RealisticCaloDigiScinPpd::convertEnergy( float energy, int inUnit ) const 
   if      ( inUnit==NPE ) return energy;
   else if ( inUnit==MIP ) return _PPD_pe_per_mip*energy;
   else if ( inUnit==GEVDEP ) return _PPD_pe_per_mip*energy/_calib_mip;
-  else streamlog_out (ERROR) << "unknown unit " << inUnit << std::endl;
-  assert (0);
+
+  throw std::runtime_error("RealisticCaloDigiScinPpd::convertEnergy - unknown unit " + std::to_string(inUnit));
 }
 
 float RealisticCaloDigiScinPpd::digitiseDetectorEnergy(float energy) const {

--- a/CaloDigi/Realistic/src/RealisticCaloDigiSilicon.cc
+++ b/CaloDigi/Realistic/src/RealisticCaloDigiSilicon.cc
@@ -30,8 +30,8 @@ float RealisticCaloDigiSilicon::convertEnergy( float energy, int inUnit ) const 
   // converts input energy to MIP scale
   if      ( inUnit==MIP ) return energy;
   else if ( inUnit==GEVDEP ) return energy/_calib_mip;
-  else streamlog_out (ERROR) << "RealisticCaloDigiSilicon::convertEnergy - unknown unit " << inUnit << std::endl;
-  assert (0);
+
+  throw std::runtime_error("RealisticCaloDigiSilicon::convertEnergy - unknown unit " + std::to_string(inUnit));
 }
 
 

--- a/Clustering/PhotonFinderKit/src/EMShowerFinder.cc
+++ b/Clustering/PhotonFinderKit/src/EMShowerFinder.cc
@@ -105,7 +105,8 @@ void EMShowerFinder::init() {
   printParameters();
 
   // FIXME: hard coded cell id's for old Mokka (e.g. Mokka v5.4) versions)
-  CellIDDecoder<CalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6");
+  // dudarboh: does nothing anymore, default encoding spedified in the constructor
+  // CellIDDecoder<CalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6");
 
 
   // debug

--- a/Clustering/PhotonFinderKit/src/EMShowerFinder.cc
+++ b/Clustering/PhotonFinderKit/src/EMShowerFinder.cc
@@ -104,11 +104,6 @@ void EMShowerFinder::init() {
   // usually a good idea to 
   printParameters();
 
-  // FIXME: hard coded cell id's for old Mokka (e.g. Mokka v5.4) versions)
-  // dudarboh: does nothing anymore, default encoding spedified in the constructor
-  // CellIDDecoder<CalorimeterHit>::setDefaultEncoding("M:3,S-1:3,I:9,J:9,K-1:6");
-
-
   // debug
   if (_drawOnCED)  MarlinCED::init(this);
 

--- a/Clustering/PhotonFinderKit/src/KITutil.cc
+++ b/Clustering/PhotonFinderKit/src/KITutil.cc
@@ -141,12 +141,10 @@ void Precalc2(vector< Superhit2* >& shvec,double r, double z, double cell, doubl
 
            unsigned int nPts=shvec.size();
            ANNpointArray dataPts;
-           // ANNpoint queryPt;
            ANNidxArray nnIdx;
            ANNdistArray dists;
            ANNkd_tree* kdTree;
 
-	   // queryPt=annAllocPt(3); // 3d point 
 	   dataPts=annAllocPts(nPts,3);
            nnIdx=new ANNidx[36];
 	   dists=new ANNdist[36];
@@ -287,8 +285,7 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 		unsigned int N, vector<float> miipstep, CoreCut2 Ccut)
 {       
           typedef pair<int,int>   test;
-	  // int psl_plun_global=0;
-	  
+
 	  double Diagby2=PGDB[PGdb::ECAL1_BAR].cell_size*sqrt(2.0)/2.0;
 	  double d=PGDB[PGdb::ECAL1_BAR].r_inner;
 	  double z=PGDB[PGdb::ECAL1_CAP].z_inner;
@@ -341,8 +338,7 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 		}
 	      poslednjipun=im;
 	    }
-	  // psl_plun_global=poslednjipun;
-	 
+
 	  vector < PROTSEED2 > prs;
 
 		for(unsigned int im=0;im<bbb[0].size();im++)

--- a/Clustering/PhotonFinderKit/src/KITutil.cc
+++ b/Clustering/PhotonFinderKit/src/KITutil.cc
@@ -141,12 +141,12 @@ void Precalc2(vector< Superhit2* >& shvec,double r, double z, double cell, doubl
 
            unsigned int nPts=shvec.size();
            ANNpointArray dataPts;
-           ANNpoint queryPt;
+           // ANNpoint queryPt;
            ANNidxArray nnIdx;
            ANNdistArray dists;
            ANNkd_tree* kdTree;
 
-	   queryPt=annAllocPt(3); // 3d point 
+	   // queryPt=annAllocPt(3); // 3d point 
 	   dataPts=annAllocPts(nPts,3);
            nnIdx=new ANNidx[36];
 	   dists=new ANNdist[36];
@@ -287,7 +287,7 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 		unsigned int N, vector<float> miipstep, CoreCut2 Ccut)
 {       
           typedef pair<int,int>   test;
-	  int psl_plun_global=0;
+	  // int psl_plun_global=0;
 	  
 	  double Diagby2=PGDB[PGdb::ECAL1_BAR].cell_size*sqrt(2.0)/2.0;
 	  double d=PGDB[PGdb::ECAL1_BAR].r_inner;
@@ -341,7 +341,7 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 		}
 	      poslednjipun=im;
 	    }
-	  psl_plun_global=poslednjipun;
+	  // psl_plun_global=poslednjipun;
 	 
 	  vector < PROTSEED2 > prs;
 
@@ -460,11 +460,11 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 			      a.X[2]=Xatf[2];
 			      a.active=true;
 			      bool stavi=true;
-			      for( unsigned int im=0;im<prs2->size();im++)
+			      for( unsigned int im2=0;im2<prs2->size();im2++)
 				{
-				  if((*prs2)[im].active)
+				  if((*prs2)[im2].active)
 				    {
-				      if( (*prs2)[im].cl==a.cl)
+				      if( (*prs2)[im2].cl==a.cl)
 					stavi=false;
 				    }
 				}
@@ -494,11 +494,11 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 			  a.active=true;
 		
 			  bool stavi=true;
-			  for( unsigned int im=0;im<prs2->size();im++)
+			  for( unsigned int im2=0;im2<prs2->size();im2++)
 			    {
-			      if((*prs2)[im].active)
+			      if((*prs2)[im2].active)
 				{
-				  if( (*prs2)[im].cl==a.cl)
+				  if( (*prs2)[im2].cl==a.cl)
 				    stavi=false;
 				}
 			    }
@@ -562,12 +562,7 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 
 	  if(kojsv.size()!=0)
 	    {
-           
-	      int iskoristio[kojsv.size()];
-	      for(unsigned int i=0;i<kojsv.size();i++)
-		{
-		  iskoristio[i]=0;
-		}
+          std::vector<int> iskoristio(kojsv.size(), 0);
 	      for(unsigned int i=0;i<kojsv.size();i++)
 		{
 		  if( iskoristio[i]==0)
@@ -687,11 +682,7 @@ void FindCores2(Shitvec2* secal1, vector<Tmpclvec2>& bbb , vector <PROTSEED2> * 
 		       }else{
                           
 		       vector <int> izabrani;
-		       int isko[trojka.size()];
-		       for(unsigned int jj=0;jj<trojka.size();jj++)
-			     {
-			       isko[jj]=0;
-			     }
+               std::vector <int> isko(trojka.size(), 0);
 		       for(unsigned int j=0;j<nivoi.size();j++)   
 			 {
 			       vector<int> sabr;
@@ -1158,22 +1149,22 @@ void LineCaloIntersect2(double* X1, double* X2,double&d,double&zmax,  double*X)
       }
    
     }else { // endcap 
-                double n[8][3];
+                double nn[8][3];
                 if(X2[2]>0.0)
                  {
-		   n[0][0]=0.0; 
-		   n[0][1]=0.0;
-		   n[0][2]=1.0;
+		   nn[0][0]=0.0; 
+		   nn[0][1]=0.0;
+		   nn[0][2]=1.0;
 		 }else{
-		  n[0][0]=0.0; 
-		  n[0][1]=0.0;
-		  n[0][2]=-1.0;
+		  nn[0][0]=0.0; 
+		  nn[0][1]=0.0;
+		  nn[0][2]=-1.0;
 		}
 
 
-		double tmp=-(n[0][0]*n[0][0]+n[0][1]*n[0][1]+n[0][2]*n[0][2])*zmax
-		            +n[0][0]*X1[0]+n[0][1]*X1[1]+n[0][2]*X1[2];
-		double tmp2=n[0][0]*(X1[0]-X2[0])+n[0][1]*(X1[1]-X2[1])+n[0][2]*(X1[2]-X2[2]);
+		double tmp=-(nn[0][0]*nn[0][0]+nn[0][1]*nn[0][1]+nn[0][2]*nn[0][2])*zmax
+		            +nn[0][0]*X1[0]+nn[0][1]*X1[1]+nn[0][2]*X1[2];
+		double tmp2=nn[0][0]*(X1[0]-X2[0])+nn[0][1]*(X1[1]-X2[1])+nn[0][2]*(X1[2]-X2[2]);
 		double t=0.0;
      
 		if(tmp2!=0.0)

--- a/Clustering/hybridEcalSplitter/src/hybridRecoProcessor.cc
+++ b/Clustering/hybridEcalSplitter/src/hybridRecoProcessor.cc
@@ -226,16 +226,16 @@ void hybridRecoProcessor::processEvent( LCEvent * evt ) {
 
   if (_makePlots) {
     // first fill some simple MC histos
-    float phi=-999;
-    float theta=-999;
+    // float phi=-999;
+    // float theta=-999;
     try {
       LCCollection * col = evt->getCollection("MCParticle");
       if (col->getNumberOfElements()>0) {
 	MCParticle * mcp = dynamic_cast<MCParticle*>(col->getElementAt(0) );
 	TVector3 mom(mcp->getMomentum()[0], mcp->getMomentum()[1], mcp->getMomentum()[2]);
 	h_phiThetaMC->Fill(mom.Phi(), mom.Theta());
-	phi = mom.Phi();
-	theta = mom.Theta();
+	// phi = mom.Phi();
+	// theta = mom.Theta();
       }
     }
     catch(DataNotAvailableException &e) {};
@@ -249,7 +249,7 @@ void hybridRecoProcessor::processEvent( LCEvent * evt ) {
 
   std::pair < TVector3, TVector3 > stripEnds;
   std::vector <std::string> * toSplit;
-  std::vector <std::string> * stripSplitter;
+  // std::vector <std::string> * stripSplitter;
   int orientation;
 
   std::map < IMPL::LCCollectionVec*, std::string > outputcolls;
@@ -270,12 +270,12 @@ void hybridRecoProcessor::processEvent( LCEvent * evt ) {
     case 0:
       orientation = TRANSVERSE;
       toSplit = &_ecalCollectionsTranStrips;
-      stripSplitter = &_ecalCollectionsLongStrips;
+      // stripSplitter = &_ecalCollectionsLongStrips;
       break;
     case 1:
       orientation = LONGITUDINAL;
       toSplit = &_ecalCollectionsLongStrips;
-      stripSplitter = &_ecalCollectionsTranStrips;
+      // stripSplitter = &_ecalCollectionsTranStrips;
       break;
     default:
       streamlog_out ( ERROR ) << "ERROR crazy stuff!!! abandoning event..." << endl;
@@ -398,22 +398,22 @@ std::vector <CalorimeterHit*> hybridRecoProcessor::getVirtualHits(LCEvent* evt, 
   if (_saveIntersections) { 
     // make new collection with a hit at each end of a strip
     //   for debugging purposes
-    float pp[3];
-    pp[0] = stripEnds.first.X();
-    pp[1] = stripEnds.first.Y();
-    pp[2] = stripEnds.first.Z();
+    float pp2[3];
+    pp2[0] = stripEnds.first.X();
+    pp2[1] = stripEnds.first.Y();
+    pp2[2] = stripEnds.first.Z();
     CalorimeterHitImpl* interhit = new CalorimeterHitImpl();
-    interhit->setPosition( pp );
+    interhit->setPosition( pp2 );
     interhit->setEnergy(0.03);
 
     if (orientation==TRANSVERSE) stripEndsTransCol->addElement(interhit);
     else if (orientation==LONGITUDINAL) stripEndsLongCol->addElement(interhit);
 
-    pp[0] = stripEnds.second.X();
-    pp[1] = stripEnds.second.Y();
-    pp[2] = stripEnds.second.Z();
+    pp2[0] = stripEnds.second.X();
+    pp2[1] = stripEnds.second.Y();
+    pp2[2] = stripEnds.second.Z();
     interhit = new CalorimeterHitImpl();
-    interhit->setPosition( pp );
+    interhit->setPosition( pp2 );
     interhit->setEnergy(0.03);
 
     if (orientation==TRANSVERSE) stripEndsTransCol->addElement(interhit);
@@ -507,10 +507,10 @@ std::vector <CalorimeterHit*> hybridRecoProcessor::getVirtualHits(LCEvent* evt, 
 	  if (intercept.Mag()>0) { // intercept found, calculate in which virtual cell
 	    nSplitters++;
 	    float frac(-1);
-	    for (int i=0; i<3; i++) {
-	      float dx = stripEnds.second[i] - stripEnds.first[i];
+	    for (int k=0; k<3; k++) {
+	      float dx = stripEnds.second[k] - stripEnds.first[k];
 	      if (fabs(dx)>0.1) {
-		frac = (intercept[i]-stripEnds.first[i])/dx;
+		frac = (intercept[k]-stripEnds.first[k])/dx;
 		break;
 	      }
 	    }

--- a/Clustering/hybridEcalSplitter/src/hybridRecoProcessor.cc
+++ b/Clustering/hybridEcalSplitter/src/hybridRecoProcessor.cc
@@ -226,16 +226,12 @@ void hybridRecoProcessor::processEvent( LCEvent * evt ) {
 
   if (_makePlots) {
     // first fill some simple MC histos
-    // float phi=-999;
-    // float theta=-999;
     try {
       LCCollection * col = evt->getCollection("MCParticle");
       if (col->getNumberOfElements()>0) {
 	MCParticle * mcp = dynamic_cast<MCParticle*>(col->getElementAt(0) );
 	TVector3 mom(mcp->getMomentum()[0], mcp->getMomentum()[1], mcp->getMomentum()[2]);
 	h_phiThetaMC->Fill(mom.Phi(), mom.Theta());
-	// phi = mom.Phi();
-	// theta = mom.Theta();
       }
     }
     catch(DataNotAvailableException &e) {};
@@ -249,7 +245,6 @@ void hybridRecoProcessor::processEvent( LCEvent * evt ) {
 
   std::pair < TVector3, TVector3 > stripEnds;
   std::vector <std::string> * toSplit;
-  // std::vector <std::string> * stripSplitter;
   int orientation;
 
   std::map < IMPL::LCCollectionVec*, std::string > outputcolls;
@@ -270,12 +265,10 @@ void hybridRecoProcessor::processEvent( LCEvent * evt ) {
     case 0:
       orientation = TRANSVERSE;
       toSplit = &_ecalCollectionsTranStrips;
-      // stripSplitter = &_ecalCollectionsLongStrips;
       break;
     case 1:
       orientation = LONGITUDINAL;
       toSplit = &_ecalCollectionsLongStrips;
-      // stripSplitter = &_ecalCollectionsTranStrips;
       break;
     default:
       streamlog_out ( ERROR ) << "ERROR crazy stuff!!! abandoning event..." << endl;

--- a/PFOID/src/CreatePDFs.cc
+++ b/PFOID/src/CreatePDFs.cc
@@ -487,10 +487,10 @@ void CreatePDFs::processEvent( LCEvent * evt ) {
           Track *track=NULL;
           FloatVec weight = TrackToMCPNav.getRelatedFromWeights(mcp);
           float weightmax=-1.0;
-          for(unsigned int i=0; i<ovt.size(); i++){
-            if(weight[i]>weightmax){
-              weightmax=weight[i];
-              track = dynamic_cast<Track*>(ovt[i]);
+          for(unsigned int k=0; k<ovt.size(); k++){
+            if(weight[k]>weightmax){
+              weightmax=weight[k];
+              track = dynamic_cast<Track*>(ovt[k]);
             }// if ...
           }// for( int i=0 ...
           if(track!=NULL){

--- a/PFOID/src/PDF.cc
+++ b/PFOID/src/PDF.cc
@@ -292,7 +292,7 @@ double PDF::GetLikelihood(std::string CatName){
 
    
    //FIXED:SJA:removed variable array:  double LH [nCats];
-   double *LH = new double [nCats];
+   std::vector<double> LH(nCats, 0.0);
 
    double sum2=0.;
 
@@ -309,7 +309,6 @@ double PDF::GetLikelihood(std::string CatName){
      std::cout << " Error in Likelihood " << std::endl;
      delete[] sum;
      delete[] prod;
-     delete[] LH;
      return -1;
    }
 
@@ -322,13 +321,11 @@ double PDF::GetLikelihood(std::string CatName){
       std::cout << " Error in Likelihood : total LH not 1!" << std::endl;
       delete[] sum;
       delete[] prod;
-      delete[] LH;
       return -1;
     }
 
     delete[] sum;
     delete[] prod;
-    delete[] LH;
     return LH[index]/sum2;
 }
 

--- a/TrackDigi/FPCCDDigi/src/FPCCDClustering.cc
+++ b/TrackDigi/FPCCDDigi/src/FPCCDClustering.cc
@@ -914,7 +914,7 @@ void FPCCDClustering::makeTrackerHitVec(FPCCDData* pHitData, LCCollection* STHco
 
 
 
-void FPCCDClustering::makeTrackerHit(LCCollection* STHcol, int layer, int ladder, FPCCDClusterVec_t &clusterVec, std::multimap< std::pair<int,int>, SimTrackerHit*> relMap, LCCollectionVec* relCol, LCCollectionVec* trkHitVec )
+void FPCCDClustering::makeTrackerHit(LCCollection* STHcol, int layer, int ladder, FPCCDClusterVec_t &clusterVec, std::multimap< std::pair<int,int>, SimTrackerHit*> /*relMap*/, LCCollectionVec* relCol, LCCollectionVec* trkHitVec )
 {
   //trkHitVec and relCol is yet void data. 
   //This Version is different from default version at the point of last area of this function scope.

--- a/TrackDigi/FPCCDDigi/src/FPCCDClustering.cc
+++ b/TrackDigi/FPCCDDigi/src/FPCCDClustering.cc
@@ -968,7 +968,7 @@ void FPCCDClustering::makeTrackerHit(LCCollection* STHcol, int layer, int ladder
       FPCCDPixelHit::HitQuality_t addedQuality = aHit->getQuality();
       if( trackquality != FPCCDPixelHit::kBKGOverlap){
         if(trackquality == FPCCDPixelHit::kBKG){
-          addedQuality=FPCCDPixelHit::kBKG ? trackquality=FPCCDPixelHit::kBKG : trackquality=FPCCDPixelHit::kBKGOverlap;
+          addedQuality = FPCCDPixelHit::kBKG;
         }
       }
       else if(addedQuality==FPCCDPixelHit::kSignalOverlap){trackquality=FPCCDPixelHit::kSignalOverlap;       }

--- a/TrackDigi/TPCDigi/include/TPCDigiProcessor.h
+++ b/TrackDigi/TPCDigi/include/TPCDigiProcessor.h
@@ -121,7 +121,6 @@ public:
   TPCDigiProcessor(const TPCDigiProcessor&) = delete;
   TPCDigiProcessor& operator=(const TPCDigiProcessor&) = delete;
 
-
   virtual Processor*  newProcessor() { return new TPCDigiProcessor ; }
   
   

--- a/TrackDigi/TPCDigi/include/TPCDigiProcessor.h
+++ b/TrackDigi/TPCDigi/include/TPCDigiProcessor.h
@@ -121,6 +121,7 @@ public:
   TPCDigiProcessor(const TPCDigiProcessor&) = delete;
   TPCDigiProcessor& operator=(const TPCDigiProcessor&) = delete;
 
+
   virtual Processor*  newProcessor() { return new TPCDigiProcessor ; }
   
   

--- a/TrackDigi/TPCDigi/src/TPCDigiProcessor.cc
+++ b/TrackDigi/TPCDigi/src/TPCDigiProcessor.cc
@@ -529,9 +529,9 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
         if( ptSqrdMC > (0.2*0.2) ) ++_NPhysicsAbove02GeVSimTPCHits ;
         if( ptSqrdMC > 1.0 )  ++_NPhysicsAbove1GeVSimTPCHits ;
         
-      #ifdef DIGIPLOTS
-            if(_mcp) plotHelixHitResidual(_mcp, &thisPoint);
-      #endif  
+#ifdef DIGIPLOTS
+        if(_mcp) plotHelixHitResidual(_mcp, &thisPoint);
+#endif  
       } else {
         ++_NBackgroundSimTPCHits;
       }
@@ -636,7 +636,7 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
           }
         }
         
-        #ifdef DIGIPLOTS
+#ifdef DIGIPLOTS
         if(colFlag.bitSet(LCIO::THBIT_MOMENTUM)) {
           
           const float * mcpMomentum = _SimTHit->getMomentum() ;
@@ -664,7 +664,7 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
           streamlog_out(DEBUG3) << "padTheta from track mom = " << mom.theta() * (360.0 / twopi) << endl; 
           
         }
-        #endif        
+#endif        
         
       }
       
@@ -1091,8 +1091,6 @@ void TPCDigiProcessor::end()
 void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   
   const gear::TPCParameters& gearTPC = Global::GEAR->getTPCParameters() ;
-  // const gear::PadRowLayout2D& padLayout = gearTPC.getPadLayout() ;
-  // const gear::Vector2D padCoord = padLayout.getPadCenter(1) ;
   
   Voxel_tpc* seed_hit  = aVoxel;
   
@@ -1123,9 +1121,6 @@ void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   trkHit->setEDep(seed_hit->getEDep());
   //  trkHit->setType( 500 );
   
-  //  int side = lcio::ILDDetID::barrel ;
-  //  
-  //  if( pos[2] < 0.0 ) side = 1 ;
   
   (*_cellid_encoder)[ lcio::LCTrackerCellID::subdet() ] = lcio::ILDDetID::TPC ;
   (*_cellid_encoder)[ lcio::LCTrackerCellID::layer()  ] = seed_hit->getRowIndex() ;
@@ -1190,7 +1185,7 @@ void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   }
   
   
- #ifdef DIGIPLOTS
+#ifdef DIGIPLOTS
   SimTrackerHit* theSimHit = _tpcHitMap[seed_hit];
   double rSimSqrd = theSimHit->getPosition()[0]*theSimHit->getPosition()[0] + theSimHit->getPosition()[1]*theSimHit->getPosition()[1];
   
@@ -1212,14 +1207,13 @@ void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   _zSigmaVsZHisto->fill(seed_hit->getZ(),sqrt(covMat[5]));
   _rPhiSigmaHisto->fill(sqrt((covMat[2])/(cos(point.phi())*cos(point.phi()))));
   _zSigmaHisto->fill(sqrt(covMat[5]));
- #endif
+#endif
 }
 
 void TPCDigiProcessor::writeMergedVoxelsToHit( vector <Voxel_tpc*>* hitsToMerge){
   
   const gear::TPCParameters& gearTPC = Global::GEAR->getTPCParameters() ;
   const gear::PadRowLayout2D& padLayout = gearTPC.getPadLayout() ;
-  // const gear::Vector2D padCoord = padLayout.getPadCenter(1) ;
   
   TrackerHitImpl* trkHit = new TrackerHitImpl ;
   

--- a/TrackDigi/TPCDigi/src/TPCDigiProcessor.cc
+++ b/TrackDigi/TPCDigi/src/TPCDigiProcessor.cc
@@ -487,7 +487,7 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
       
       _SimTHit = dynamic_cast<SimTrackerHit*>( STHcol->getElementAt( i ) ) ;
       
-      float edep;
+      float edepHit;
       double padPhi(0.0);
       double padTheta (0.0);
       
@@ -529,9 +529,9 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
         if( ptSqrdMC > (0.2*0.2) ) ++_NPhysicsAbove02GeVSimTPCHits ;
         if( ptSqrdMC > 1.0 )  ++_NPhysicsAbove1GeVSimTPCHits ;
         
-#ifdef DIGIPLOTS
-        if(_mcp) plotHelixHitResidual(_mcp, &thisPoint);
-#endif  
+      #ifdef DIGIPLOTS
+            if(_mcp) plotHelixHitResidual(_mcp, &thisPoint);
+      #endif  
       } else {
         ++_NBackgroundSimTPCHits;
       }
@@ -636,7 +636,7 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
           }
         }
         
-#ifdef DIGIPLOTS
+        #ifdef DIGIPLOTS
         if(colFlag.bitSet(LCIO::THBIT_MOMENTUM)) {
           
           const float * mcpMomentum = _SimTHit->getMomentum() ;
@@ -664,7 +664,7 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
           streamlog_out(DEBUG3) << "padTheta from track mom = " << mom.theta() * (360.0 / twopi) << endl; 
           
         }
-#endif        
+        #endif        
         
       }
       
@@ -675,7 +675,7 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
         continue;
       }
       
-      edep = _SimTHit->getEDep();
+      edepHit = _SimTHit->getEDep();
       
       // Calculate Point Resolutions according to Ron's Formula 
       
@@ -746,10 +746,10 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
       }
       
       //get energy deposit of this row
-      edep=_SimTHit->getEDep();
+      edepHit=_SimTHit->getEDep();
 
       // create a tpc voxel hit and store it for this row
-      Voxel_tpc * atpcVoxel = new Voxel_tpc(iRowHit,iPhiHit,iZHit, thisPoint, edep, tpcRPhiRes, tpcZRes);
+      Voxel_tpc * atpcVoxel = new Voxel_tpc(iRowHit,iPhiHit,iZHit, thisPoint, edepHit, tpcRPhiRes, tpcZRes);
       
       _tpcRowHits.at(iRowHit).push_back(atpcVoxel);
       ++numberOfVoxelsCreated;
@@ -1091,8 +1091,8 @@ void TPCDigiProcessor::end()
 void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   
   const gear::TPCParameters& gearTPC = Global::GEAR->getTPCParameters() ;
-  const gear::PadRowLayout2D& padLayout = gearTPC.getPadLayout() ;
-  const gear::Vector2D padCoord = padLayout.getPadCenter(1) ;
+  // const gear::PadRowLayout2D& padLayout = gearTPC.getPadLayout() ;
+  // const gear::Vector2D padCoord = padLayout.getPadCenter(1) ;
   
   Voxel_tpc* seed_hit  = aVoxel;
   
@@ -1123,9 +1123,9 @@ void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   trkHit->setEDep(seed_hit->getEDep());
   //  trkHit->setType( 500 );
   
-//  int side = lcio::ILDDetID::barrel ;
-//  
-//  if( pos[2] < 0.0 ) side = 1 ;
+  //  int side = lcio::ILDDetID::barrel ;
+  //  
+  //  if( pos[2] < 0.0 ) side = 1 ;
   
   (*_cellid_encoder)[ lcio::LCTrackerCellID::subdet() ] = lcio::ILDDetID::TPC ;
   (*_cellid_encoder)[ lcio::LCTrackerCellID::layer()  ] = seed_hit->getRowIndex() ;
@@ -1190,7 +1190,7 @@ void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   }
   
   
-#ifdef DIGIPLOTS
+ #ifdef DIGIPLOTS
   SimTrackerHit* theSimHit = _tpcHitMap[seed_hit];
   double rSimSqrd = theSimHit->getPosition()[0]*theSimHit->getPosition()[0] + theSimHit->getPosition()[1]*theSimHit->getPosition()[1];
   
@@ -1212,14 +1212,14 @@ void TPCDigiProcessor::writeVoxelToHit( Voxel_tpc* aVoxel){
   _zSigmaVsZHisto->fill(seed_hit->getZ(),sqrt(covMat[5]));
   _rPhiSigmaHisto->fill(sqrt((covMat[2])/(cos(point.phi())*cos(point.phi()))));
   _zSigmaHisto->fill(sqrt(covMat[5]));
-#endif
+ #endif
 }
 
 void TPCDigiProcessor::writeMergedVoxelsToHit( vector <Voxel_tpc*>* hitsToMerge){
   
   const gear::TPCParameters& gearTPC = Global::GEAR->getTPCParameters() ;
   const gear::PadRowLayout2D& padLayout = gearTPC.getPadLayout() ;
-  const gear::Vector2D padCoord = padLayout.getPadCenter(1) ;
+  // const gear::Vector2D padCoord = padLayout.getPadCenter(1) ;
   
   TrackerHitImpl* trkHit = new TrackerHitImpl ;
   

--- a/TrackDigi/TPCDigi/src/voxel.cc
+++ b/TrackDigi/TPCDigi/src/voxel.cc
@@ -7,7 +7,7 @@ using namespace std;
 
 Voxel_tpc::Voxel_tpc(){
 }
-Voxel_tpc::Voxel_tpc(int row, int phi, int z, double pos[3], double posRPhi[2], double edep, double RPhiRes, double ZRes)
+Voxel_tpc::Voxel_tpc(int row, int phi, int z, double pos[3], double* /*posRPhi[2]*/, double edep, double RPhiRes, double ZRes)
 {
   _row_index = row;
   _phi_index = phi;
@@ -57,4 +57,3 @@ int Voxel_tpc::clusterFind(vector <Voxel_tpc*>* hitList){
 
   return hitList->size();
 }
-

--- a/TrackDigi/VTXDigi/src/CCDDigitizer.cc
+++ b/TrackDigi/VTXDigi/src/CCDDigitizer.cc
@@ -669,14 +669,12 @@ void CCDDigitizer::FindLocalPosition(SimTrackerHit * hit,
   //cout<<"nLadders "<<nLadders<<" "<<dPhi<<" "<<Phi0<<" "<<endl;
   
 
-  // int iLadder=0;
   for (int ic=0; ic<nLadders; ++ic) {
     PhiLadder = double(ic)*dPhi + Phi0;
     PhiInLocal = PhiInLab - PhiLadder;
     //cout<<"Phi "<<PhiLadder<<" "<<PhiInLocal<<" "<<PhiInLab<<" "<<_layerThickness[layer]<<" "<<Radius<<endl;
     if (RXY*cos(PhiInLocal)-Radius > -_layerThickness[layer] && 
         RXY*cos(PhiInLocal)-Radius < _layerThickness[layer]) {
-      // iLadder = ic;
       break;
     }
     //cout<<"phi ladder "<<PhiLadder<<endl;

--- a/TrackDigi/VTXDigi/src/CCDDigitizer.cc
+++ b/TrackDigi/VTXDigi/src/CCDDigitizer.cc
@@ -509,8 +509,8 @@ void CCDDigitizer::processEvent( LCEvent * evt ) {
           RelCol->addElement(rel);
         }
 // Clean Up        
-        for (int i=0; i < int(simTrkHitVec.size()); ++i) {
-          SimTrackerHit * hit = simTrkHitVec[i];
+        for (int j=0; j < int(simTrkHitVec.size()); ++j) {
+          SimTrackerHit * hit = simTrkHitVec[j];
           delete hit;
         }     
       } 
@@ -669,14 +669,14 @@ void CCDDigitizer::FindLocalPosition(SimTrackerHit * hit,
   //cout<<"nLadders "<<nLadders<<" "<<dPhi<<" "<<Phi0<<" "<<endl;
   
 
-  int iLadder=0;
+  // int iLadder=0;
   for (int ic=0; ic<nLadders; ++ic) {
     PhiLadder = double(ic)*dPhi + Phi0;
     PhiInLocal = PhiInLab - PhiLadder;
     //cout<<"Phi "<<PhiLadder<<" "<<PhiInLocal<<" "<<PhiInLab<<" "<<_layerThickness[layer]<<" "<<Radius<<endl;
     if (RXY*cos(PhiInLocal)-Radius > -_layerThickness[layer] && 
         RXY*cos(PhiInLocal)-Radius < _layerThickness[layer]) {
-      iLadder = ic;
+      // iLadder = ic;
       break;
     }
     //cout<<"phi ladder "<<PhiLadder<<endl;
@@ -883,18 +883,18 @@ void CCDDigitizer::ProduceHits( SimTrackerHitImplVec & vectorOfHits) {
        diffusion(xdif, ydif,sigmadirect);
        //diffusiontable(xdif, ydif,sigmadirect);
       
-      for(int i=0;i<maxpixx;i++){
+      for(int j=0;j<maxpixx;j++){
         for(int k=0;k<maxpixy;k++){
           
-          spxl[i][k]= (1-weight) * pxl[i][k];
+          spxl[j][k]= (1-weight) * pxl[j][k];
         }
       }
       
       diffusion(xdif, ydif,sigmareflect);
       //diffusiontable(xdif, ydif,sigmareflect);
-      for(int i=0;i<maxpixx;i++){
+      for(int j=0;j<maxpixx;j++){
         for(int k=0;k<maxpixy;k++){
-          pxl[i][k]= spxl[i][k]+ weight * pxl[i][k]; 
+          pxl[j][k]= spxl[j][k]+ weight * pxl[j][k]; 
         }
       }      
       //  delete spxl;
@@ -927,8 +927,8 @@ void CCDDigitizer::ProduceHits( SimTrackerHitImplVec & vectorOfHits) {
     double Numladderpixy=(int)(ladderlength/_pixelSizeY); 
      
 
-    for (int i = 0; i<maxpixx; i++) {
-      int ix=i+xcell-midpixx;
+    for (int j = 0; j<maxpixx; j++) {
+      int ix=j+xcell-midpixx;
       // if(_debug)cout<<ix<<","<<endl;
 
       if (ix >= 0 && ix<=Numladderpixx) {//test, whether pixel exists
@@ -938,7 +938,7 @@ void CCDDigitizer::ProduceHits( SimTrackerHitImplVec & vectorOfHits) {
           if (iy >=0 && iy<=Numladderpixy) {
 
 
-            double charge=(1e+6*energy*_electronsPerKeV) *pxl[i][k]; 
+            double charge=(1e+6*energy*_electronsPerKeV) *pxl[j][k]; 
             // if(_debug)cout<<"charge   " <<i<<" "<<k<<" "<<charge<<endl;
             int iexist = 0;
 
@@ -1640,4 +1640,3 @@ void CCDDigitizer::diffusiontable(double xdif, double ydif,double sigma){
   }
 }
 */
-

--- a/TrackDigi/VTXDigi/src/VTXBgClusters.cc
+++ b/TrackDigi/VTXDigi/src/VTXBgClusters.cc
@@ -145,8 +145,8 @@ void VTXBgClusters::processEvent( LCEvent * evt ) {
 
       float totMomentum = 0;
       if (_removeDRays) { // check if hit originates from delta-electron 
-        for (int i=0;i<3;++i) 
-          totMomentum+=SimTHit->getMomentum()[i]*SimTHit->getMomentum()[i];
+        for (int j=0;j<3;++j) 
+          totMomentum+=SimTHit->getMomentum()[j]*SimTHit->getMomentum()[j];
         totMomentum = sqrt(totMomentum);
         if (totMomentum < _momCut)
           accept = 0;
@@ -417,4 +417,3 @@ void VTXBgClusters::end(){
                            << " processed " << _nEvt << " events in " << _nRun << " runs "
                            << std::endl ;
 }
-

--- a/TrackDigi/VTXDigi/src/VTXDigiProcessor.cc
+++ b/TrackDigi/VTXDigi/src/VTXDigiProcessor.cc
@@ -196,12 +196,15 @@ void VTXDigiProcessor::processEvent( LCEvent * evt ) {
     }
     catch(DataNotAvailableException &e){
 
-      if (iColl==0)
+      if (iColl==0){
         streamlog_out(DEBUG) << "Collection " << _colNameVTX.c_str() << " is unavailable in event " << _nEvt << std::endl;
-      else if (iColl==1)
+      }
+      else if (iColl==1){
         streamlog_out(DEBUG) << "Collection " << _colNameSIT.c_str() << " is unavailable in event " << _nEvt << std::endl;
-      else 
+      }
+      else{
         streamlog_out(DEBUG) << "Collection " << _colNameSET.c_str() << " is unavailable in event " << _nEvt << std::endl; 
+      }
     }
 
     if( STHcol != 0 ){    
@@ -227,9 +230,9 @@ void VTXDigiProcessor::processEvent( LCEvent * evt ) {
         
         if (_removeDRays) { // check if hit originates from delta-electron 
           float totMomentum = 0;
-          for (int i=0;i<3;++i) 
+          for (int j=0;j<3;++j) 
             {
-              totMomentum+=SimTHit->getMomentum()[i]*SimTHit->getMomentum()[i];
+              totMomentum+=SimTHit->getMomentum()[j]*SimTHit->getMomentum()[j];
             }
           totMomentum = sqrt(totMomentum);
           
@@ -285,34 +288,34 @@ void VTXDigiProcessor::processEvent( LCEvent * evt ) {
 
             streamlog_out(DEBUG) << "start smearing along ladders for: " << layer << std::endl;
             
-            int layer = SimTHit->getCellID0() - 1;
+            int hitLayer = SimTHit->getCellID0() - 1;
               
             //phi between each ladder
-            double deltaPhi = ( 2 * M_PI ) / layerVXD.getNLadders(layer) ;
+            double deltaPhi = ( 2 * M_PI ) / layerVXD.getNLadders(hitLayer) ;
               
             double PhiInLocal(0.0);
             //find the ladder that the hit is in
             int ladderIndex = -1;
             double ladderPhi=999;
               
-            for (int ic=0; ic < layerVXD.getNLadders(layer); ++ic) {
+            for (int ic=0; ic < layerVXD.getNLadders(hitLayer); ++ic) {
                 
-              ladderPhi = correctPhiRange( layerVXD.getPhi0( layer ) + ic*deltaPhi ) ;
+              ladderPhi = correctPhiRange( layerVXD.getPhi0( hitLayer ) + ic*deltaPhi ) ;
                 
               PhiInLocal = hitvec.phi() - ladderPhi;
               double RXY = hitvec.rho();
                 
               // check if point is in range of ladder
-              if (RXY*cos(PhiInLocal) - layerVXD.getSensitiveDistance(layer) > -layerVXD.getSensitiveThickness(layer) && 
-                  RXY*cos(PhiInLocal) - layerVXD.getSensitiveDistance(layer) <  layerVXD.getSensitiveThickness(layer) )
+              if (RXY*cos(PhiInLocal) - layerVXD.getSensitiveDistance(hitLayer) > -layerVXD.getSensitiveThickness(hitLayer) && 
+                  RXY*cos(PhiInLocal) - layerVXD.getSensitiveDistance(hitLayer) <  layerVXD.getSensitiveThickness(hitLayer) )
                 {
                   ladderIndex = ic;
                   break;
                 }
             }
 
-            double sensitive_width  = layerVXD.getSensitiveWidth(layer);
-            double sensitive_offset = layerVXD.getSensitiveOffset(layer);
+            double sensitive_width  = layerVXD.getSensitiveWidth(hitLayer);
+            double sensitive_offset = layerVXD.getSensitiveOffset(hitLayer);
 
             double ladder_incline = correctPhiRange( (M_PI/2.0 ) + ladderPhi );
               
@@ -322,12 +325,12 @@ void VTXDigiProcessor::processEvent( LCEvent * evt ) {
                                  << " Event: " << _nEvt 
                                  << " hit: " << i 
                                  << " of "   << nSimHits
-                                 << "  layer: " << layer 
+                                 << "  layer: " << hitLayer 
                                  << "  ladderIndex: " << ladderIndex 
                                  << "  half ladder width " << sensitive_width * 0.5 
                                  << "  u: " <<  u
                                  << "  layer sensitive_offset " << sensitive_offset
-                                 << "  layer phi0 " << layerVXD.getPhi0( layer )
+                                 << "  layer phi0 " << layerVXD.getPhi0( hitLayer )
                                  << "  phi: " <<  hitvec.phi()
                                  << "  PhiInLocal: " << PhiInLocal
                                  << "  ladderPhi: " << ladderPhi
@@ -346,7 +349,7 @@ void VTXDigiProcessor::processEvent( LCEvent * evt ) {
             while( tries < 100 )
               {
                   
-                if(tries > 0) streamlog_out(DEBUG) << "retry smearing for " << layer << " " << ladderIndex << " : retries " << tries << std::endl;
+                if(tries > 0) streamlog_out(DEBUG) << "retry smearing for " << hitLayer << " " << ladderIndex << " : retries " << tries << std::endl;
                   
                 _pointResoRPhi = _pointResoRPhi_VTX;
                 _pointResoZ    = _pointResoZ_VTX;
@@ -511,4 +514,3 @@ double VTXDigiProcessor::correctPhiRange( double Phi ) const {
   return Phi ;
   
 } // function correctPhiRange
-

--- a/TrackDigi/VTXDigi/src/VTXDigitizer.cc
+++ b/TrackDigi/VTXDigi/src/VTXDigitizer.cc
@@ -564,7 +564,6 @@ void VTXDigitizer::FindLocalPosition(SimTrackerHit * hit,
   
   if (nLadders > 2) { // laddered structure
     //std::cout<<"laddered structure "<<std::endl;
-    // int iLadder=0;
     for (int ic=0; ic<nLadders; ++ic) {
       //      PhiLadder = - PI2 + double(ic)*dPhi + Phi0;
       PhiLadder = double(ic)*dPhi + Phi0;
@@ -572,7 +571,6 @@ void VTXDigitizer::FindLocalPosition(SimTrackerHit * hit,
       //cout<<"Phi "<<PhiLadder<<" "<<PhiInLocal<<" "<<PhiInLab<<" "<<_layerThickness[layer]<<" "<<Radius<<endl;
       if (RXY*cos(PhiInLocal)-Radius > -_layerThickness[layer] && 
           RXY*cos(PhiInLocal)-Radius < _layerThickness[layer]) {
-        // iLadder = ic;
         break;
       }
       //cout<<"phi ladder "<<PhiLadder<<endl;

--- a/TrackDigi/VTXDigi/src/VTXDigitizer.cc
+++ b/TrackDigi/VTXDigi/src/VTXDigitizer.cc
@@ -395,8 +395,8 @@ void VTXDigitizer::processEvent( LCEvent * evt ) {
           // LCRelationImpl * rel = new LCRelationImpl(recoHit,simTrkHit,float(1.0));
           // RelCol->addElement(rel);
           // Clean Up                
-          for (int i=0; i < int(simTrkHitVec.size()); ++i) {
-            SimTrackerHit * hit = simTrkHitVec[i];
+          for (int j=0; j < int(simTrkHitVec.size()); ++j) {
+            SimTrackerHit * hit = simTrkHitVec[j];
             delete hit;
           }     
         }          
@@ -564,7 +564,7 @@ void VTXDigitizer::FindLocalPosition(SimTrackerHit * hit,
   
   if (nLadders > 2) { // laddered structure
     //std::cout<<"laddered structure "<<std::endl;
-    int iLadder=0;
+    // int iLadder=0;
     for (int ic=0; ic<nLadders; ++ic) {
       //      PhiLadder = - PI2 + double(ic)*dPhi + Phi0;
       PhiLadder = double(ic)*dPhi + Phi0;
@@ -572,7 +572,7 @@ void VTXDigitizer::FindLocalPosition(SimTrackerHit * hit,
       //cout<<"Phi "<<PhiLadder<<" "<<PhiInLocal<<" "<<PhiInLab<<" "<<_layerThickness[layer]<<" "<<Radius<<endl;
       if (RXY*cos(PhiInLocal)-Radius > -_layerThickness[layer] && 
           RXY*cos(PhiInLocal)-Radius < _layerThickness[layer]) {
-        iLadder = ic;
+        // iLadder = ic;
         break;
       }
       //cout<<"phi ladder "<<PhiLadder<<endl;
@@ -810,14 +810,14 @@ void VTXDigitizer::ProduceHits( SimTrackerHitImplVec & vectorOfHits) {
             double xCurrent,yCurrent;
             TransformCellIDToXY(ix,iy,xCurrent,yCurrent);
             gsl_sf_result result;
-            int status = gsl_sf_erf_Q_e(float((xCurrent - 0.5*_pixelSizeX - xCentre)/sigmaX), &result);
+            gsl_sf_erf_Q_e(float((xCurrent - 0.5*_pixelSizeX - xCentre)/sigmaX), &result);
             float LowerBound = 1 - result.val;
-            status = gsl_sf_erf_Q_e(float((xCurrent + 0.5*_pixelSizeX - xCentre)/sigmaX), &result);
+            gsl_sf_erf_Q_e(float((xCurrent + 0.5*_pixelSizeX - xCentre)/sigmaX), &result);
             float UpperBound = 1 - result.val;
             float integralX = UpperBound - LowerBound;
-            status = gsl_sf_erf_Q_e(float((yCurrent - 0.5*_pixelSizeY - yCentre)/sigmaY), &result);
+            gsl_sf_erf_Q_e(float((yCurrent - 0.5*_pixelSizeY - yCentre)/sigmaY), &result);
             LowerBound = 1 - result.val;
-            status = gsl_sf_erf_Q_e(float((yCurrent + 0.5*_pixelSizeY - yCentre)/sigmaY), &result);
+            gsl_sf_erf_Q_e(float((yCurrent + 0.5*_pixelSizeY - yCentre)/sigmaY), &result);
             UpperBound = 1 - result.val;
             float integralY = UpperBound - LowerBound;
             float totCharge = float(spoint.charge)*integralX*integralY;

--- a/Tracking/KinkFinder/src/KinkFinder.cc
+++ b/Tracking/KinkFinder/src/KinkFinder.cc
@@ -1135,4 +1135,3 @@ float KinkFinder::kinkMass(HelixClass* parent, HelixClass* daughter, float daugh
   return mx;
 
 }
-

--- a/Tracking/V0Finder/src/V0Finder.cc
+++ b/Tracking/V0Finder/src/V0Finder.cc
@@ -466,10 +466,10 @@ float V0Finder::Rmin( Track* track ) {
     if(z<zmin)zmin=z;
     if(z>zmax)zmax=z;
   }
-  float tanLambda = track->getTanLambda();
+  // float tanLambda = track->getTanLambda();
   //  std::cout << " V0 Check : " << tanLambda << " z = " << zmin << " - " << zmax << std::endl; 
-  float zzz = zmin;
-  if(tanLambda<0)zzz=zmax;
+  // float zzz = zmin;
+  // if(tanLambda<0)zzz=zmax;
 
   float zstart = 0;
   if(fabs(zmin)<fabs(zmax))zstart = zmin;

--- a/Tracking/V0Finder/src/V0Finder.cc
+++ b/Tracking/V0Finder/src/V0Finder.cc
@@ -466,10 +466,7 @@ float V0Finder::Rmin( Track* track ) {
     if(z<zmin)zmin=z;
     if(z>zmax)zmax=z;
   }
-  // float tanLambda = track->getTanLambda();
   //  std::cout << " V0 Check : " << tanLambda << " z = " << zmin << " - " << zmax << std::endl; 
-  // float zzz = zmin;
-  // if(tanLambda<0)zzz=zmax;
 
   float zstart = 0;
   if(fabs(zmin)<fabs(zmax))zstart = zmin;


### PR DESCRIPTION
BEGINRELEASENOTES

- Fix all compiler warnings in MarlinReco, including
  - A lot of shadowed variables
  - A lot of unused parameters / variables
  - A few deprecations
  - A genuine use-after-free bug
  - A few others
- Make at least one CI workflow use `-Werror` to make it harder to (re-)introduce new warnings

ENDRELEASENOTES

As proposed by @tmadlener, this time is a good opportunity to also fix all warning within MarlinReco


Detailed breakdown of situation before (via `ninja 2>&1 | sed -nr 's/.+ \[-(.*)\].*/\1/p' | sort | uniq -c`):
```
      2 Wdangling-else
      6 Wdeprecated-declarations
      6 Weffc++
      1 Wint-in-bool-context
      1 Wmaybe-uninitialized
      2 Wreturn-type
     69 Wshadow
      1 Wsizeof-pointer-div
     32 Wunused-but-set-variable
      2 Wunused-function
     23 Wunused-parameter
      7 Wunused-variable
      1 Wuse-after-free
      2 Wvla
```