### PR TITLE
Fix usage of dd4hep::long64 to dd4hep::CellID

### DIFF
--- a/CaloDigi/SDHCALDigi/include/SimDigital.h
+++ b/CaloDigi/SDHCALDigi/include/SimDigital.h
@@ -127,7 +127,7 @@ class SimDigital : public Processor
 				hitMemory& operator=(const hitMemory& other) = delete ;
 		} ;
 
-		typedef std::map<dd4hep::long64, hitMemory> cellIDHitMap ;
+		typedef std::map<dd4hep::CellID, hitMemory> cellIDHitMap ;
 
 
 		void processCollection(LCCollection* inputCol , LCCollectionVec*& outputCol , LCCollectionVec*& outputRelCol , CHT::Layout layout) ;
@@ -151,7 +151,7 @@ class SimDigital : public Processor
 
 		std::vector<double> _hitCharge = {};
 
-		std::map<dd4hep::long64 , std::vector<LCGenericObject*>> geneMap = {};
+		std::map<dd4hep::CellID , std::vector<LCGenericObject*>> geneMap = {};
 
 		float _cellSize = 0 ;
 		float _gasGapWidth = 1.2f ;

--- a/CaloDigi/SDHCALDigi/include/SimDigitalGeom.h
+++ b/CaloDigi/SDHCALDigi/include/SimDigitalGeom.h
@@ -95,7 +95,7 @@ class SimDigitalGeomCellId
 
 		CHT::Layout _currentHCALCollectionCaloLayout = CHT::any ;
 
-		dd4hep::long64 _cellIDvalue = 0 ;
+		dd4hep::CellID _cellIDvalue = 0 ;
 		CellIDDecoder<SimCalorimeterHit> _decoder ;
 		CellIDEncoder<CalorimeterHitImpl> _encoder ;
 

--- a/CaloDigi/SDHCALDigi/src/SimDigital.cc
+++ b/CaloDigi/SDHCALDigi/src/SimDigital.cc
@@ -444,7 +444,7 @@ SimDigital::cellIDHitMap SimDigital::createPotentialOutputHits(LCCollection* col
 			chargeSpreader->addCharge( itstep.charge , static_cast<float>(itstep.step.x()) , static_cast<float>(itstep.step.y()) , aGeomCellId ) ;
 
 
-		for ( const std::pair<ChargeSpreader::I_J_Coordinates,float>& it : chargeSpreader->getChargeMap() )
+		for ( const auto& it : chargeSpreader->getChargeMap() )
 		{
 			if (it.second >= 0)
 			{
@@ -453,7 +453,7 @@ SimDigital::cellIDHitMap SimDigital::createPotentialOutputHits(LCCollection* col
 				if (tmp == nullptr)
 					continue ;
 
-				dd4hep::long64 index = tmp->getCellID1() ;
+				dd4hep::CellID index = tmp->getCellID1() ;
 				index = index << 32 ;
 				index += tmp->getCellID0() ;
 

--- a/CaloDigi/SDHCALDigi/src/SimDigitalGeom.cc
+++ b/CaloDigi/SDHCALDigi/src/SimDigitalGeom.cc
@@ -210,12 +210,12 @@ void SimDigitalGeomCellIdLCGEO::processGeometry(SimCalorimeterHit* hit)
 
 	dd4hep::BitField64 idDecoder( _cellIDEncodingString ) ;
 
-	dd4hep::long64 id0 = hit->getCellID0() ;
-	dd4hep::long64 id1 = hit->getCellID1() ;
+	const dd4hep::CellID id0 = hit->getCellID0() ;
+	const dd4hep::CellID id1 = hit->getCellID1() ;
 
 	idDecoder.setValue( id0 , id1 ) ;
 
-	dd4hep::long64 id = idDecoder.getValue() ;
+	const dd4hep::CellID id = idDecoder.getValue() ;
 	dd4hep::Position pos_0 = idposConv.position( id ) ;
 
 #if 0


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch from `dd4hep::long64` to `dd4hep::CellID` to be compatible with DD4hep after [AIDASoft/DD4hep#1125](https://github.com/AIDASoft/DD4hep/pull/1125)

ENDRELEASENOTES