### PR TITLE
Update of the time of flight processor

### DIFF
--- a/TimeOfFlight/include/TOFEstimators.h
+++ b/TimeOfFlight/include/TOFEstimators.h
@@ -76,10 +76,6 @@ class TOFEstimators : public marlin::Processor {
         /** Stores z component of the magnetic field at the origin in Tesla.
         */
         double _bField{};
-
-        /** Stores outer TPC radius in mm.
-        */
-        double _tpcOuterR{};
 };
 
 #endif

--- a/TimeOfFlight/include/TOFUtils.h
+++ b/TimeOfFlight/include/TOFUtils.h
@@ -13,15 +13,9 @@
 */
 namespace TOFUtils{
 
-    /** Returns TPC outer radius from the DD4hep detector geometry.
+    /** Returns SET hit if exists.
     */
-    double getTPCOuterR();
-
-    /** Returns SET hit.
-    Checks the \f$ \rho = \sqrt{x^{2}+y^{2}} \f$ of the tracker hit.
-    If \f$ \rho > R_{\mathrm{TPC, outer}} \f$  then it is the SET hit.
-    */
-    EVENT::TrackerHit* getSETHit(EVENT::Track* track, double tpcOuterR);
+    EVENT::TrackerHit* getSETHit(EVENT::Track* track);
 
     /** Get a subset of the cluster calorimeter hits.
     Returns the subset of the cluster calorimeter hits which we call "Frank"

--- a/TimeOfFlight/include/TOFUtils.h
+++ b/TimeOfFlight/include/TOFUtils.h
@@ -13,11 +13,6 @@
 */
 namespace TOFUtils{
 
-    /** Get track momentum at the track state.
-    Returns momentum Vector3D from the given track state.
-    */
-    dd4hep::rec::Vector3D getHelixMomAtTrackState(const EVENT::TrackState& ts, double bField);
-
     /** Returns TPC outer radius from the DD4hep detector geometry.
     */
     double getTPCOuterR();

--- a/TimeOfFlight/include/TOFUtils.h
+++ b/TimeOfFlight/include/TOFUtils.h
@@ -61,7 +61,7 @@ namespace TOFUtils{
     /** Get TrackState of the track at the Calorimeter surface. In case of multiple curls take the latest curl (closest to the calorimeter)
     to get the extrapolated position.
     */
-    const EVENT::TrackState* geTrackStateAtCalorimeter(EVENT::Track* track);
+    const EVENT::TrackState* getTrackStateAtCalorimeter(EVENT::Track* track);
 
 
 }

--- a/TimeOfFlight/include/TOFUtils.h
+++ b/TimeOfFlight/include/TOFUtils.h
@@ -64,6 +64,12 @@ namespace TOFUtils{
     */
     double getTofFrankFit( std::vector<EVENT::CalorimeterHit*> selectedHits, EVENT::Track* track, double timeResolution);
 
+    /** Get TrackState of the track at the Calorimeter surface. In case of multiple curls take the latest curl (closest to the calorimeter)
+    to get the extrapolated position.
+    */
+    const EVENT::TrackState* geTrackStateAtCalorimeter(EVENT::Track* track);
+
+
 }
 
 #endif

--- a/TimeOfFlight/src/TOFEstimators.cc
+++ b/TimeOfFlight/src/TOFEstimators.cc
@@ -80,7 +80,6 @@ void TOFEstimators::init(){
 
     _outputParNames = {"timeOfFlight"};
     _bField = MarlinUtil::getBzAtOrigin();
-    _tpcOuterR = getTPCOuterR();
     // internally we use time resolution in nanoseconds
     _timeResolution = _timeResolution/1000.;
 }
@@ -133,7 +132,7 @@ void TOFEstimators::processEvent(EVENT::LCEvent * evt){
         else{
             //define tof as an average time between two SET strips
             //if no SET hits found, tof alreasy is 0, just skip
-            TrackerHit* hitSET = getSETHit(track, _tpcOuterR);
+            TrackerHit* hitSET = getSETHit(track);
             if ( hitSET != nullptr ){
                 const vector<LCObject*>& simHitsSET = navigatorSET.getRelatedToObjects( hitSET );
                 if ( simHitsSET.size() >= 2 ){

--- a/TimeOfFlight/src/TOFUtils.cc
+++ b/TimeOfFlight/src/TOFUtils.cc
@@ -42,7 +42,7 @@ EVENT::TrackerHit* TOFUtils::getSETHit(EVENT::Track* track){
     return nullptr;
 }
 
-const EVENT::TrackState* TOFUtils::geTrackStateAtCalorimeter(EVENT::Track* track){
+const EVENT::TrackState* TOFUtils::getTrackStateAtCalorimeter(EVENT::Track* track){
     UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
     auto isTPCHit = [&encoder](TrackerHit* hit) -> bool {
         encoder.setValue( hit->getCellID0() ) ;
@@ -73,7 +73,7 @@ const EVENT::TrackState* TOFUtils::geTrackStateAtCalorimeter(EVENT::Track* track
 
 
 std::vector<EVENT::CalorimeterHit*> TOFUtils::selectFrankEcalHits( EVENT::Cluster* cluster, EVENT::Track* track, int maxEcalLayer, double bField ){
-    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
+    const TrackState* tsEcal = getTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
     std::array<double, 3> momArr = UTIL::getTrackMomentum(tsEcal, bField);
     Vector3D trackMomAtEcal(momArr[0], momArr[1], momArr[2]);
@@ -101,7 +101,7 @@ std::vector<EVENT::CalorimeterHit*> TOFUtils::selectFrankEcalHits( EVENT::Cluste
 
 
 double TOFUtils::getTofClosest( EVENT::Cluster* cluster, EVENT::Track* track, double timeResolution){
-    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
+    const TrackState* tsEcal = getTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
 
     double hitTime = numeric_limits<double>::max();
@@ -125,7 +125,7 @@ double TOFUtils::getTofClosest( EVENT::Cluster* cluster, EVENT::Track* track, do
 
 
 double TOFUtils::getTofFrankAvg( std::vector<EVENT::CalorimeterHit*> selectedHits, EVENT::Track* track, double timeResolution){
-    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
+    const TrackState* tsEcal = getTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
 
     int nHits = selectedHits.size();
@@ -142,7 +142,7 @@ double TOFUtils::getTofFrankAvg( std::vector<EVENT::CalorimeterHit*> selectedHit
 
 
 double TOFUtils::getTofFrankFit( std::vector<EVENT::CalorimeterHit*> selectedHits, EVENT::Track* track, double timeResolution){
-    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
+    const TrackState* tsEcal = getTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
 
     int nHits = selectedHits.size();

--- a/TimeOfFlight/src/TOFUtils.cc
+++ b/TimeOfFlight/src/TOFUtils.cc
@@ -61,7 +61,7 @@ const EVENT::TrackState* TOFUtils::getTrackStateAtCalorimeter(EVENT::Track* trac
         }
     }
 
-    // Take the trackState at thhe calorimeter surface always from the latest curl
+    // Take the trackState at the calorimeter surface always from the latest curl
     // Track has only one curl
     if ( indexOfFirstTPCCurl == nSubTracks-1 ) return track->getTrackState( TrackState::AtCalorimeter );
     else{

--- a/TimeOfFlight/src/TOFUtils.cc
+++ b/TimeOfFlight/src/TOFUtils.cc
@@ -6,7 +6,7 @@
 
 #include "marlin/VerbosityLevels.h"
 #include "marlinutil/CalorimeterHitType.h"
-#include "HelixClass.h"
+#include "UTIL/TrackTools.h"
 #include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
 #include "DDRec/DetectorData.h"
@@ -27,19 +27,6 @@ using dd4hep::DetElement;
 using dd4hep::rec::Vector3D;
 using dd4hep::rec::FixedPadSizeTPCData;
 using CLHEP::RandGauss;
-
-
-dd4hep::rec::Vector3D TOFUtils::getHelixMomAtTrackState(const EVENT::TrackState& ts, double bField){
-    double phi = ts.getPhi();
-    double d0 = ts.getD0();
-    double z0 = ts.getZ0();
-    double omega = ts.getOmega();
-    double tanL = ts.getTanLambda();
-
-    HelixClass helix;
-    helix.Initialize_Canonical(phi, d0, z0, omega, tanL, bField);
-    return helix.getMomentum();
-}
 
 
 double TOFUtils::getTPCOuterR(){
@@ -63,7 +50,8 @@ EVENT::TrackerHit* TOFUtils::getSETHit(EVENT::Track* track, double tpcOuterR){
 std::vector<EVENT::CalorimeterHit*> TOFUtils::selectFrankEcalHits( EVENT::Cluster* cluster, EVENT::Track* track, int maxEcalLayer, double bField ){
     const TrackState* tsEcal = track->getTrackState(TrackState::AtCalorimeter);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
-    Vector3D trackMomAtEcal = TOFUtils::getHelixMomAtTrackState(*tsEcal, bField);
+    std::array<double, 3> momArr = UTIL::getTrackMomentum(tsEcal, bField);
+    Vector3D trackMomAtEcal(momArr[0], momArr[1], momArr[2]);
 
     vector<CalorimeterHit*> selectedHits(maxEcalLayer, nullptr);
     vector<double> minDistances(maxEcalLayer, numeric_limits<double>::max());

--- a/TimeOfFlight/src/TOFUtils.cc
+++ b/TimeOfFlight/src/TOFUtils.cc
@@ -1,12 +1,9 @@
 #include "TOFUtils.h"
 
-#include <cmath>
-#include <algorithm>
-#include <limits>
-
 #include "marlin/VerbosityLevels.h"
 #include "marlinutil/CalorimeterHitType.h"
 #include "UTIL/TrackTools.h"
+#include "UTIL/ILDConf.h"
 #include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
 #include "DDRec/DetectorData.h"
@@ -14,6 +11,10 @@
 #include "CLHEP/Units/PhysicalConstants.h"
 #include "TGraph.h"
 #include "TF1.h"
+
+#include <cmath>
+#include <algorithm>
+#include <limits>
 
 using std::vector;
 using std::numeric_limits;
@@ -46,9 +47,38 @@ EVENT::TrackerHit* TOFUtils::getSETHit(EVENT::Track* track, double tpcOuterR){
     return nullptr;
 }
 
+const EVENT::TrackState* TOFUtils::geTrackStateAtCalorimeter(EVENT::Track* track){
+    auto isTPCHit = [](TrackerHit* hit) -> bool {
+        UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
+        encoder.setValue( hit->getCellID0() ) ;
+        int subdet = encoder[ UTIL::LCTrackerCellID::subdet() ];
+        return subdet == UTIL::ILDDetID::TPC;
+    };
+
+    int indexOfFirstTPCCurl = 0;
+    int nSubTracks = track->getTracks().size();
+    for(int i = 0; i < nSubTracks; ++i){
+        Track* subTrack = track->getTracks()[i];
+        auto hits = subTrack->getTrackerHits();
+        if ( std::find_if(hits.begin(), hits.end(), isTPCHit) != hits.end() ){
+            indexOfFirstTPCCurl = i;
+            break;
+        }
+    }
+
+    // Take the trackState at thhe calorimeter surface always from the latest curl
+    // Track has only one curl
+    if ( indexOfFirstTPCCurl == nSubTracks-1 ) return track->getTrackState( TrackState::AtCalorimeter );
+    else{
+        // Track has multiple curls
+        Track* lastSubTrack = track->getTracks().back();
+        return lastSubTrack->getTrackState( TrackState::AtCalorimeter );
+    }
+}
+
 
 std::vector<EVENT::CalorimeterHit*> TOFUtils::selectFrankEcalHits( EVENT::Cluster* cluster, EVENT::Track* track, int maxEcalLayer, double bField ){
-    const TrackState* tsEcal = track->getTrackState(TrackState::AtCalorimeter);
+    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
     std::array<double, 3> momArr = UTIL::getTrackMomentum(tsEcal, bField);
     Vector3D trackMomAtEcal(momArr[0], momArr[1], momArr[2]);
@@ -76,7 +106,7 @@ std::vector<EVENT::CalorimeterHit*> TOFUtils::selectFrankEcalHits( EVENT::Cluste
 
 
 double TOFUtils::getTofClosest( EVENT::Cluster* cluster, EVENT::Track* track, double timeResolution){
-    const TrackState* tsEcal = track->getTrackState(TrackState::AtCalorimeter);
+    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
 
     double hitTime = numeric_limits<double>::max();
@@ -100,7 +130,7 @@ double TOFUtils::getTofClosest( EVENT::Cluster* cluster, EVENT::Track* track, do
 
 
 double TOFUtils::getTofFrankAvg( std::vector<EVENT::CalorimeterHit*> selectedHits, EVENT::Track* track, double timeResolution){
-    const TrackState* tsEcal = track->getTrackState(TrackState::AtCalorimeter);
+    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
 
     int nHits = selectedHits.size();
@@ -117,7 +147,7 @@ double TOFUtils::getTofFrankAvg( std::vector<EVENT::CalorimeterHit*> selectedHit
 
 
 double TOFUtils::getTofFrankFit( std::vector<EVENT::CalorimeterHit*> selectedHits, EVENT::Track* track, double timeResolution){
-    const TrackState* tsEcal = track->getTrackState(TrackState::AtCalorimeter);
+    const TrackState* tsEcal = geTrackStateAtCalorimeter(track);
     Vector3D trackPosAtEcal ( tsEcal->getReferencePoint() );
 
     int nHits = selectedHits.size();

--- a/TimeOfFlight/src/TOFUtils.cc
+++ b/TimeOfFlight/src/TOFUtils.cc
@@ -31,8 +31,8 @@ using CLHEP::RandGauss;
 
 EVENT::TrackerHit* TOFUtils::getSETHit(EVENT::Track* track){
     vector<TrackerHit*> hits = track->getTrackerHits();
-    auto isSETHit = [](TrackerHit* hit) -> bool {
-        UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
+    UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
+    auto isSETHit = [&encoder](TrackerHit* hit) -> bool {
         encoder.setValue( hit->getCellID0() ) ;
         int subdet = encoder[ UTIL::LCTrackerCellID::subdet() ];
         return subdet == UTIL::ILDDetID::SET;
@@ -43,8 +43,8 @@ EVENT::TrackerHit* TOFUtils::getSETHit(EVENT::Track* track){
 }
 
 const EVENT::TrackState* TOFUtils::geTrackStateAtCalorimeter(EVENT::Track* track){
-    auto isTPCHit = [](TrackerHit* hit) -> bool {
-        UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
+    UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ;
+    auto isTPCHit = [&encoder](TrackerHit* hit) -> bool {
         encoder.setValue( hit->getCellID0() ) ;
         int subdet = encoder[ UTIL::LCTrackerCellID::subdet() ];
         return subdet == UTIL::ILDDetID::TPC;


### PR DESCRIPTION
BEGINRELEASENOTES

- Always use the first (before)  --> latest (now) curl in the track to get extrapolated track position at the calorimeter surface. This gives sometimes better estimate of the track position at the ECAL surface, especially for the tracks with large number of curls. Thus  new version gives better time of flight correction for the distance to the surface and thus TOF itself.
- Minor style improvements

ENDRELEASENOTES
