### PR TITLE
hot fix seg. fault when there is not enough hits to calculate the track length

### DIFF
--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -85,6 +85,14 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
         double trackLengthToEcal = 0.;
         double harmonicMomToEcal = 0.;
         int nTrackStates = trackStates.size();
+        streamlog_out(DEBUG9)<<"PFO has "<<nTrackStates<<" track states to calculate the length"<<std::endl;
+        if (nTrackStates <= 1){
+            streamlog_out(DEBUG9)<<" Not enough track states to calculate the track length. Writing zeros."<<std::endl;
+            vector<float> results{0., 0., 0., 0.};
+            pidHandler.setParticleID(pfo , 0, 0, 0., algoID, results);
+            continue;
+        }
+
         //exclude last track state at the ECal
         for( int j=1; j < nTrackStates-1; ++j ){
             //we check which track length formula to use

--- a/Tracking/TrackLength/src/TrackLengthUtils.cc
+++ b/Tracking/TrackLength/src/TrackLengthUtils.cc
@@ -126,6 +126,7 @@ std::vector<IMPL::TrackStateImpl> TrackLengthUtils::getTrackStatesPerHit(std::ve
     for(int i=0; i<nTracks; ++i){
         Track* track = tracks[i];
         vector <TrackerHit*> hits = track->getTrackerHits();
+        streamlog_out(DEBUG8)<<"Subtrack "<<i+1<<" has "<<hits.size()<<" hits."<<std::endl;
         std::sort(hits.begin(), hits.end(), sortByRho);
 
         // setup initial dummy covariance matrix

--- a/Tracking/TrackLength/src/TrackLengthUtils.cc
+++ b/Tracking/TrackLength/src/TrackLengthUtils.cc
@@ -122,6 +122,7 @@ std::vector<EVENT::Track*> TrackLengthUtils::getSubTracks(EVENT::Track* track){
 std::vector<IMPL::TrackStateImpl> TrackLengthUtils::getTrackStatesPerHit(std::vector<EVENT::Track*> tracks, MarlinTrk::IMarlinTrkSystem* trkSystem, double bField){
     vector<TrackStateImpl> trackStatesPerHit;
     int nTracks = tracks.size();
+    streamlog_out(DEBUG8)<<"PFO has "<<nTracks<<" subTracks."<<std::endl;
     for(int i=0; i<nTracks; ++i){
         Track* track = tracks[i];
         vector <TrackerHit*> hits = track->getTrackerHits();


### PR DESCRIPTION

BEGINRELEASENOTES

- Fix a seg. fault, in rare cases, when the track fit fails in both directions due to the lack of hits.

ENDRELEASENOTES

Found out that around 2.2% of my jobs seg. faulted because of that. Few cases, which i encountered, had tracks with 3-6 hits in total.
I am not sure, how the track successfully created in the first place, as I have tried to keep fit procedure as similar to the production code as possible.