### PR TITLE
Fix warnings that are trivial to fix

### DIFF
--- a/Analysis/AddClusterProperties/src/AddClusterProperties.cc
+++ b/Analysis/AddClusterProperties/src/AddClusterProperties.cc
@@ -117,7 +117,7 @@ void AddClusterProperties::processEvent( LCEvent * evt ) {
 	  if ( subDetectorNames[kkk] == "bcal"  )   { bcal_index  = kkk ;  }
         }
     }
-    catch( lcio::DataNotAvailableException e )
+    catch( lcio::DataNotAvailableException& e )
     {
         streamlog_out(WARNING) <<  _clusterCollectionName   << " collection not available" << std::endl;
         clucol = NULL;
@@ -262,7 +262,7 @@ void AddClusterProperties::processEvent( LCEvent * evt ) {
     try{
       pfocol = evt->getCollection( _PFOName );
     }
-    catch( lcio::DataNotAvailableException e )
+    catch( lcio::DataNotAvailableException& e )
     {
         streamlog_out(WARNING) << _PFOName    << " collection not available" << std::endl;
         pfocol = NULL;
@@ -507,4 +507,3 @@ void AddClusterProperties::end(){
     // 	    << std::endl ;
 
 }
-

--- a/Analysis/CLICPfoSelector/include/CLICPfoSelectorAnalysis.h
+++ b/Analysis/CLICPfoSelector/include/CLICPfoSelectorAnalysis.h
@@ -43,6 +43,10 @@ using namespace std;
 
 class CLICPfoSelectorAnalysis : public Processor {
 public:
+
+  CLICPfoSelectorAnalysis(const CLICPfoSelectorAnalysis&) = delete;
+  CLICPfoSelectorAnalysis& operator=(const CLICPfoSelectorAnalysis&) = delete;
+
   virtual Processor* newProcessor() { return new CLICPfoSelectorAnalysis; }
 
   CLICPfoSelectorAnalysis();

--- a/Analysis/CLICPfoSelector/src/CLICPfoSelectorAnalysis.cc
+++ b/Analysis/CLICPfoSelector/src/CLICPfoSelectorAnalysis.cc
@@ -186,7 +186,7 @@ void CLICPfoSelectorAnalysis::processEvent(LCEvent* evt) {
   LCCollection* physicsParticleCollection = NULL;
   try {
     physicsParticleCollection = evt->getCollection(m_inputPhysicsParticleCollection);
-  } catch (lcio::DataNotAvailableException e) {
+  } catch (lcio::DataNotAvailableException& e) {
     streamlog_out(WARNING) << m_inputPhysicsParticleCollection << " collection not available" << std::endl;
     physicsParticleCollection = NULL;
   }
@@ -200,7 +200,7 @@ void CLICPfoSelectorAnalysis::processEvent(LCEvent* evt) {
   LCCollection* rmclcol = NULL;
   try {
     rmclcol = evt->getCollection(m_recoMCTruthLink);
-  } catch (lcio::DataNotAvailableException e) {
+  } catch (lcio::DataNotAvailableException& e) {
     streamlog_out(WARNING) << m_recoMCTruthLink << " collection not available" << std::endl;
     rmclcol = NULL;
   }
@@ -212,7 +212,7 @@ void CLICPfoSelectorAnalysis::processEvent(LCEvent* evt) {
   LCCollection* rtrkclcol = NULL;
   try {
     rtrkclcol = evt->getCollection(m_SiTracksMCTruthLink);
-  } catch (lcio::DataNotAvailableException e) {
+  } catch (lcio::DataNotAvailableException& e) {
     streamlog_out(WARNING) << m_SiTracksMCTruthLink << " collection not available" << std::endl;
     rtrkclcol = NULL;
   }
@@ -224,7 +224,7 @@ void CLICPfoSelectorAnalysis::processEvent(LCEvent* evt) {
   LCCollection* rclulcol = NULL;
   try {
     rclulcol = evt->getCollection(m_ClusterMCTruthLink);
-  } catch (lcio::DataNotAvailableException e) {
+  } catch (lcio::DataNotAvailableException& e) {
     streamlog_out(WARNING) << m_ClusterMCTruthLink << " collection not available" << std::endl;
     rclulcol = NULL;
   }

--- a/Analysis/EventShapes/include/ThrustReconstruction.h
+++ b/Analysis/EventShapes/include/ThrustReconstruction.h
@@ -31,6 +31,9 @@ class ThrustReconstruction : public Processor {
   
 public:
   
+  ThrustReconstruction(const ThrustReconstruction&) = delete;
+  ThrustReconstruction& operator=(const ThrustReconstruction&) = delete;
+
   virtual Processor* newProcessor() { return new ThrustReconstruction;}
   
   

--- a/Analysis/EventShapes/src/Sphere.cc
+++ b/Analysis/EventShapes/src/Sphere.cc
@@ -95,7 +95,7 @@ void Sphere::processEvent( LCEvent * evt ) {
   LCCollection* col ; 
   
   try{ col = evt -> getCollection( _colName ) ; }
-  catch(EVENT::DataNotAvailableException){
+  catch(EVENT::DataNotAvailableException&){
     streamlog_out(DEBUG)  << "Cannot find PFO Collection in event/run  " << evt->getEventNumber() <<" / "<< evt->getRunNumber() <<std::endl;
    streamlog_out(DEBUG) << "Skipping this event!" << std::endl;
    throw marlin::SkipEventException(this);
@@ -196,4 +196,3 @@ void Sphere::end(){
 // 	    << std::endl ;
 
 }
-

--- a/Analysis/GammaGammaHadronRemoval/src/TrackZVertexGrouping.cc
+++ b/Analysis/GammaGammaHadronRemoval/src/TrackZVertexGrouping.cc
@@ -144,7 +144,7 @@ void TrackZVertexGrouping::processEvent( LCEvent * evt ) {
   try{
     colTrk = evt->getCollection( _colNameTracks ) ;
   }
-  catch(lcio::Exception){
+  catch(lcio::Exception&){
     streamlog_out( DEBUG6 ) << " collection " << _colNameTracks
 			    << " not found in event - nothing to do ... " << std::endl ;
   }
@@ -325,4 +325,3 @@ void TrackZVertexGrouping::end(){
 
 
 //*******************************************************************************************************
-

--- a/Analysis/IsolatedLeptonTagging/include/IsoLepTrainingProcessor.h
+++ b/Analysis/IsolatedLeptonTagging/include/IsoLepTrainingProcessor.h
@@ -59,23 +59,20 @@ class IsoLepTrainingProcessor : public marlin::Processor {
 
   /** Input collection name.
    */
-  std::string _colMCP ;
-  std::string _colMCTL ;
-  std::string _colPFOs ;
-  std::string _colPVtx ;  
+  std::string _colMCP{} ;
+  std::string _colMCTL{} ;
+  std::string _colPFOs{} ;
+  std::string _colPVtx{} ;  
 
-  bool   _mcdebug;
+  bool   _mcdebug{};
 
-  bool _is_lep_tune;
-  bool _is_for_sig;
+  bool _is_lep_tune{};
+  bool _is_for_sig{};
 
-  int _nRun ;
-  int _nEvt ;
+  int _nRun{} ;
+  int _nEvt{} ;
 
-  int _iso_lep_type;
+  int _iso_lep_type{};
 } ;
 
 #endif
-
-
-

--- a/Analysis/IsolatedLeptonTagging/src/IsoLepTrainingProcessor.cc
+++ b/Analysis/IsolatedLeptonTagging/src/IsoLepTrainingProcessor.cc
@@ -344,7 +344,7 @@ void IsoLepTrainingProcessor::processEvent( LCEvent * evt ) {
     //    Int_t mcserial = getMCSerial(recPart,colMCTL,colMC);
     //    Int_t isOrigLep = mcserial==serialLepMC? 1:0;
     Int_t isOrigLep = 0;
-    for (Int_t j=0;j<serialLepMCv.size();j++) {
+    for (size_t j=0;j<serialLepMCv.size();j++) {
       if (mcserial == serialLepMCv[j]) {
 	isOrigLep = 1;
 	break;

--- a/Analysis/IsolatedLeptonTagging/src/IsoLepTrainingProcessor.cc
+++ b/Analysis/IsolatedLeptonTagging/src/IsoLepTrainingProcessor.cc
@@ -112,7 +112,7 @@ void IsoLepTrainingProcessor::init() {
   
 }
 
-void IsoLepTrainingProcessor::processRunHeader( LCRunHeader* run) { 
+void IsoLepTrainingProcessor::processRunHeader( LCRunHeader* ) { 
 
   _nRun++ ;
 } 
@@ -518,7 +518,7 @@ void IsoLepTrainingProcessor::processEvent( LCEvent * evt ) {
 
 
 
-void IsoLepTrainingProcessor::check( LCEvent * evt ) { 
+void IsoLepTrainingProcessor::check( LCEvent * ) { 
   // nothing to check here - could be used to fill checkplots in reconstruction processor
 }
 

--- a/Analysis/PIDTools/include/ComputeShowerShapesProcessor.hh
+++ b/Analysis/PIDTools/include/ComputeShowerShapesProcessor.hh
@@ -11,6 +11,10 @@ using namespace marlin ;
 
 class ComputeShowerShapesProcessor : public Processor{
 public:
+
+  ComputeShowerShapesProcessor(const ComputeShowerShapesProcessor&) = delete;
+  ComputeShowerShapesProcessor& operator=(const ComputeShowerShapesProcessor&) = delete;
+
   virtual Processor*  newProcessor() { return new ComputeShowerShapesProcessor ; }
   ComputeShowerShapesProcessor();
   virtual void init( LCEvent * evt ) ;

--- a/Analysis/PIDTools/include/LikelihoodPID.hh
+++ b/Analysis/PIDTools/include/LikelihoodPID.hh
@@ -11,6 +11,10 @@
 
 class LikelihoodPID{
 public:
+
+  LikelihoodPID(const LikelihoodPID&) = delete;
+  LikelihoodPID& operator=(const LikelihoodPID&) = delete;
+
   LikelihoodPID(){};
   LikelihoodPID(std::string fname, double *pars, std::vector<float> cost);
   LikelihoodPID(double *pars);

--- a/Analysis/PIDTools/include/LikelihoodPID.hh
+++ b/Analysis/PIDTools/include/LikelihoodPID.hh
@@ -48,7 +48,7 @@ private:
   int Class_electron(TLorentzVector pp, EVENT::Track* trk, EVENT::ClusterVec& cluvec);
   int Class_muon(TLorentzVector pp, EVENT::Track* trk, EVENT::ClusterVec& cluvec);
   int Class_hadron(TLorentzVector pp, EVENT::Track* trk, EVENT::ClusterVec& cluvec);
-  const  double getValue(int type, int valtype,  double value);
+  double getValue(int type, int valtype,  double value);
   double getPenalty(int ptype, int hypothesis,  double p);
   
   double par[5][5]{};

--- a/Analysis/PIDTools/include/LikelihoodPIDProcessor.hh
+++ b/Analysis/PIDTools/include/LikelihoodPIDProcessor.hh
@@ -18,6 +18,10 @@ class LowMomentumMuPiSeparationPID_BDTG;
 
 class LikelihoodPIDProcessor : public Processor{
 public:
+
+  LikelihoodPIDProcessor(const LikelihoodPIDProcessor&) = delete;
+  LikelihoodPIDProcessor& operator=(const LikelihoodPIDProcessor&) = delete;
+
   virtual Processor*  newProcessor() { return new LikelihoodPIDProcessor ; }
   LikelihoodPIDProcessor();
   virtual void init() ;

--- a/Analysis/PIDTools/include/LowMomentumMuPiSeparationPID_BDTG.hh
+++ b/Analysis/PIDTools/include/LowMomentumMuPiSeparationPID_BDTG.hh
@@ -12,6 +12,10 @@
 
 class LowMomentumMuPiSeparationPID_BDTG{
 public:
+
+  LowMomentumMuPiSeparationPID_BDTG(const LowMomentumMuPiSeparationPID_BDTG&) = delete;
+  LowMomentumMuPiSeparationPID_BDTG& operator=(const LowMomentumMuPiSeparationPID_BDTG&) = delete;
+
   LowMomentumMuPiSeparationPID_BDTG(std::vector< std::string > fname);
   
   ~LowMomentumMuPiSeparationPID_BDTG();

--- a/Analysis/PIDTools/include/PIDParticles.hh
+++ b/Analysis/PIDTools/include/PIDParticles.hh
@@ -30,6 +30,9 @@ namespace PIDParticles
 
 class PIDParticle_base {
 public:
+
+  PIDParticle_base& operator=(const PIDParticle_base&) = delete;
+
   PIDParticle_base (const char *name, int _pdg, double _mass, const double* BBpars) :
     pdg(_pdg), mass(_mass), _name(name)
   {

--- a/Analysis/PIDTools/include/PIDParticles.hh
+++ b/Analysis/PIDTools/include/PIDParticles.hh
@@ -138,7 +138,7 @@ public:
   float GetMVAout() const { return _mva; }
   float GetQ() const { return _q; }
   float GetSigAbove() const { return _sigAbove; }
-  const float GetMVAcut() const { return _mvaCut; }
+  float GetMVAcut() const { return _mvaCut; }
 
 
   void AddMVAVariable( const TString& name, Float_t* ptr)

--- a/Analysis/PIDTools/include/PIDVariables.hh
+++ b/Analysis/PIDTools/include/PIDVariables.hh
@@ -40,6 +40,10 @@ using EVENT::FloatVec;
 
 class PIDVariable_base {
 public:
+
+  PIDVariable_base(const PIDVariable_base&) = delete;
+  PIDVariable_base& operator=(const PIDVariable_base&) = delete;
+
   PIDVariable_base(const char*name, const char *description, const char *unit) :
     _value(0.), _name(name), _description(description), _unit(unit)
     {};
@@ -148,6 +152,8 @@ public:
 class PID_dEdxChi2: public PIDVariable_base
 {
 public:
+
+  PID_dEdxChi2& operator=(const PID_dEdxChi2&) = delete;
   PID_dEdxChi2(const PID_dEdxChi2&);
   PID_dEdxChi2(const PIDParticles::PIDParticle_base* hypothesis, const float dEdx_MIP=1.35e-7);
   ~PID_dEdxChi2();
@@ -162,6 +168,8 @@ public:
 class PID_dEdxLogChi2: public PIDVariable_base
 {
 public:
+
+  PID_dEdxLogChi2& operator=(const PID_dEdxLogChi2&) = delete;
   PID_dEdxLogChi2(const PID_dEdxLogChi2&);
   PID_dEdxLogChi2(const PIDParticles::PIDParticle_base* hypothesis, const float dEdx_MIP=1.35e-7);
   ~PID_dEdxLogChi2();

--- a/Analysis/PIDTools/src/LikelihoodPID.cc
+++ b/Analysis/PIDTools/src/LikelihoodPID.cc
@@ -1036,7 +1036,7 @@ int LikelihoodPID::Class_hadron(TLorentzVector pp, EVENT::Track* trk, EVENT::Clu
   return okflg;  
 }
 
-const double LikelihoodPID::getValue(int type, int valtype, double value){
+double LikelihoodPID::getValue(int type, int valtype, double value){
 
   /*int nbins=pdf[type][valtype]->GetNbinsX();
   double interval=pdf[type][valtype]->GetBinWidth(1);

--- a/Analysis/PIDTools/src/LikelihoodPIDProcessor.cc
+++ b/Analysis/PIDTools/src/LikelihoodPIDProcessor.cc
@@ -262,7 +262,7 @@ void LikelihoodPIDProcessor::init() {
 
   //CHECK that init settings are correct
   bool allnamecorrect=false;
-  for(int i=0; i<_methodstorun.size(); i++) {
+  for(size_t i=0; i<_methodstorun.size(); i++) {
     {
       if(  _methodstorun.at(i).compare("dEdxPID")==0 
 	   ||  _methodstorun.at(i).compare("LowMomMuID")==0 
@@ -289,7 +289,7 @@ void LikelihoodPIDProcessor::processEvent( LCEvent * evt ) {
   PIDHandler pidh(_pfoCol);   //BasicPID
 
   int algoID[10]; 
-  for(int i=0; i<_methodstorun.size(); i++) {
+  for(size_t i=0; i<_methodstorun.size(); i++) {
     if(_methodstorun.at(i).compare("dEdxPID")==0) algoID[i] = pidh.addAlgorithm(_methodstorun.at(i)+_methodstorun_version,_dEdxNames);
     else algoID[i] = pidh.addAlgorithm(_methodstorun.at(i)+_methodstorun_version, _particleNames);
   }
@@ -308,7 +308,7 @@ void LikelihoodPIDProcessor::processEvent( LCEvent * evt ) {
     
     Int_t parttype=-1;
 //////////////////////////////////////////////////////////////////////////////////
-    for(int ialgo=0; ialgo<_methodstorun.size(); ialgo++) {
+    for(size_t ialgo=0; ialgo<_methodstorun.size(); ialgo++) {
       if(_methodstorun.at(ialgo) == "LowMomMuID") {
 	//Low momentum Muon identification 
 	// (from 0.2 GeV until 2 GeV)   

--- a/Analysis/PIDTools/src/LowMomentumMuPiSeparationPID_BDTG.cc
+++ b/Analysis/PIDTools/src/LowMomentumMuPiSeparationPID_BDTG.cc
@@ -167,7 +167,7 @@ Int_t LowMomentumMuPiSeparationPID_BDTG::MuPiSeparation(TLorentzVector pp, EVENT
   float tscpy = ts->getReferencePoint()[1] ;
   float tscpz = ts->getReferencePoint()[2] ;
   
-  for(int iclu=0; iclu < cluvec.size(); iclu++){
+  for(size_t iclu=0; iclu < cluvec.size(); iclu++){
       
       float Eclu=0;
       if(cluvec[iclu]->getEnergy() > Eclu){
@@ -189,7 +189,7 @@ Int_t LowMomentumMuPiSeparationPID_BDTG::MuPiSeparation(TLorentzVector pp, EVENT
           }
       }
   }
-  for(int iclu=0; iclu < cluvec.size(); iclu++){
+  for(size_t iclu=0; iclu < cluvec.size(); iclu++){
       for( unsigned jhit=0; jhit < nch ; ++jhit ) {
           
           Rhits_clu=sqrt(pow(chpox[jhit]-clpox,2)+pow(chpoy[jhit]-clpoy,2));
@@ -335,6 +335,3 @@ bool LowMomentumMuPiSeparationPID_BDTG::isValid(){
 LowMomentumMuPiSeparationPID_BDTG::~LowMomentumMuPiSeparationPID_BDTG(){
     delete reader;
 }
-
-
-

--- a/Analysis/RecoMCTruthLink/include/MCTruthJetEnergy.h
+++ b/Analysis/RecoMCTruthLink/include/MCTruthJetEnergy.h
@@ -38,6 +38,9 @@ class MCTruthJetEnergy : public Processor {
   
  public:
   
+  MCTruthJetEnergy(const MCTruthJetEnergy&) = delete;
+  MCTruthJetEnergy& operator=(const MCTruthJetEnergy&) = delete;
+
   virtual Processor*  newProcessor() { return new MCTruthJetEnergy ; }
   
   
@@ -87,6 +90,3 @@ class MCTruthJetEnergy : public Processor {
 } ;
 
 #endif
-
-
-

--- a/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h
+++ b/Analysis/RecoMCTruthLink/include/RecoMCTruthLinker.h
@@ -110,6 +110,9 @@ class RecoMCTruthLinker : public marlin::Processor {
 
 public:
   
+  RecoMCTruthLinker(const RecoMCTruthLinker&) = delete;
+  RecoMCTruthLinker& operator=(const RecoMCTruthLinker&) = delete;
+
   virtual Processor*  newProcessor() { return new RecoMCTruthLinker ; }
   
   

--- a/Analysis/RecoMCTruthLink/src/MCTruthJetEnergy.cc
+++ b/Analysis/RecoMCTruthLink/src/MCTruthJetEnergy.cc
@@ -112,7 +112,7 @@ void MCTruthJetEnergy::processEvent( LCEvent * evt ) {
       jetcol = evt->getCollection( _jetcolNames[i] ) ;
     }
     
-    catch( lcio::DataNotAvailableException ){
+    catch( lcio::DataNotAvailableException& ){
       
       streamlog_out( WARNING ) << " collection " << _jetcolNames[i] << "  not found ! " << std::endl ;
       
@@ -232,7 +232,7 @@ void MCTruthJetEnergy::check( LCEvent * evt ) {
       jetcol = evt->getCollection( _jetcolNames[i] ) ;
     }
     
-    catch( lcio::DataNotAvailableException ){
+    catch( lcio::DataNotAvailableException& ){
       
       streamlog_out( WARNING ) << " collection " << _jetcolNames[i] << "  not found ! " << std::endl ;
       

--- a/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
+++ b/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
@@ -2073,7 +2073,7 @@ void RecoMCTruthLinker::check( LCEvent * evt ) {
   try{  
     mcpskCol = evt->getCollection( _mcParticlesSkimmedName ); 
   }
-  catch (DataNotAvailableException e){
+  catch (DataNotAvailableException& e){
     streamlog_out(DEBUG9) << "RecoMCTructh::Check(): MCParticleSkimmed collection \"" << _mcParticlesSkimmedName << "\" does not exist, skipping" << std::endl;
   }
   

--- a/Analysis/TauFinder/src/EvaluateTauFinder.cc
+++ b/Analysis/TauFinder/src/EvaluateTauFinder.cc
@@ -142,25 +142,25 @@ void EvaluateTauFinder::processEvent( LCEvent * evt )
   LCCollection *colTauRecLink;
   try {
     colMC = evt->getCollection( _colNameMC ) ;
-  } catch (Exception e) {
+} catch (Exception& e) {
     colMC = 0;
   }
   
   try {
     colTau = evt->getCollection( _incol ) ;
-  } catch (Exception e) {
+} catch (Exception& e) {
     colTau = 0;
   }
   
   try {
     colMCTruth = evt->getCollection( _colNameMCTruth ) ;
-  } catch (Exception e) {
+} catch (Exception& e) {
     colMCTruth = 0;
   }
  
   try {
     colTauRecLink = evt->getCollection( _colNameTauRecLink ) ;
-  } catch (Exception e) {
+} catch (Exception& e) {
     colTauRecLink = 0;
   }
   
@@ -582,5 +582,3 @@ void EvaluateTauFinder::end(){
   delete rootfile;
   // rootfile->Close();
 }
-
-

--- a/Analysis/TauFinder/src/PrepareRECParticles.cc
+++ b/Analysis/TauFinder/src/PrepareRECParticles.cc
@@ -129,13 +129,13 @@ void PrepareRECParticles::processEvent( LCEvent * evt )
   LCCollection *colMC, *colTrack;
   try {
     colMC = evt->getCollection( _colNameMC ) ;
-  } catch (Exception e) {
+} catch (Exception& e) {
     colMC = 0;
   }
   
   try {
     colTrack = evt->getCollection( _colNameTrack ) ;
-  } catch (Exception e) {
+} catch (Exception& e) {
     colTrack = 0;
   }
   
@@ -254,5 +254,3 @@ void PrepareRECParticles::end(){
   
 
 }
-
-

--- a/Analysis/TauFinder/src/TauFinder.cc
+++ b/Analysis/TauFinder/src/TauFinder.cc
@@ -157,7 +157,7 @@ void TauFinder::processEvent( LCEvent * evt )
 
   try {
     colRECO = evt->getCollection( _incol ) ;
-  } catch (Exception e) {
+} catch (Exception& e) {
     colRECO = 0;
   }
  
@@ -643,5 +643,3 @@ void TauFinder::end(){
  
 
 }
-
-

--- a/Analysis/TrueJet/src/TrueJet.cc
+++ b/Analysis/TrueJet/src/TrueJet.cc
@@ -206,11 +206,11 @@ void TrueJet::processEvent( LCEvent * event ) {
         fafp[kk]=0;
         nfsr[kk]=0 ;
       }
-      bool seen[4000];
+      bool seen[4001];
       for ( int kk=1 ; kk <= 4000 ; kk++ ) {
         jet[kk]=0;
         companion[kk] = 0;
-	seen[kk] = false;
+	    seen[kk] = false;
       }
 
         // the actual work happens in the following routines. They are each responible to 

--- a/Analysis/TrueJet/src/TrueJet.cc
+++ b/Analysis/TrueJet/src/TrueJet.cc
@@ -156,7 +156,7 @@ void TrueJet::processEvent( LCEvent * event ) {
     try{
         mcpcol = evt->getCollection( _MCParticleColllectionName );
     }
-    catch( lcio::DataNotAvailableException e )
+    catch( lcio::DataNotAvailableException& e )
     {
         streamlog_out(WARNING) <<  _MCParticleColllectionName  << " collection not available" << std::endl;
         mcpcol = NULL;
@@ -166,7 +166,7 @@ void TrueJet::processEvent( LCEvent * event ) {
     try{
         rmclcol = evt->getCollection( _recoMCTruthLink );
     }
-    catch( lcio::DataNotAvailableException e )
+    catch( lcio::DataNotAvailableException& e )
     {
         streamlog_out(MESSAGE4) << _recoMCTruthLink   << " collection not available" << std::endl;
         rmclcol = NULL;

--- a/Analysis/TruthVertexFinder/include/MCOperator.hh
+++ b/Analysis/TruthVertexFinder/include/MCOperator.hh
@@ -29,6 +29,8 @@ namespace TTbarAnalysis
 		//
 			MCOperator (EVENT::LCCollection * col, EVENT::LCCollection * rel);
 			virtual ~MCOperator () {};
+            MCOperator(const MCOperator&) = delete;
+            MCOperator& operator=(const MCOperator&) = delete;
 		//
 		//	Methods
 		//

--- a/Analysis/TruthVertexFinder/include/TruthVertexFinder.hh
+++ b/Analysis/TruthVertexFinder/include/TruthVertexFinder.hh
@@ -50,6 +50,9 @@ namespace TTbarAnalysis
 	  
 	 public:
 	  
+      TruthVertexFinder(const TruthVertexFinder&) = delete;
+      TruthVertexFinder& operator=(const TruthVertexFinder&) = delete;
+
 	  virtual Processor*  newProcessor() { return new TruthVertexFinder ; }
 	  
 	  
@@ -190,6 +193,3 @@ namespace TTbarAnalysis
 	} ;
 } /* TTbarAnalysis */
 #endif
-
-
-

--- a/Analysis/TruthVertexFinder/include/VertexMCOperator.hh
+++ b/Analysis/TruthVertexFinder/include/VertexMCOperator.hh
@@ -25,6 +25,8 @@ namespace TTbarAnalysis
 		//
 			VertexMCOperator (EVENT::LCCollection * rel);
 			virtual ~VertexMCOperator () {};
+            VertexMCOperator(const VertexMCOperator&) = delete;
+            VertexMCOperator& operator=(const VertexMCOperator&) = delete;
 		//
 		//	Methods
 		//

--- a/CaloDigi/LDCCaloDigi/include/G2CD.hh
+++ b/CaloDigi/LDCCaloDigi/include/G2CD.hh
@@ -21,6 +21,9 @@ class G2CD  : public marlin::Processor
 {
 	public:
 
+    G2CD(const G2CD&) = delete;
+    G2CD& operator=(const G2CD&) = delete;
+
 	Processor*  newProcessor() { return new G2CD ; }
 
 	G2CD();
@@ -71,5 +74,3 @@ class G2CD  : public marlin::Processor
 };
 
 #endif
-
-

--- a/CaloDigi/LDCCaloDigi/include/ILDCaloDigi.h
+++ b/CaloDigi/LDCCaloDigi/include/ILDCaloDigi.h
@@ -76,6 +76,9 @@ class ILDCaloDigi : public Processor {
   
  public:
   
+  ILDCaloDigi(const ILDCaloDigi&) = delete;
+  ILDCaloDigi& operator=(const ILDCaloDigi&) = delete;
+
   virtual Processor*  newProcessor() { return new ILDCaloDigi ; }
   
   
@@ -301,6 +304,3 @@ class ILDCaloDigi : public Processor {
 } ;
 
 #endif
-
-
-

--- a/CaloDigi/LDCCaloDigi/include/LDCCaloDigi.h
+++ b/CaloDigi/LDCCaloDigi/include/LDCCaloDigi.h
@@ -69,6 +69,9 @@ class LDCCaloDigi : public Processor {
   
  public:
   
+  LDCCaloDigi(const LDCCaloDigi&) = delete;
+  LDCCaloDigi& operator=(const LDCCaloDigi&) = delete;
+
   virtual Processor*  newProcessor() { return new LDCCaloDigi ; }
   
   
@@ -129,6 +132,3 @@ class LDCCaloDigi : public Processor {
 } ;
 
 #endif
-
-
-

--- a/CaloDigi/LDCCaloDigi/include/MokkaCaloDigi.h
+++ b/CaloDigi/LDCCaloDigi/include/MokkaCaloDigi.h
@@ -73,6 +73,9 @@ class MokkaCaloDigi : public Processor {
   
  public:
   
+  MokkaCaloDigi(const MokkaCaloDigi&) = delete;
+  MokkaCaloDigi& operator=(const MokkaCaloDigi&) = delete;
+
   virtual Processor*  newProcessor() { return new MokkaCaloDigi ; }
   
   
@@ -158,6 +161,3 @@ class MokkaCaloDigi : public Processor {
 } ;
 
 #endif
-
-
-

--- a/CaloDigi/LDCCaloDigi/src/G2CD.cc
+++ b/CaloDigi/LDCCaloDigi/src/G2CD.cc
@@ -427,7 +427,7 @@ void G2CD::processEvent( LCEvent * evtP )
 
 					evtP->addCollection(ecalcol,_outputEcalCollections[k0].c_str());
 
-				}catch(lcio::DataNotAvailableException zero) { }
+				}catch(lcio::DataNotAvailableException& zero) { }
 			}
 
 
@@ -618,12 +618,12 @@ void G2CD::processEvent( LCEvent * evtP )
 					evtP->addCollection(hcalcol,_outputHcalCollections[i].c_str());
 					IDtoDigiHit.clear();
 				}
-				catch (lcio::DataNotAvailableException zero) { }
+				catch (lcio::DataNotAvailableException& zero) { }
 			}
 
 			evtP->addCollection(relcol, "CaloToSimuCaloLink");
 		}
-		catch (lcio::DataNotAvailableException zero) { }
+		catch (lcio::DataNotAvailableException& zero) { }
 	}
 }
 

--- a/CaloDigi/LDCCaloDigi/src/ILDCaloDigi.cc
+++ b/CaloDigi/LDCCaloDigi/src/ILDCaloDigi.cc
@@ -627,7 +627,7 @@ void ILDCaloDigi::init() {
     try {                                                             // first try to get from ECAL barrel section of gear file (it's here for "latest" Mokka versions)
       _strip_virt_cells=pEcalBarrel.getIntVal("Ecal_Sc_number_of_virtual_cells");
       streamlog_out (MESSAGE) << "taking number of virtual cells from calo section of gear file: " << _strip_virt_cells << endl;
-    } catch(gear::UnknownParameterException &e) {
+    } catch(gear::UnknownParameterException &e1) {
       try {                                                           // otherwise look in the mokka parameters section
         std::string nVirtualMokkaS = pMokka.getStringVal("Ecal_Sc_number_of_virtual_cells");
 
@@ -640,7 +640,7 @@ void ILDCaloDigi::init() {
         }
 
         streamlog_out (MESSAGE) << "taking number of virtual cells from Mokka section of gear file: " << nVirtualMokkaS << " " << _strip_virt_cells << endl;
-      } catch(gear::UnknownParameterException &e) {                  // if still not found, use default from processor parameter
+      } catch(gear::UnknownParameterException &e2) {                  // if still not found, use default from processor parameter
         _strip_virt_cells = _ecalStrip_default_nVirt;
         streamlog_out (WARNING) << "taking number of virtual cells from steering file (not found in gear file): " << _strip_virt_cells << endl;
       }
@@ -650,11 +650,11 @@ void ILDCaloDigi::init() {
     try {
       _ecalLayout = pEcalBarrel.getStringVal("Ecal_Barrel_Sc_Si_mix");
       streamlog_out (MESSAGE) << "taking layer layout from calo sections of gear file: " << _ecalLayout << endl;
-    } catch(gear::UnknownParameterException &e) {
+    } catch(gear::UnknownParameterException &e1) {
       try {
         _ecalLayout = pMokka.getStringVal("Ecal_Sc_Si_mix");
         streamlog_out (MESSAGE) << "taking layer layout from mokka section of gear file: " << _ecalLayout << endl;
-      } catch(gear::UnknownParameterException &e) {
+      } catch(gear::UnknownParameterException &e2) {
         _ecalLayout = _ecal_deafult_layer_config;
         streamlog_out (WARNING) << "taking layer layout from steering file (not found in gear file): " << _ecalLayout << endl;
       }

--- a/Clustering/PhotonFinderKit/include/KITutil.h
+++ b/Clustering/PhotonFinderKit/include/KITutil.h
@@ -36,6 +36,8 @@ class Superhit2
 {
  public:
 
+  Superhit2(const Superhit2&) = delete;
+  Superhit2& operator=(const Superhit2&) = delete;
   /**
    *  Constructor , needs absolute MIP energy (calibrated ) , and pointer to 
    *  calorimeter hit
@@ -359,6 +361,3 @@ inline double Dot2(double* X1,double* X2);
 void ClusterInCluster2(Tmpcl2* cl, vector<Tmpcl2*>& clv,vector<Tmpcl2*>& clout);
 
 #endif
-
-
-

--- a/Clustering/hybridEcalSplitter/include/hybridRecoProcessor.h
+++ b/Clustering/hybridEcalSplitter/include/hybridRecoProcessor.h
@@ -41,6 +41,9 @@ class hybridRecoProcessor : public Processor {
   
  public:
   
+  hybridRecoProcessor(const hybridRecoProcessor&) = delete;
+  hybridRecoProcessor& operator=(const hybridRecoProcessor&) = delete;
+
   virtual Processor*  newProcessor() { return new hybridRecoProcessor ; }
   
   hybridRecoProcessor() ;
@@ -124,6 +127,3 @@ class hybridRecoProcessor : public Processor {
 
 
 #endif
-
-
-

--- a/Clustering/hybridEcalSplitter/src/hybridRecoProcessor.cc
+++ b/Clustering/hybridEcalSplitter/src/hybridRecoProcessor.cc
@@ -165,7 +165,7 @@ void hybridRecoProcessor::setupGeometry() {
     // first try to get from ECAL barrel section of gear file (it's here for "latest" Mokka versions)
     nMokkaVirtualCells = pEcalBarrel.getIntVal("Ecal_Sc_number_of_virtual_cells");
     streamlog_out (MESSAGE) << "taking number of Mokka virtual cells from calo section of gear file: " << nMokkaVirtualCells << endl;
-  } catch(gear::UnknownParameterException &e) {
+  } catch(gear::UnknownParameterException &e1) {
     try {
       // otherwise look in the mokka parameters section
       std::string nVirtualMokkaS = pMokka.getStringVal("Ecal_Sc_number_of_virtual_cells");
@@ -175,7 +175,7 @@ void hybridRecoProcessor::setupGeometry() {
 	assert(0);
       }
       streamlog_out (MESSAGE) << "taking number of Mokka virtual cells from Mokka section of gear file: " << nVirtualMokkaS << " " << nMokkaVirtualCells << endl;
-    } catch(gear::UnknownParameterException &e) {
+    } catch(gear::UnknownParameterException &e2) {
       // if still not found, use default from processor parameter
       nMokkaVirtualCells = _ecalStrip_default_nVirt;
       streamlog_out (WARNING) << "taking number of Mokka virtual cells from steering file (not found in gear file): " << nMokkaVirtualCells << endl;

--- a/PFOID/include/CreatePDFs.h
+++ b/PFOID/include/CreatePDFs.h
@@ -27,6 +27,8 @@ class PDF;
 class CreatePDFs : public Processor {
 
  public:
+  CreatePDFs(const CreatePDFs&) = delete;
+  CreatePDFs& operator=(const CreatePDFs&) = delete;
 
   virtual Processor* newProcessor() { return new CreatePDFs ; }
 
@@ -84,5 +86,3 @@ class CreatePDFs : public Processor {
 };
 
 #endif
-
-

--- a/PFOID/include/Histogram.h
+++ b/PFOID/include/Histogram.h
@@ -21,6 +21,8 @@ private:
   double vol{};               // volume of one bin  // vol*norm = correct norm
 
 public:
+  Histogram(const Histogram&) = delete;
+  Histogram& operator=(const Histogram&) = delete;
   Histogram(std::string HistName, int Dimension);          // creates arrays
   Histogram(std::string HistName, int Dimension, std::string *VarName, double *StartVal, double *BinWidth, int *NoOfBins);          // creates arrays
   ~Histogram();                                            // deletes arrays

--- a/PFOID/include/PDF.h
+++ b/PFOID/include/PDF.h
@@ -18,6 +18,8 @@ private:
 public:
   VObject *VO{};
   
+  PDF(const PDF&) = delete;
+  PDF& operator=(const PDF&) = delete;
   // constructor: creates arrays
   PDF(std::string PDFname, int NoOfCats, std::string* CatNames, int NoOfHists, int NoOfVar, std::string *VarNames);
   PDF(std::string Filename);                // overloaded constructor: creates arrays, fills from file

--- a/PFOID/include/PFOID.h
+++ b/PFOID/include/PFOID.h
@@ -90,6 +90,8 @@ class PDFs;
 class PFOID : public Processor {
 
  public:
+  PFOID(const PFOID&) = delete;
+  PFOID& operator=(const PFOID&) = delete;
 
   virtual Processor* newProcessor() { return new PFOID ; }
 
@@ -151,5 +153,3 @@ class PFOID : public Processor {
 };
 
 #endif
-
-

--- a/PFOID/include/VObject.h
+++ b/PFOID/include/VObject.h
@@ -10,6 +10,8 @@ private:
   double *varValues{};          // array of values of variables
 
 public:
+  VObject(const VObject&) = delete;
+  VObject& operator=(const VObject&) = delete;
   VObject(int NoOfVars) ;      // constructor : creates arrays, takes number of variables
   ~VObject() ;                 // destructor  : deletes arrays
 

--- a/TimeOfFlight/src/TOFPlots.cc
+++ b/TimeOfFlight/src/TOFPlots.cc
@@ -289,8 +289,8 @@ void TOFPlots::processEvent( LCEvent * evt ) {
   LCCollection* colMCP=0 ;
   LCCollection* colPFO=0 ;
     
-  try{ colMCP = evt->getCollection( _colNameMCP ) ; } catch(lcio::Exception){}
-  try{ colPFO = evt->getCollection( _colNamePFO ) ; } catch(lcio::Exception){}
+  try{ colMCP = evt->getCollection( _colNameMCP ) ; } catch(lcio::Exception&){}
+  try{ colPFO = evt->getCollection( _colNamePFO ) ; } catch(lcio::Exception&){}
 
 
   if( colMCP != NULL ){

--- a/TrackDigi/FPCCDDigi/include/FPCCDClustering.h
+++ b/TrackDigi/FPCCDDigi/include/FPCCDClustering.h
@@ -68,6 +68,8 @@ typedef std::vector<FPCCDCluster_t*> FPCCDClusterVec_t;
 class FPCCDClustering : public marlin::Processor, public marlin::EventModifier {
   
  public:
+  FPCCDClustering(const FPCCDClustering&) = delete;
+  FPCCDClustering& operator=(const FPCCDClustering&) = delete;
   
   virtual Processor*  newProcessor() { return new FPCCDClustering ; }
   

--- a/TrackDigi/FPCCDDigi/include/FPCCDDigitizer.h
+++ b/TrackDigi/FPCCDDigi/include/FPCCDDigitizer.h
@@ -73,7 +73,9 @@ typedef struct {
 class FPCCDDigitizer : public marlin::Processor, public marlin::EventModifier {
 
  public:
-  
+  FPCCDDigitizer(const FPCCDDigitizer&) = delete;
+  FPCCDDigitizer& operator=(const FPCCDDigitizer&) = delete;
+
   virtual Processor*  newProcessor() { return new FPCCDDigitizer ; }
   
   

--- a/TrackDigi/FPCCDDigi/include/anaPix.h
+++ b/TrackDigi/FPCCDDigi/include/anaPix.h
@@ -29,6 +29,8 @@ class FPCCDData;
 class anaPix : public marlin::Processor {
   
  public:
+  anaPix(const anaPix&) = delete;
+  anaPix& operator=(const anaPix&) = delete;
   
   virtual Processor*  newProcessor() { return new anaPix ; }
   

--- a/TrackDigi/TPCDigi/include/TPCDigiProcessor.h
+++ b/TrackDigi/TPCDigi/include/TPCDigiProcessor.h
@@ -118,6 +118,9 @@ class TPCDigiProcessor : public Processor {
   
 public:
   
+  TPCDigiProcessor(const TPCDigiProcessor&) = delete;
+  TPCDigiProcessor& operator=(const TPCDigiProcessor&) = delete;
+
   virtual Processor*  newProcessor() { return new TPCDigiProcessor ; }
   
   
@@ -274,6 +277,3 @@ protected:
 
 
 #endif
-
-
-

--- a/TrackDigi/TPCDigi/src/TPCDigiProcessor.cc
+++ b/TrackDigi/TPCDigi/src/TPCDigiProcessor.cc
@@ -766,15 +766,15 @@ void TPCDigiProcessor::processEvent( LCEvent * evt )
     }
   }
   
-  // now process the LowPt collection
-  LCCollection* STHcolLowPt = 0 ;
-  try{
-    STHcolLowPt = evt->getCollection( _lowPtHitscolName ) ;
-  }
-  catch(DataNotAvailableException &e){
-  }
+    // now process the LowPt collection
+    LCCollection* STHcolLowPt = 0 ;
+    try{
+      STHcolLowPt = evt->getCollection( _lowPtHitscolName ) ;
+    }
+    catch(DataNotAvailableException &e){
+    }
   
-  if(STHcolLowPt!=NULL){
+    if(STHcolLowPt!=NULL){
     
     int n_sim_hitsLowPt = STHcolLowPt->getNumberOfElements()  ;
     

--- a/TrackDigi/VTXDigi/include/CCDDigitizer.h
+++ b/TrackDigi/VTXDigi/include/CCDDigitizer.h
@@ -83,6 +83,9 @@ typedef std::vector<SimTrackerHitImpl*> SimTrackerHitImplVec;
 class CCDDigitizer : public Processor {
   
  public:
+
+  CCDDigitizer(const CCDDigitizer&) = delete;
+  CCDDigitizer& operator=(const CCDDigitizer&) = delete;
   
   virtual Processor*  newProcessor() { return new CCDDigitizer ; }
   
@@ -274,4 +277,3 @@ class CCDDigitizer : public Processor {
 
 
 #endif
-

--- a/TrackDigi/VTXDigi/include/VTXBgClusters.h
+++ b/TrackDigi/VTXDigi/include/VTXBgClusters.h
@@ -44,6 +44,9 @@ class VXDGeometry ;
 class VTXBgClusters : public Processor {
   
  public:
+
+  VTXBgClusters(const VTXBgClusters&) = delete;
+  VTXBgClusters& operator=(const VTXBgClusters&) = delete;
   
   virtual Processor*  newProcessor() { return new VTXBgClusters ; }
   
@@ -106,6 +109,3 @@ class VTXBgClusters : public Processor {
 } ;
 
 #endif
-
-
-

--- a/TrackDigi/VTXDigi/include/VTXDigiProcessor.h
+++ b/TrackDigi/VTXDigi/include/VTXDigiProcessor.h
@@ -67,7 +67,9 @@ using namespace marlin ;
 class VTXDigiProcessor : public Processor {
   
  public:
-  
+  VTXDigiProcessor(const VTXDigiProcessor&) = delete;
+  VTXDigiProcessor& operator=(const VTXDigiProcessor&) = delete;
+
   virtual Processor*  newProcessor() { return new VTXDigiProcessor ; }
   
   
@@ -127,6 +129,3 @@ class VTXDigiProcessor : public Processor {
 } ;
 
 #endif
-
-
-

--- a/TrackDigi/VTXDigi/include/VTXDigitizer.h
+++ b/TrackDigi/VTXDigi/include/VTXDigitizer.h
@@ -123,7 +123,9 @@ typedef std::vector<SimTrackerHitImpl*> SimTrackerHitImplVec;
 class VTXDigitizer : public Processor {
   
  public:
-  
+  VTXDigitizer(const VTXDigitizer&) = delete;
+  VTXDigitizer& operator=(const VTXDigitizer&) = delete;
+
   virtual Processor*  newProcessor() { return new VTXDigitizer ; }
   
   
@@ -297,6 +299,3 @@ class VTXDigitizer : public Processor {
 } ;
 
 #endif
-
-
-

--- a/TrackDigi/VTXDigi/include/VTXNoiseClusters.h
+++ b/TrackDigi/VTXDigi/include/VTXNoiseClusters.h
@@ -48,6 +48,8 @@ class VXDGeometry ;
 class VTXNoiseClusters : public  Processor, public EventModifier{
   
  public:
+  VTXNoiseClusters(const VTXNoiseClusters&) = delete;
+  VTXNoiseClusters& operator=(const VTXNoiseClusters&) = delete;
   
   virtual Processor*  newProcessor() { return new VTXNoiseClusters ; }
   
@@ -107,6 +109,3 @@ class VTXNoiseClusters : public  Processor, public EventModifier{
 
 #endif
 //#endif // USE_ROOT
-
-
-

--- a/TrackDigi/VTXDigi/include/VTXNoiseHits.h
+++ b/TrackDigi/VTXDigi/include/VTXNoiseHits.h
@@ -37,7 +37,9 @@ using namespace marlin ;
 class VTXNoiseHits : public Processor {
   
  public:
-  
+  VTXNoiseHits(const VTXNoiseHits&) = delete;
+  VTXNoiseHits& operator=(const VTXNoiseHits&) = delete; 
+ 
   virtual Processor*  newProcessor() { return new VTXNoiseHits ; }
   
   
@@ -81,6 +83,3 @@ class VTXNoiseHits : public Processor {
 } ;
 
 #endif
-
-
-

--- a/TrackDigi/VTXDigi/include/VXDGeometry.h
+++ b/TrackDigi/VTXDigi/include/VXDGeometry.h
@@ -49,7 +49,10 @@ typedef std::vector< VXDLayer >  VXDLayers ;
 class VXDGeometry  {
   
 public:
-  
+
+  VXDGeometry(const VXDGeometry&) = delete;
+  VXDGeometry& operator=(const VXDGeometry&) = delete;  
+
   VXDGeometry(gear::GearMgr* gearMgr) ;
 
   
@@ -93,6 +96,3 @@ protected:
 } ;
 
 #endif
-
-
-


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix all warnings that are trivial to fix (i.e. where the fix is obvious without having to think about things). .
  - Make all Processors that have pointer members have deleted copy c'tors and assignment operators.
- Fix a potential out ouf bounds access in `TrueJet`.

**Thanks to Bohdan Dudar** (@dudarboh) 

ENDRELEASENOTES

Split the "trival" fixes from #99 for easier reviewing

Status (via `make 2>&1 | sed -nr 's/.+ \[-(.*)\].*/\1/p' | sort | uniq -c`) before (against v02-02-02 release):
```console
     38 Wcatch-value=
      2 Wdangling-else
     21 Wdeprecated-declarations
    186 Weffc++
      6 Wignored-qualifiers
      1 Wint-in-bool-context
     64 Wshadow
      3 Wsign-compare
      1 Wsizeof-pointer-div
     33 Wunused-but-set-variable
      2 Wunused-function
     26 Wunused-parameter
      3 Wunused-variable
      2 Wvla
```

Status now:
```console
      2 Wdangling-else
     21 Wdeprecated-declarations
      6 Weffc++
      1 Wint-in-bool-context
     55 Wshadow
      1 Wsizeof-pointer-div
     34 Wunused-but-set-variable
      2 Wunused-function
     23 Wunused-parameter
      6 Wunused-variable
      2 Wvla
```