### PR TITLE
Make the TrueJet processor use the PIDHandler to set the ParticleIDs 

### DIFF
--- a/Analysis/TrueJet/include/TrueJet.h
+++ b/Analysis/TrueJet/include/TrueJet.h
@@ -3,14 +3,10 @@
 
 #include "marlin/Processor.h"
 #include "lcio.h"
-#include <EVENT/LCCollection.h>
+
 #include <EVENT/MCParticle.h>
-#include <EVENT/ReconstructedParticle.h>
-#include <EVENT/LCRelation.h>
-#include <UTIL/LCRelationNavigator.h>
-#include "IMPL/LCCollectionVec.h"
-#include <IMPL/ReconstructedParticleImpl.h>
-#include <IMPL/ParticleIDImpl.h>
+#include <EVENT/LCCollection.h>
+
 #include <string>
 
 

--- a/Analysis/TrueJet/src/TrueJet.cc
+++ b/Analysis/TrueJet/src/TrueJet.cc
@@ -705,10 +705,10 @@ void TrueJet::processEvent( LCEvent * event ) {
 
       LCCollectionVec* fafpf_vec = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE ) ;
       auto fafpfPidHandler = UTIL::PIDHandler(fafpf_vec);
-      auto fafpf_mainPidId = fafpfPidHandler.addAlgorithm("TrueType_fafpf", {});
-      std::array<int, 25> fafpf_pidIds{};
+      auto fafpf_mainPidId = fafpfPidHandler.addAlgorithm("TrueJet_fafpf", {});
+      std::array<int, 2> fafpf_pidIds{};
       for (size_t i = 0; i < fafpf_pidIds.size(); ++i) {
-          fafpf_pidIds[i] = fafpfPidHandler.addAlgorithm("TrutType_fafpf_jet_" + std::to_string(i), {});
+          fafpf_pidIds[i] = fafpfPidHandler.addAlgorithm("TrueJet_fafpf_jet_" + std::to_string(i), {});
       }
 
       LCRelationNavigator FinalColourNeutral_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::RECONSTRUCTEDPARTICLE ) ;
