### PR TITLE
Update of the Track length calculator

### DIFF
--- a/Tracking/TrackLength/include/TrackLengthUtils.h
+++ b/Tracking/TrackLength/include/TrackLengthUtils.h
@@ -43,35 +43,15 @@ namespace TrackLengthUtils{
     /** Get all subtracks of the Track.
     Returns a vector of the subTracks of the main track that is passed as an argument.
 
-    The main purpose of this function is to capture all hits of the track.
-    This requires iteration over the subTracks as the main Track stores hits only
-    of the first half turn due to the our fit procedure.
-
-    The first subTrack in the returned vector is always main Track itself, which
-    containes VXD, SIT and TPC tracker hits for the first half turn.
-
-    Then additional subTracks are added which contain hits for additional track revolutions if such exist.
-
-    If nTPCHits \f$ \pm  1\f$ = nHits of SubTrack0 then assume subTrack0 stores TPC hits.
-    This would mean that VXD and SIT subTrack is not stored!
-    So we need skip *only first* subtrack: initial subTrack0 with TPC hits which we have anyhow added with the main Track
-    Else if nTPCHits \f$ \pm  1\f$ = nHits of SubTrack1 assume subTrack1 stores TPC hits
-    This would mean that subTrack0 stores VXD and SIT hits.
-    So we need to *skip both* subtracks VXD+SIT and 1st TPC half-turn subTracks which we have anyhow added with the main Track
-
-    Note: We consider deviations for \f$\pm 1\f$ hit may happen because of the
-    SET and only God knows what other reasons...
-
-    Note: This function is not guarantied to properly work 100% of times,
-    but I didn't find a better way to collect subTracks.
+    The main purpose of this function is to capture all hits of the track, not only the first curl which is stored with the main track.
     */
     std::vector<EVENT::Track*> getSubTracks(EVENT::Track* track);
 
     /** Get list of track states.
-    Returns a vector of track states at the IP, track state for every tracker hit
-    inside all provided subTracks as tracks argument and the track state at the ECal surface if extrapolateToEcal argument is set to true.
+    Returns a vector of track states at the IP, track state for every tracker hit of the pfo
+    and the track state at the ECal surface.
     */
-    std::vector<IMPL::TrackStateImpl> getTrackStatesPerHit(std::vector<EVENT::Track*> tracks, MarlinTrk::IMarlinTrkSystem* trkSystem, double bField);
+    std::vector<IMPL::TrackStateImpl> getTrackStates(EVENT::ReconstructedParticle* pfo, MarlinTrk::IMarlinTrkSystem* trkSystem, double bField);
 }
 
 

