### PR TITLE
Remove no longer available CI workflow based on gcc8

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'iLCSoft/MarlinReco'
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         coverity-cmake-command: 'cmake -C $ILCSOFT/ILCSoft.cmake ..'
         coverity-project: 'iLCSoft%2FMarlinReco'

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,31 @@
+name: keyh4ep
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
+      with:
+        container: centos7
+        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
+        run: |
+          mkdir build
+          cd build
+          echo "::group::Run CMake"
+          cmake -GNinja \
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            ..
+          echo "::endgroup::" && echo "::group::Build"
+          ninja -k0
+          echo "::endgroup::" && echo "::group::Run Tests"
+          ctest --output-on-failure
+          echo "::endgroup::" && echo "::group::Install"
+          ninja install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,14 +9,11 @@ jobs:
       matrix:
         COMPILER: [gcc10, clang11]
         LCG: [100]
-        include:
-          - COMPILER: gcc8
-            LCG: 99python2
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/${{ matrix.LCG }}/nightly/x86_64-centos7-${{ matrix.COMPILER }}-opt"
         setup-script: "init_ilcsoft.sh"


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove no longer available CI workflow based on gcc8 since the underlying nightly builds are no longer available
- Update github actions to latest available versions

ENDRELEASENOTES