@@ -832,7 +832,7 @@ void TrueJet::processEvent( LCEvent * event ) {
                                       0, fafpf_mainPidId, {});
 
         for ( int j_jet_end=1 ; j_jet_end<=jets_end[0][k_dj_end] ; j_jet_end++ ) {
-          fafpfPidHandler.setParticleID(fafpf, type[jets_end[j_jet_end][k_dj_end]], pdg[j_jet_end], 0, fafpf_pidIds[j_jet_end], {});
+          fafpfPidHandler.setParticleID(fafpf, type[jets_end[j_jet_end][k_dj_end]], pdg[j_jet_end], 0, fafpf_pidIds[j_jet_end - 1], {});
 
           if ( elementon[jets_end[j_jet_end][k_dj_end]] > 0 ) {
             FinalElementon_Nav.addRelation(  jet_vec->getElementAt(jets_end[j_jet_end][k_dj_end]-1) , 
@@ -849,10 +849,10 @@ void TrueJet::processEvent( LCEvent * event ) {
 
       LCCollectionVec* fafpi_vec = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE ) ;
       auto fafpiPidHandler = UTIL::PIDHandler(fafpi_vec);
-      auto fafpi_mainPidId = fafpiPidHandler.addAlgorithm("TrueType_fafpi", {});
+      auto fafpi_mainPidId = fafpiPidHandler.addAlgorithm("TrueJet_fafpi", {});
       std::array<int, 25> fafpi_pidIds{};
       for (size_t i = 0; i < fafpi_pidIds.size(); ++i) {
-          fafpi_pidIds[i] = fafpiPidHandler.addAlgorithm("TrutType_fafpi_jet_" + std::to_string(i), {});
+          fafpi_pidIds[i] = fafpiPidHandler.addAlgorithm("TrueJet_fafpi_jet_" + std::to_string(i), {});
       }
 
       LCRelationNavigator InitialElementon_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::MCPARTICLE ) ;
@@ -981,7 +981,7 @@ void TrueJet::processEvent( LCEvent * event ) {
         fafpiPidHandler.setParticleID(fafpi, type[jets_begin[1][k_dj_begin]] % 100, pdg[0], 0, fafpi_mainPidId, {});
 
         for(int j_jet_begin=1 ; j_jet_begin<=jets_begin[0][k_dj_begin] ; j_jet_begin++) {
-          fafpiPidHandler.setParticleID(fafpi, type[jets_begin[j_jet_begin][k_dj_begin]], pdg[j_jet_begin], 0, fafpi_pidIds[j_jet_begin], {});
+          fafpiPidHandler.setParticleID(fafpi, type[jets_begin[j_jet_begin][k_dj_begin]], pdg[j_jet_begin], 0, fafpi_pidIds[j_jet_begin - 1], {});
           fafpi->addParticle(dynamic_cast<ReconstructedParticle*>(jet_vec->getElementAt(jets_begin[j_jet_begin][k_dj_begin]-1)));
         }
         fafpi_vec->addElement(fafpi);

--- a/Analysis/TrueJet/src/TrueJet.cc
+++ b/Analysis/TrueJet/src/TrueJet.cc
@@ -31,6 +31,16 @@ LCRelationNavigator* reltrue =0;
 
 TrueJet aTrueJet ;
 
+namespace {
+/// Return a 0 padded number for 2 digit numbers
+auto paddedNumber(int i) {
+    if (i < 9) {
+        return "0" + std::to_string(i);
+    }
+    return std::to_string(i);
+}
+}
+
 TrueJet::TrueJet() : Processor("TrueJet") {
 
     // modify processor description
@@ -708,7 +718,7 @@ void TrueJet::processEvent( LCEvent * event ) {
       auto fafpf_mainPidId = fafpfPidHandler.addAlgorithm("TrueJet_fafpf", {});
       std::array<int, 2> fafpf_pidIds{};
       for (size_t i = 0; i < fafpf_pidIds.size(); ++i) {
-          fafpf_pidIds[i] = fafpfPidHandler.addAlgorithm("TrueJet_fafpf_jet_" + std::to_string(i), {});
+          fafpf_pidIds[i] = fafpfPidHandler.addAlgorithm("TrueJet_fafpf_jet_" + ::paddedNumber(i), {});
       }
 
       LCRelationNavigator FinalColourNeutral_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::RECONSTRUCTEDPARTICLE ) ;
@@ -852,7 +862,7 @@ void TrueJet::processEvent( LCEvent * event ) {
       auto fafpi_mainPidId = fafpiPidHandler.addAlgorithm("TrueJet_fafpi", {});
       std::array<int, 25> fafpi_pidIds{};
       for (size_t i = 0; i < fafpi_pidIds.size(); ++i) {
-          fafpi_pidIds[i] = fafpiPidHandler.addAlgorithm("TrueJet_fafpi_jet_" + std::to_string(i), {});
+          fafpi_pidIds[i] = fafpiPidHandler.addAlgorithm("TrueJet_fafpi_jet_" + ::paddedNumber(i), {});
       }
 
       LCRelationNavigator InitialElementon_Nav(LCIO::RECONSTRUCTEDPARTICLE , LCIO::MCPARTICLE ) ;

--- a/Analysis/TrueJet/src/TrueJet.cc
+++ b/Analysis/TrueJet/src/TrueJet.cc
@@ -14,6 +14,13 @@
 //#include <AIDA/IHistogram1D.h>
 #endif // MARLIN_USE_AIDA
 
+#include <EVENT/ReconstructedParticle.h>
+#include <EVENT/LCRelation.h>
+#include "IMPL/LCCollectionVec.h"
+#include <IMPL/ReconstructedParticleImpl.h>
+#include <IMPL/ParticleIDImpl.h>
+#include <UTIL/PIDHandler.h>
+#include <UTIL/LCRelationNavigator.h>
 
 using namespace lcio ;
 using namespace marlin ;

--- a/Analysis/TrueJet/src/TrueJet.cc
+++ b/Analysis/TrueJet/src/TrueJet.cc
@@ -154,7 +154,7 @@ void TrueJet::processEvent( LCEvent * event ) {
     // For the concepts this method works with, see the comments in TrueJet.h
 
     evt=event;
-    streamlog_out(WARNING) << " processing event: " << evt->getEventNumber() 
+    streamlog_out(MESSAGE) << " processing event: " << evt->getEventNumber()
         << "   in run:  " << evt->getRunNumber() << std::endl ;
     streamlog_out(MESSAGE4) << " =====================================" << std::endl;
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the `TrueJet` processor use the `PIDHandler` to set the `ParticleIDs` for the different objects it creates. This sets the necessary metadata that is required, e.g. for the conversion to EDM4hep. 

ENDRELEASENOTES

Fixes key4hep/k4EDM4hep2LcioConv#62

@Zehvogel can you check whether this fixes things on your end? At least from a technical level, the algorithm names might still need some tuning, but I would also be interested to see which ones are actually hit / converted.