--- a/Tracking/TrackLength/include/TrackLengthUtils.h
+++ b/Tracking/TrackLength/include/TrackLengthUtils.h
@@ -35,9 +35,31 @@ namespace TrackLengthUtils{
     /** Get track length.
     Returns the track length between two track states estimated by the helix length formula:
 
-    \f$ \ell = \frac{\left |z_{i+1} - z_{i}\right |}{| \tan{\lambda}| } \sqrt{1 + \tan{\lambda}^{2} } \f$
+    \f$ \ell_{i} = \frac{\left |z_{i+1} - z_{i}\right |}{| \tan{\lambda_{i}}| } \sqrt{1 + \tan{\lambda_{i}}^{2} } \f$
     */
     double getHelixLength(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
+
+
+    /** Get track length.
+    Returns the track length between two track states estimated by the helix length formula:
+
+    \f$ \ell_{i} = \sqrt{\frac{(\varphi_{i+1} - \varphi_{i})^{2}}{\Omega_{i}^{2}} + (z_{i+1} - z_{i})^2 } \f$
+
+    NOTE: This option is known to perform significantly worse than the default method.
+    It remains here as a reference only for testting/developement/debugging purposes.
+    */
+    double getHelixLengthOption1(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
+
+    /** Get track length.
+    Returns the track length between two track states estimated by the helix length formula:
+
+    \f$ \ell_{i} = \frac{\left| \varphi_{i+1} - \varphi_{i} \right|}{\left| \Omega_{i} \right|}\sqrt{ 1 + \tan{\lambda_{i}}^{2} } \f$
+
+    NOTE: This option is known to perform significantly worse than the default method and even option 1.
+    It remains here as a reference only for testting/developement/debugging purposes.
+    */
+    double getHelixLengthOption2(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
+
 
 
     /** Get all subtracks of the Track.
@@ -52,6 +74,14 @@ namespace TrackLengthUtils{
     and the track state at the ECal surface.
     */
     std::vector<IMPL::TrackStateImpl> getTrackStates(EVENT::ReconstructedParticle* pfo, MarlinTrk::IMarlinTrkSystem* trkSystem, double bField);
+
+
+    /** Get number of helix revolutions.
+    Returns the number of helix revolutions/curls between two track states.
+    The calculation is done with:
+    \f$  N_{\mathrm{turns}} = \frac{\left |z_{i+1} - z_{i}\right |}{| \tan{\lambda_{i}}| } \bigg / (2 \pi \frac{1}{|\Omega_{i}|}) \f$
+    */
+    double getHelixNRevolutions(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
 }
 
 

--- a/Tracking/TrackLength/include/TrackLengthUtils.h
+++ b/Tracking/TrackLength/include/TrackLengthUtils.h
@@ -32,42 +32,12 @@ namespace TrackLengthUtils{
     IMPL::TrackStateImpl getTrackStateAtHit(MarlinTrk::IMarlinTrack* marlinTrk, EVENT::TrackerHit* hit);
 
 
-    /** Get track momentum at the track state.
-    Returns momentum Vector3D from the given track state.
-    */
-    dd4hep::rec::Vector3D getHelixMomAtTrackState(const EVENT::TrackState& ts, double bField);
-
-
-    /** Get track length.
-    Returns the track length between two track states estimated by the helix length formula:
-
-    \f$ \ell = \sqrt{\left( \frac{\varphi_{i+1} - \varphi_{i}}{\Omega}\right)^{2} + \left( z_{i+1} - z_{i} \right)^{2} } \f$
-
-    Note: The formula above works only for the arcs with \f$ \Delta \varphi < \pi \f$.
-    */
-    double getHelixArcLength(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
-
-
     /** Get track length.
     Returns the track length between two track states estimated by the helix length formula:
 
     \f$ \ell = \frac{\left |z_{i+1} - z_{i}\right |}{| \tan{\lambda}| } \sqrt{1 + \tan{\lambda}^{2} } \f$
-
-    Note: The formula above works for any \f$ \Delta \varphi \f$.
-
-    However it is less precise than getHelixArcLength() due to the less precise \f$ \tan{\lambda} \f$.
-    Also helix formula implies constant momentum assumption which may show higher discrepancy for long tracks with low momentum.
     */
-    double getHelixLengthAlongZ(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
-
-
-    /** Get number of helix revolutions.
-    Returns number of helix revolutions between two track states.
-
-    The calculation is done with:
-    \f$  N_{\mathrm{turns}} = \frac{\left |z_{i+1} - z_{i}\right |}{| \tan{\lambda}| } \bigg / (2 \pi \frac{1}{|\Omega|}) \f$
-    */
-    double getHelixNRevolutions(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
+    double getHelixLength(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2);
 
 
     /** Get all subtracks of the Track.

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -68,12 +68,9 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
         streamlog_out(DEBUG9)<<std::endl<<"Starting to analyze "<<i+1<<" PFO"<<std::endl;
         ReconstructedParticle* pfo = static_cast <ReconstructedParticle*> ( pfos->getElementAt(i) );
 
-        int nClusters = pfo->getClusters().size();
-        int nTracks = pfo->getTracks().size();
-
-        if( nTracks == 0 ){
-            // Calculate track length only for particles with a track.
-            //Note: If pfo has more than one track attached, only the first track will be used. The results may be not accurate in such cases. 
+        if( pfo->getTracks().empty() ){
+            // Calculate track length only for particles with at least one track.
+            // Note: If the pfo has more than one track attached (e.g. kink, v0), only the first track will be used. The results may be not accurate in these cases. 
             vector<float> results{0., 0., 0., 0.};
             pidHandler.setParticleID(pfo , 0, 0, 0., algoID, results);
             continue;

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -78,8 +78,7 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
         }
         Track* track = pfo->getTracks()[0];
 
-        vector<Track*> subTracks = getSubTracks(track);
-        vector<TrackStateImpl> trackStates = getTrackStatesPerHit(subTracks, _trkSystem, _bField);
+        vector<TrackStateImpl> trackStates = getTrackStates(pfo, _trkSystem, _bField);
 
         double trackLengthToSET = 0.;
         double harmonicMomToSET = 0.;

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -71,6 +71,7 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
         if( pfo->getTracks().empty() ){
             // Calculate track length only for particles with at least one track.
             // Note: If the pfo has more than one track attached (e.g. kink, v0), only the first track will be used. The results may be not accurate in these cases. 
+            streamlog_out(DEBUG9)<<"PFO has no tracks. Writing zeros."<<std::endl;
             vector<float> results{0., 0., 0., 0.};
             pidHandler.setParticleID(pfo , 0, 0, 0., algoID, results);
             continue;

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -10,6 +10,7 @@
 #include "marlinutil/GeometryUtil.h"
 #include "MarlinTrk/Factory.h"
 #include "EVENT/SimTrackerHit.h"
+#include "UTIL/TrackTools.h"
 
 using namespace TrackLengthUtils;
 using std::vector;
@@ -102,7 +103,8 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
             if ( nTurns <= 0.5 ) arcLength = getHelixArcLength( trackStates[j-1], trackStates[j] );
             else arcLength = getHelixLengthAlongZ( trackStates[j-1], trackStates[j] );
 
-            Vector3D mom = getHelixMomAtTrackState( trackStates[j-1], _bField );
+            std::array<double, 3> momArr = UTIL::getTrackMomentum( &(trackStates[j-1]), _bField);
+            Vector3D mom(momArr[0], momArr[1], momArr[2]);
             trackLengthToSET += arcLength;
             trackLengthToEcal += arcLength;
             harmonicMomToSET += arcLength/mom.r2();
@@ -115,7 +117,8 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
         double arcLength;
         if ( nTurns <= 0.5 ) arcLength = getHelixArcLength( trackStates[nTrackStates - 2], trackStates[nTrackStates - 1] );
         else arcLength = getHelixLengthAlongZ( trackStates[nTrackStates - 2], trackStates[nTrackStates - 1] );
-        Vector3D mom = getHelixMomAtTrackState( trackStates[nTrackStates - 2], _bField );
+        std::array<double, 3> momArr = UTIL::getTrackMomentum( &(trackStates[nTrackStates - 2]), _bField );
+        Vector3D mom(momArr[0], momArr[1], momArr[2]);
         trackLengthToEcal += arcLength;
         harmonicMomToEcal += arcLength/mom.r2();
         harmonicMomToEcal = std::sqrt(trackLengthToEcal/harmonicMomToEcal);

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -72,7 +72,6 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
             // Calculate track length only for particles with at least one track.
             // Note: If the pfo has more than one track attached (e.g. kink, v0), only the first track will be used. The results may be not accurate in these cases. 
             streamlog_out(DEBUG9) << "PFO has no tracks. Writing zeros." << std::endl;
-            streamlog_out(DEBUG9)<<"PFO has no tracks. Writing zeros."<<std::endl;
             vector<float> results{0., 0., 0., 0.};
             pidHandler.setParticleID(pfo , 0, 0, 0., algoID, results);
             continue;

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -101,21 +101,18 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
             std::array<double, 3> momArr = UTIL::getTrackMomentum( &(trackStates[j-1]), _bField);
             Vector3D mom(momArr[0], momArr[1], momArr[2]);
             trackLengthToSET += arcLength;
-            trackLengthToEcal += arcLength;
             harmonicMomToSET += arcLength/mom.r2();
-            harmonicMomToEcal += arcLength/mom.r2();
         }
-        harmonicMomToSET = std::sqrt(trackLengthToSET/harmonicMomToSET);
         
         //now calculate to the Ecal one more step
         double arcLength = getHelixLength( trackStates[nTrackStates - 2], trackStates[nTrackStates - 1] );
-
         std::array<double, 3> momArr = UTIL::getTrackMomentum( &(trackStates[nTrackStates - 2]), _bField );
         Vector3D mom(momArr[0], momArr[1], momArr[2]);
-        trackLengthToEcal += arcLength;
-        harmonicMomToEcal += arcLength/mom.r2();
-        harmonicMomToEcal = std::sqrt(trackLengthToEcal/harmonicMomToEcal);
+        trackLengthToEcal = trackLengthToSET + arcLength;
+        harmonicMomToEcal = harmonicMomToSET + arcLength/mom.r2();
 
+        harmonicMomToSET = std::sqrt(trackLengthToSET/harmonicMomToSET);
+        harmonicMomToEcal = std::sqrt(trackLengthToEcal/harmonicMomToEcal);
 
         vector<float> results{float(trackLengthToSET), float(trackLengthToEcal), float(harmonicMomToSET), float(harmonicMomToEcal)};
         pidHandler.setParticleID(pfo , 0, 0, 0., algoID, results);

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -71,6 +71,7 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
         if( pfo->getTracks().empty() ){
             // Calculate track length only for particles with at least one track.
             // Note: If the pfo has more than one track attached (e.g. kink, v0), only the first track will be used. The results may be not accurate in these cases. 
+            streamlog_out(DEBUG9) << "PFO has no tracks. Writing zeros." << std::endl;
             streamlog_out(DEBUG9)<<"PFO has no tracks. Writing zeros."<<std::endl;
             vector<float> results{0., 0., 0., 0.};
             pidHandler.setParticleID(pfo , 0, 0, 0., algoID, results);

--- a/Tracking/TrackLength/src/TrackLengthProcessor.cc
+++ b/Tracking/TrackLength/src/TrackLengthProcessor.cc
@@ -96,12 +96,7 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
 
         //exclude last track state at the ECal
         for( int j=1; j < nTrackStates-1; ++j ){
-            //we check which track length formula to use
-            double nTurns = getHelixNRevolutions( trackStates[j-1], trackStates[j] );
-            double arcLength;
-            // we cannot calculate arc length for more than pi revolution using delta phi. Use formula with only z
-            if ( nTurns <= 0.5 ) arcLength = getHelixArcLength( trackStates[j-1], trackStates[j] );
-            else arcLength = getHelixLengthAlongZ( trackStates[j-1], trackStates[j] );
+            double arcLength = getHelixLength( trackStates[j-1], trackStates[j] );
 
             std::array<double, 3> momArr = UTIL::getTrackMomentum( &(trackStates[j-1]), _bField);
             Vector3D mom(momArr[0], momArr[1], momArr[2]);
@@ -113,10 +108,8 @@ void TrackLengthProcessor::processEvent(EVENT::LCEvent * evt){
         harmonicMomToSET = std::sqrt(trackLengthToSET/harmonicMomToSET);
         
         //now calculate to the Ecal one more step
-        double nTurns = getHelixNRevolutions( trackStates[nTrackStates - 2], trackStates[nTrackStates - 1] );
-        double arcLength;
-        if ( nTurns <= 0.5 ) arcLength = getHelixArcLength( trackStates[nTrackStates - 2], trackStates[nTrackStates - 1] );
-        else arcLength = getHelixLengthAlongZ( trackStates[nTrackStates - 2], trackStates[nTrackStates - 1] );
+        double arcLength = getHelixLength( trackStates[nTrackStates - 2], trackStates[nTrackStates - 1] );
+
         std::array<double, 3> momArr = UTIL::getTrackMomentum( &(trackStates[nTrackStates - 2]), _bField );
         Vector3D mom(momArr[0], momArr[1], momArr[2]);
         trackLengthToEcal += arcLength;

--- a/Tracking/TrackLength/src/TrackLengthUtils.cc
+++ b/Tracking/TrackLength/src/TrackLengthUtils.cc
@@ -45,37 +45,12 @@ IMPL::TrackStateImpl TrackLengthUtils::getTrackStateAtHit(MarlinTrk::IMarlinTrac
     return ts;
 }
 
-double TrackLengthUtils::getHelixArcLength(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
-    double omega = ts1.getOmega();
-    double z1 = ts1.getReferencePoint()[2] + ts1.getZ0();
-    double z2 = ts2.getReferencePoint()[2] + ts2.getZ0();
-    double dPhi = std::abs( ts2.getPhi() - ts1.getPhi() );
-    if (dPhi > M_PI) dPhi = 2*M_PI - dPhi;
 
-    return std::sqrt( std::pow(dPhi/omega, 2) + std::pow(z2-z1, 2) );
-}
-
-
-double TrackLengthUtils::getHelixLengthAlongZ(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
+double TrackLengthUtils::getHelixLength(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
     double tanL = ts1.getTanLambda();
     double z1 = ts1.getReferencePoint()[2] + ts1.getZ0();
     double z2 = ts2.getReferencePoint()[2] + ts2.getZ0();
-
     return std::abs( (z2-z1)/tanL ) * std::sqrt( 1.+tanL*tanL );
-}
-
-
-double TrackLengthUtils::getHelixNRevolutions(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
-    double omega = ts1.getOmega();
-    double tanL = ts1.getTanLambda();
-    double z1 = ts1.getReferencePoint()[2] + ts1.getZ0();
-    double z2 = ts2.getReferencePoint()[2] + ts2.getZ0();
-
-    // helix length projected on xy
-    double circHelix = std::abs( (z2-z1)/tanL );
-    double circFull = 2*M_PI/std::abs(omega);
-
-    return circHelix/circFull;
 }
 
 

--- a/Tracking/TrackLength/src/TrackLengthUtils.cc
+++ b/Tracking/TrackLength/src/TrackLengthUtils.cc
@@ -53,6 +53,35 @@ double TrackLengthUtils::getHelixLength(const EVENT::TrackState& ts1, const EVEN
 }
 
 
+double TrackLengthUtils::getHelixLengthOption1(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
+    double omega = std::abs( ts1.getOmega() );
+    double z1 = ts1.getReferencePoint()[2] + ts1.getZ0();
+    double z2 = ts2.getReferencePoint()[2] + ts2.getZ0();
+    double dz = std::abs(z2 - z1);
+    double dPhi = std::abs( ts2.getPhi() - ts1.getPhi() );
+    // We are never sure whether the track indeed curled for more than pi
+    // or it was just a crossing of the singularity point (-pi/+pi) in the phi coordinate system.
+    // We always assume it was the crossing of the (-pi/+pi) and correct for this.
+    // Thus this formula only applicable for small distances between the track states or for the non-curly tracks (dPhi < pi).
+    if (dPhi > M_PI) dPhi = 2*M_PI - dPhi;
+    return std::sqrt(dPhi*dPhi/(omega*omega)+dz*dz);
+};
+
+
+double TrackLengthUtils::getHelixLengthOption2(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
+    double omega = std::abs( ts1.getOmega() );
+    double tanL = std::abs( ts1.getTanLambda() );
+    double dPhi = std::abs( ts2.getPhi() - ts1.getPhi() );
+    // We are never sure whether the track indeed curled for more than pi
+    // or it was just a crossing of the singularity point (-pi/+pi) in the phi coordinate system.
+    // We always assume it was the crossing of the (-pi/+pi) and correct for this.
+    // Thus this formula only applicable for small distances between the track states or for the non-curly tracks (dPhi < pi).
+    if (dPhi > M_PI) dPhi = 2*M_PI - dPhi;
+    return dPhi/omega*std::sqrt(1+tanL*tanL);
+};
+
+
+
 std::vector<EVENT::Track*> TrackLengthUtils::getSubTracks(EVENT::Track* track){
     vector<Track*> subTracks;
     // add track itself, which contains VXD+FTD+SIT+TPC hits of the first curl.
@@ -172,4 +201,17 @@ std::vector<IMPL::TrackStateImpl> TrackLengthUtils::getTrackStates(EVENT::Recons
     const TrackStateImpl* tsCalo = static_cast<const TrackStateImpl*> (lastGoodRefittedTrack.getTrackState(TrackState::AtCalorimeter) );
     if ( pfo->getClusters().size() > 0 && tsCalo != nullptr ) trackStates.push_back( *(tsCalo) );
     return trackStates;
+}
+
+
+double TrackLengthUtils::getHelixNRevolutions(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
+    double omega = std::abs( ts1.getOmega() );
+    double tanL = std::abs( ts1.getTanLambda() );
+    double z1 = ts1.getReferencePoint()[2] + ts1.getZ0();
+    double z2 = ts2.getReferencePoint()[2] + ts2.getZ0();
+    double dz = std::abs(z2 - z1);
+    // helix length projected on xy
+    double circHelix = dz/tanL;
+    double circFull = 2*M_PI/omega;
+    return circHelix/circFull;
 }

--- a/Tracking/TrackLength/src/TrackLengthUtils.cc
+++ b/Tracking/TrackLength/src/TrackLengthUtils.cc
@@ -90,8 +90,8 @@ std::vector<EVENT::Track*> TrackLengthUtils::getSubTracks(EVENT::Track* track){
     int nSubTracks = track->getTracks().size();
     if (nSubTracks <= 1) return subTracks;
 
-    auto isTPCHit = [](TrackerHit* hit) -> bool {
-        UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
+    UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
+    auto isTPCHit = [&encoder](TrackerHit* hit) -> bool {
         encoder.setValue( hit->getCellID0() ) ;
         int subdet = encoder[ UTIL::LCTrackerCellID::subdet() ];
         return subdet == UTIL::ILDDetID::TPC;

--- a/Tracking/TrackLength/src/TrackLengthUtils.cc
+++ b/Tracking/TrackLength/src/TrackLengthUtils.cc
@@ -45,20 +45,6 @@ IMPL::TrackStateImpl TrackLengthUtils::getTrackStateAtHit(MarlinTrk::IMarlinTrac
     return ts;
 }
 
-
-dd4hep::rec::Vector3D TrackLengthUtils::getHelixMomAtTrackState(const EVENT::TrackState& ts, double bField){
-    double phi = ts.getPhi();
-    double d0 = ts.getD0();
-    double z0 = ts.getZ0();
-    double omega = ts.getOmega();
-    double tanL = ts.getTanLambda();
-
-    HelixClass helix;
-    helix.Initialize_Canonical(phi, d0, z0, omega, tanL, bField);
-    return helix.getMomentum();
-}
-
-
 double TrackLengthUtils::getHelixArcLength(const EVENT::TrackState& ts1, const EVENT::TrackState& ts2){
     double omega = ts1.getOmega();
     double z1 = ts1.getReferencePoint()[2] + ts1.getZ0();


### PR DESCRIPTION
BEGINRELEASENOTES

- Switch to the helix formula without Omega: $\ell_{i} = \frac{|z_{i+1} - z_{i}|}{|\tan{\lambda_{i}}|}\sqrt{1 +\tan^2{\lambda_{i}}}$. It shows the best performance so far.
- Other bug fixes and consistency improvements.

ENDRELEASENOTES


+ The most major change is the new formula to calculate the helical distance between two neighboring track states.
We change from $\ell_{i} = \sqrt{\left( \frac{\varphi_{i+1} - \varphi_{i}}{\Omega_{i}}\right)^{2} + \left( z_{i+1} - z_{i} \right)^{2} }$ to $\ell_{i} = \frac{|z_{i+1} - z_{i}|}{|\tan{\lambda_{i}}|}\sqrt{1 +\tan^2{\lambda_{i}}}$ as it shows much more precise results for all tracks.
+ Fixed a bug where the track state at the calorimeter surface was not included when track fit of the last subTrack has failed. Now we extrapolate to the calorimeter from the latest successfuly fitted subTrack if PFO has any matched shower in the calorimeter.
+ Fixed a bug where an additional extra track state was added by mistake before the calorimeter track state.
+ Improved robustness of identifying first TPC curl subTrack. Now it is expected to work100% of the time, not most of the time.
+ Now track length calculated for all PFOs which have at least one track, independently of number of clusters, as it should be. In case of the PFOs with 2+ tracks attached (e.g. kinks, V0s) track length takes only the first track to do the calculation. For these cases track length might not be very well defined.
+ Code cleanup, style and comments improvements and clarifications.