### PR TITLE
CPID and LeptonID update

### DIFF
--- a/Analysis/LeptonID/include/LeptonIDProcessor.h
+++ b/Analysis/LeptonID/include/LeptonIDProcessor.h
@@ -35,7 +35,7 @@ using namespace marlin;
  * @version $Id: MyProcessor.h,v 1.4 2005-10-11 12:57:39 gaede Exp $
  */
 
-class LeptonIDProcessor : public Processor, public EventModifier
+class LeptonIDProcessor : public Processor //, public EventModifier
 {
 
 public:
@@ -57,7 +57,7 @@ public:
 
   /** Called for every event - the working horse.
    */
-  virtual void modifyEvent(LCEvent *evt);
+  virtual void processEvent(LCEvent *evt);
 
   virtual const std::string & name() const {return Processor::name();}
 
@@ -90,15 +90,15 @@ protected:
 
   std::vector<std::string> _usedVariables{};
 
-  bool _buildTree;
-  bool _evalMVA;
+  bool _buildTree = true;
+  bool _evalMVA = false;
 
   float _MCTruthRecoCweightCut{};
   float _MCTruthRecoTweightCut{};
   float _RecoMCTruthCweightCut{};
   float _RecoMCTruthTweightCut{};
 
-  TTree* _tree;
+  TTree* _tree{};
   TMVA::Reader _mvareader;
 
   int _truePDG{};

--- a/Analysis/LeptonID/src/LeptonIDProcessor.cc
+++ b/Analysis/LeptonID/src/LeptonIDProcessor.cc
@@ -166,6 +166,9 @@ void LeptonIDProcessor::setupMVAReader()
 
 void LeptonIDProcessor::init()
 {
+    // usually a good idea to
+    printParameters();
+
     streamlog_out(DEBUG) << "   init called  " << std::endl;
     if (_buildTree) {
         // if I keep this here it magically appears in the aida file :)
@@ -194,7 +197,7 @@ void LeptonIDProcessor::processRunHeader(LCRunHeader *run)
     (void) run;
 }
 
-void LeptonIDProcessor::modifyEvent(LCEvent *evt)
+void LeptonIDProcessor::processEvent(LCEvent *evt)
 {
     streamlog_out(DEBUG) << "process Event called" << std::endl;
     LCCollection *PandoraPFOs = nullptr;

--- a/Analysis/PIDTools/include/ComprehensivePIDProcessor.h
+++ b/Analysis/PIDTools/include/ComprehensivePIDProcessor.h
@@ -66,7 +66,7 @@ using namespace marlin;
  * @param _modeInfer - Set true to infer PID from the specified TrainingModels. Cannot be true at the same time as _modeTrain.
  *    bool, default: false.
  *
- * @param _TTreeFileName - Name of the root file in which the TTree with all observables is stored; optional output in case of extraction, otherwise necessary input.
+ * @param _TTreeFileName - Name of the root file in which the TTree with all observables is stored; in case of extraction it is an optional output with no output if left empty, otherwise it is a necessary input.
  *    string, default: TTreeFile.root.
  * @param _inputAlgoSpecs - List of input algorithms; for each specify type:name or only type (then name=type).
  *    string vector, default: {}.
@@ -103,7 +103,7 @@ public:
   void ReadReferenceFile(int n);
   std::string ReferenceFile(int n);
 
-  void PlotTH2(TCanvas* can, TH2* hist);
+  void PlotTH2(TCanvas* can, TH2* hist, int effpur=0);
  
 private:
 
@@ -138,6 +138,7 @@ private:
   long long int _nPFO=0;
 
   TFile* _TTreeFile{};
+  bool _writeTTreeFile = false;
 
   std::vector<std::string> _inputAlgoTypes{};
   std::vector<std::string> _inputAlgoNames{};

--- a/Analysis/PIDTools/include/ComprehensivePIDProcessor.h
+++ b/Analysis/PIDTools/include/ComprehensivePIDProcessor.h
@@ -52,12 +52,12 @@ using namespace marlin;
  * Signal and background PDGs can be defined. Only PFOs which originate from either of these are used.
  * The consequence of belonging to either of these groups lies in the details of the individual TrainingModels.
  * The PFOs are divided into momentum bins, for each of which a separate TrainingModel is created and trained/inferred from.
- * If inference is specified, a plot of the confusion matrix of all signal PDGs is created in the current working directory during end.
+ * If inference is specified, confusion matrix plots of all signal PDGs can be created in the specified folder during end.
  *
  * @param _PFOColName - Name of the PFO input collection (ReconstructedParticleImpl).
- *    string, default: PandoraPFOs.
+ *    string, default: "PandoraPFOs".
  * @param _RecoMCTruthLinkName - Name of the link from PFOs to MCParticles input collection (LCRelation).
- *    string, default: RecoMCTruthLink.
+ *    string, default: "RecoMCTruthLink".
  *
  * @param _modeExtract - Set true to extract PID observables via the specified InputAlgorithms.
  *    bool, default: false.
@@ -67,15 +67,47 @@ using namespace marlin;
  *    bool, default: false.
  *
  * @param _TTreeFileName - Name of the root file in which the TTree with all observables is stored; in case of extraction it is an optional output with no output if left empty, otherwise it is a necessary input.
- *    string, default: TTreeFile.root.
+ *    string, default: "TTreeFile.root".
  * @param _inputAlgoSpecs - List of input algorithms; for each specify type:name or only type (then name=type).
  *    string vector, default: {}.
  * @param _trainModelSpecs - List of training models; for each specify type:name or only type (then name=type).
  *    string vector, default: {}.
  * @param _reffile - Reference file(s). If only one file but several training models are specified the reference files are auto-numbered.
- *    string vector, default: {Ref.txt}.
+ *    string vector, default: {"Ref.txt"}.
  * @param _trainingObservables - List of observables that should be used for traning. If empty, all observables from the specified algorithms + momabs + lambda are used.
- *    string vector, default: {}
+ *    string vector, default: {}.
+ *
+ * @param _signalPDGs - List of PDG numbers that are considered signal.
+ *    int vector, default: {11,13,211,321,2212}.
+ * @param _backgroundPDGs - List of PDG numbers that are considered background.
+ *    int vector, default: {}.
+ *
+ * @param _plotFolder - Folder in which the automatic confusion matrix plots of inference will be put, is created if not already existing; if empty, no plots are created.
+ *    string, default: "CPID_Plots".
+ * @param _fileFormat - File format of the automatic confusion matrix plots of inference.
+ *    string, default: ".png".
+ *
+ * @param _momMin - For momentum bins: minimum momentum / GeV.
+ *    float, default: 1.
+ * @param _momMax - For momentum bins: maximum momentum / GeV.
+ *    float, default: 100
+ * @param _momLog - For momentum bins: should the momentum bins be logarithmic.
+ *    bool, default: true.
+ * @param _momNBins - For momentum bins: number of momentum bins.
+ *    int, default: 12.
+ *
+ * @param _cutD0 - PFOs whose first track have a d0 larger than the given value will be ignored; set to 0 to accept all particles.
+ *    float, default: 0.
+ * @param _cutZ0 - PFOs whose first track have a z0 larger than the given value will be ignored; set to 0 to accept all particles.
+ *    float, default: 0.
+ * @param _cutLamMin - PFOs whose first track have an angle lambda (relative to the cathode) smaller than the given value will be ignored; set to 0 to accept all particles.
+ *    float, default: 0.
+ * @param _cutLamMax - PFOs whose first track have an angle lambda (relative to the cathode) larger than the given value will be ignored; set to 0 to accept all particles.
+ *    float, default: 0.
+ * @param _cutNTracksMin - PFOs with fewer (<) tracks than the given value are ignored; set to -1 to accept all PFOs.
+ *    int, default: -1.
+ * @param _cutNTracksMax - PFOs with more (>) tracks than the given value are ignored; set to -1 to accept all PFOs.
+ *    int, default: -1.
  */
 
 class ComprehensivePIDProcessor : public Processor{

--- a/Analysis/PIDTools/src/AlgorithmMgr.cc
+++ b/Analysis/PIDTools/src/AlgorithmMgr.cc
@@ -41,9 +41,9 @@ namespace cpid
 
   void AlgorithmMgr::printAvailableAlgorithmTypes()
   {
-    std::cout << "Available input algorithms: " << std::endl;
-    for (const auto& [key, value] : _map) {sloM << " " << key << std::endl;}
-    sloM << "-------------------------" << std::endl;
+    sloD << "Available input algorithms: " << std::endl;
+    for (const auto& [key, value] : _map) {sloD << " " << key << std::endl;}
+    sloD << "-------------------------" << std::endl;
   }
 
 }

--- a/Analysis/PIDTools/src/ComprehensivePIDProcessor.cc
+++ b/Analysis/PIDTools/src/ComprehensivePIDProcessor.cc
@@ -52,7 +52,7 @@ ComprehensivePIDProcessor::ComprehensivePIDProcessor() : Processor("Comprehensiv
                  false);
 
   registerProcessorParameter("modeInfer",
-                 "Set true to infer the trained MVA with the specified observables to the PFOs; if true you need to provide the weight files; default: false.",
+                 "Set true to infer the trained MVA with the specified observables to the PFOs; if true you need to provide the reference and weight files; default: false.",
                  _modeInfer,
                  false);
 
@@ -84,17 +84,17 @@ ComprehensivePIDProcessor::ComprehensivePIDProcessor() : Processor("Comprehensiv
 
   std::vector<int> signalPDGs = {11,13,211,321,2212};
   registerProcessorParameter("signalPDGs",
-                 "Vector of PDG numbers that are considered signal; default: {11,13,211,321,2212}.",
+                 "List of PDG numbers that are considered signal; default: {11,13,211,321,2212}.",
                  _signalPDGs,
                  signalPDGs);
 
   registerProcessorParameter("backgroundPDGs",
-                 "Vector of PDG numbers that are considered background; default: {}.",
+                 "List of PDG numbers that are considered background; default: {}.",
                  _backgroundPDGs,
                  std::vector<int>());
 
   registerProcessorParameter("plotFolder",
-                 "Folder in which the automatic confusion matrix plots of inference will be put, needs to exist; if empty, no plots are created; default: .  [current working directory]",
+                 "Folder in which the automatic confusion matrix plots of inference will be put, is created if not already existing; if empty, no plots are created; default: CPID_Plots  [current working directory]",
                  _plotFolder,
                  std::string("CPID_Plots"));
 
@@ -105,22 +105,22 @@ ComprehensivePIDProcessor::ComprehensivePIDProcessor() : Processor("Comprehensiv
 
 
   registerProcessorParameter("momMin",
-                 "For training: minimum momentum cut / GeV; default: 1.",
+                 "For momentum bins: minimum momentum cut / GeV; default: 1.",
                  _momMin,
                  float(1));
 
   registerProcessorParameter("momMax",
-                 "For training: maximum momentum cut / GeV; default: 100.",
+                 "For momentum bins: maximum momentum cut / GeV; default: 100.",
                  _momMax,
                  float(100));
 
   registerProcessorParameter("momLog",
-                 "For training: should the momentum bins be logarihtmic; default: true.",
+                 "For momentum bins: should the momentum bins be logarihtmic; default: true.",
                  _momLog,
                  true);
 
   registerProcessorParameter("momNBins",
-                 "For training: number of momentum bins; default: 12.",
+                 "For momentum bins: number of momentum bins; default: 12.",
                  _momNBins,
                  int(12));
 
@@ -145,12 +145,12 @@ ComprehensivePIDProcessor::ComprehensivePIDProcessor() : Processor("Comprehensiv
                  float(0));
 
   registerProcessorParameter("cutNTracksMin",
-                 "PFOs with fewer tracks the given value are ignored; set to -1 to accept all PFOs; default: -1.",
+                 "PFOs with fewer (<) tracks than the given value are ignored; set to -1 to accept all PFOs; default: -1.",
                  _cutNTracksMin,
                  int(-1));
 
   registerProcessorParameter("cutNTracksMax",
-                 "PFOs with more tracks the given value are ignored; set to -1 to accept all PFOs; default: -1.",
+                 "PFOs with more (>) tracks the given value are ignored; set to -1 to accept all PFOs; default: -1.",
                  _cutNTracksMax,
                  int(-1));
 

--- a/Analysis/PIDTools/src/InputAlgorithm_TOF.cc
+++ b/Analysis/PIDTools/src/InputAlgorithm_TOF.cc
@@ -25,7 +25,8 @@ namespace cpid {
       throw std::runtime_error("parameters error");
     }
 
-    std::vector<std::string> obsNames{"beta"};
+    //std::vector<std::string> obsNames{"beta"};
+    std::vector<std::string> obsNames{"mass2"};
     return obsNames;
   }
 
@@ -42,15 +43,20 @@ namespace cpid {
     const ParticleID& TOFPID = PIDHan.getParticleID(pfo,TOFAlgoID);
     const FloatVec& TOFParams = TOFPID.getParameters();
 
+    const double* mom = pfo->getMomentum();
+
     if (int(TOFParams.size())>TOFParaID_length)
     {
+      float momabs = sqrt(mom[0]*mom[0] + mom[1]*mom[1] + mom[2]*mom[2]);
       float TOFlength = TOFParams[TOFParaID_length];
       float TOFbeta_ch = (TOFlength/TOFParams[TOFParaID_closest]) / 299.8;
-      if (isnan(TOFbeta_ch) || isinf(TOFbeta_ch)) TOFbeta_ch = -1;
-      obsValues.push_back(std::pair<float,float>{TOFbeta_ch, 0});
+      float TOFmass2 = (isnan(TOFbeta_ch) || isinf(TOFbeta_ch)) ? 0 : momabs*momabs/TOFbeta_ch/TOFbeta_ch - momabs*momabs;
+      obsValues.push_back(std::pair<float,float>{TOFmass2, 0});
+      //if (isnan(TOFbeta_ch) || isinf(TOFbeta_ch)) TOFbeta_ch = -1;
+      //obsValues.push_back(std::pair<float,float>{TOFbeta_ch, 0});
     }
     else
-      obsValues.push_back(std::pair<float,float>{-1,-1} );
+      obsValues.push_back(std::pair<float,float>{-1,-1});
 
     return obsValues;
   }

--- a/Analysis/PIDTools/src/ModelMgr.cc
+++ b/Analysis/PIDTools/src/ModelMgr.cc
@@ -41,9 +41,9 @@ namespace cpid
 
   void ModelMgr::printAvailableModelTypes()
   {
-    std::cout << "Available training models: " << std::endl;
-    for (const auto& [key, value] : _map) {sloM << " " << key << std::endl;}
-    sloM << "-------------------------" << std::endl;
+    sloD << "Available training models: " << std::endl;
+    for (const auto& [key, value] : _map) {sloD << " " << key << std::endl;}
+    sloD << "-------------------------" << std::endl;
   }
 
 }


### PR DESCRIPTION
BEGINRELEASENOTES
Minor changes in CPID:
- allow for no automatic creation of root file or plots
- if no output root file and no training then no intermediate TTree is filled
- add efficiency numbers on additional confusion matrix plot
- in TOF algorithm use mass² instead of beta

LeptonID: Remove inheritance from EventModifier
ENDRELEASENOTES