### PR TITLE
Fix seg fault when fit fails and improve subTrack direction check based on z

### DIFF
--- a/TimeOfFlight/src/TOFEstimators.cc
+++ b/TimeOfFlight/src/TOFEstimators.cc
@@ -98,7 +98,7 @@ void TOFEstimators::init(){
 void TOFEstimators::processEvent(EVENT::LCEvent * evt){
     RandGauss::setTheSeed( marlin::Global::EVENTSEEDER->getSeed(this) );
     ++_nEvent;
-    streamlog_out(MESSAGE)<<"************Event************ "<<_nEvent<<std::endl;
+    streamlog_out(DEBUG9)<<std::endl<<"==========Event========== "<<_nEvent<<std::endl;
     auto startTime = std::chrono::steady_clock::now();
 
     LCCollection* pfos = evt->getCollection(_pfoCollectionName);
@@ -111,6 +111,7 @@ void TOFEstimators::processEvent(EVENT::LCEvent * evt){
 
 
     for (int i=0; i<pfos->getNumberOfElements(); ++i){
+        streamlog_out(DEBUG9)<<std::endl<<"Starting to analyze "<<i+1<<" PFO"<<std::endl;
         ReconstructedParticle* pfo = static_cast <ReconstructedParticle*> ( pfos->getElementAt(i) );
 
         int nClusters = pfo->getClusters().size();
@@ -194,13 +195,14 @@ void TOFEstimators::processEvent(EVENT::LCEvent * evt){
         }
         vector<float> results{float(harmonicMom), float(trackLength), float(timeOfFlight)};
         pidHandler.setParticleID(pfo , 0, 0, 0., algoID, results);
-        streamlog_out(DEBUG6)<<"*****PFO***** "<< i+1<<std::endl;
-        streamlog_out(DEBUG6)<<"momentum: "<< float(harmonicMom)<<" Gev"<<std::endl;
-        streamlog_out(DEBUG6)<<"track length: "<< float(trackLength)<<" mm"<<std::endl;
-        streamlog_out(DEBUG6)<<"time-of-flight: "<< float(timeOfFlight)<<" ns"<<std::endl;
+        streamlog_out(DEBUG9)<<"Final results for the "<<i+1<<" PFO"<<std::endl;
+        streamlog_out(DEBUG9)<<"momentum: "<< float(harmonicMom)<<" Gev"<<std::endl;
+        streamlog_out(DEBUG9)<<"track length: "<< float(trackLength)<<" mm"<<std::endl;
+        streamlog_out(DEBUG9)<<"time-of-flight: "<< float(timeOfFlight)<<" ns"<<std::endl;
+        streamlog_out(DEBUG9)<<std::endl<<std::endl;
     }
 
     auto endTime = std::chrono::steady_clock::now();
     std::chrono::duration<double> duration = endTime - startTime;
-    streamlog_out(DEBUG7)<<"Time spent (sec): "<<duration.count()<<std::endl;
+    streamlog_out(DEBUG9)<<"Time spent (sec): "<<duration.count()<<std::endl;
 }


### PR DESCRIPTION
BEGINRELEASENOTES

- Try to fit subtrack forward if backward fit fails
- Fix seg. fault if the very first sub track fit fails in both directions
- Change behaviour of checking track direction. Now it is more robust and relies on z position of first and last hits.

ENDRELEASENOTES

This is the fix for #102 with some improved behaviour on how do we check what is the direction of subTrack.

Previous behaviour:
- check position of the last hit from previous iteration `prevHit`
- check **linear** distance between `prevHit` and two edge hits of current iteration.
- choose closest one to be continuation of the prev. subtrack.

Playing with event display has shown it doesn't always work with curly tracks. 
As it may curl in and out of the inner TPC edge so some hits will disappear and the last hit which goes further along the track not necessarily  will be linearly further away from the prev. hit.

Thus i decided to look at the z direction of the track. If track goes along the z, I should know all sub track directions immediately based on their last and first hit z position.
For very perpendicular tracks, if `|zFirstHit - zLastHit| < 5*zTPCResolution` i provide check by the radius, as for the very perpendicular tracks checking by radius should be preferred, although i couldn't find so perfectly perpendicular tracks that z check fails.
