### PR TITLE
Add a processor for filtering ParticleIDs from ReconstructedParticles

### DIFF
--- a/Analysis/PIDTools/include/ReconstructedParticleParticleIDFilterProcessor.h
+++ b/Analysis/PIDTools/include/ReconstructedParticleParticleIDFilterProcessor.h
@@ -1,0 +1,25 @@
+#ifndef ReconstructedParticleParticleIDFilterProcessor_H
+#define ReconstructedParticleParticleIDFilterProcessor_H 1
+
+#include "marlin/Processor.h"
+
+#include <string>
+#include <vector>
+
+class ReconstructedParticleParticleIDFilterProcessor : public marlin::Processor {
+public:
+  Processor* newProcessor() override { return new ReconstructedParticleParticleIDFilterProcessor(); }
+
+  ReconstructedParticleParticleIDFilterProcessor();
+  ReconstructedParticleParticleIDFilterProcessor(const ReconstructedParticleParticleIDFilterProcessor&)            = delete;
+  ReconstructedParticleParticleIDFilterProcessor& operator=(const ReconstructedParticleParticleIDFilterProcessor&) = delete;
+  ~ReconstructedParticleParticleIDFilterProcessor()                                                                = default;
+
+  void processEvent(LCEvent* event) override;
+
+private:
+  std::string              m_inputCollName{};
+  std::vector<std::string> m_filterPidAlgos{};
+};
+
+#endif  // ReconstructedParticleParticleIDFilterProcessor_H

--- a/Analysis/PIDTools/src/ReconstructedParticleParticleIDFilterProcessor.cc
+++ b/Analysis/PIDTools/src/ReconstructedParticleParticleIDFilterProcessor.cc
@@ -54,6 +54,8 @@ struct RecoParticleIDFilterAccessor : public IMPL::ReconstructedParticleImpl {
     auto lastIt =
         std::remove_if(_pid.begin(), _pid.end(), [algoId](const auto& pid) { return (pid->getAlgorithmType() == algoId); });
 
+    // We have to take care of cleanup in this case!
+    std::for_each(lastIt, _pid.end(), [](auto& p) { delete p; });
     _pid.erase(lastIt, _pid.end());
   }
 };

--- a/Analysis/PIDTools/src/ReconstructedParticleParticleIDFilterProcessor.cc
+++ b/Analysis/PIDTools/src/ReconstructedParticleParticleIDFilterProcessor.cc
@@ -1,0 +1,99 @@
+#include "ReconstructedParticleParticleIDFilterProcessor.h"
+
+#include <EVENT/LCEvent.h>
+#include <EVENT/ReconstructedParticle.h>
+#include <Exceptions.h>
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCParametersImpl.h>
+#include <IMPL/ReconstructedParticleImpl.h>
+#include <UTIL/PIDHandler.h>
+
+#include <algorithm>
+
+ReconstructedParticleParticleIDFilterProcessor aReconstructedParticleParticleIDFilterProcessor;
+
+struct LCParametersFilterAccessor : public IMPL::LCParametersImpl {
+  void purgeAlgoMetaData(const std::string& algoName) {
+    streamlog_out(DEBUG) << "Purging ParticleID meta information for algorithm " << algoName << '\n';
+
+    auto paramNamesHandle = _stringMap.extract("ParameterNames_" + algoName);
+    if (paramNamesHandle.empty()) {
+      streamlog_out(DEBUG) << "Could not find ParameterNames_" << algoName << " to purge\n";
+    } else {
+      streamlog_out(DEBUG) << "Purged ParameterNames_" << algoName << '\n';
+    }
+  }
+};
+
+struct PIDHandlerFilterAccessor : public UTIL::PIDHandler {
+  void purgeAlgoMetaData(const std::string& algoName) {
+    auto& algoIDMap    = _cpm.map();
+    auto  nameIDHandle = algoIDMap.extract(algoName);
+    if (nameIDHandle.empty()) {
+      streamlog_out(DEBUG) << "Could not find the meta information mapping the ID to the name for " << algoName
+                           << " cannot purge it\n";
+      return;
+    } else {
+      streamlog_out(DEBUG) << "Purged meta information for algorithm " << algoName << " from metadata\n";
+    }
+
+    // Take out the parameter names meta information as well, otherwise the
+    // PIDHandler will re-insert them into the collection parameters
+    auto& paramNameMap    = _pNames;
+    auto  paramNameHandle = paramNameMap.extract(nameIDHandle.mapped());
+    if (paramNameHandle.empty()) {
+      streamlog_out(DEBUG) << "Could not find parameter names for " << algoName << " cannot purge them\n";
+    } else {
+      streamlog_out(DEBUG) << "Purged parameter names for " << algoName << " from metadata\n";
+    }
+  }
+};
+
+struct RecoParticleIDFilterAccessor : public IMPL::ReconstructedParticleImpl {
+  void purgeParticleIDAlgorithm(const int algoId) {
+    auto lastIt =
+        std::remove_if(_pid.begin(), _pid.end(), [algoId](const auto& pid) { return (pid->getAlgorithmType() == algoId); });
+
+    _pid.erase(lastIt, _pid.end());
+  }
+};
+
+ReconstructedParticleParticleIDFilterProcessor::ReconstructedParticleParticleIDFilterProcessor()
+    : marlin::Processor("ReconstructedParticleParticleIDFilterProcessor") {
+  _description = "ReconstructedParticleParticleIDFilterProcessor: Filters ParticleID objects from ReconstructedParticles";
+
+  registerInputCollection(LCIO::RECONSTRUCTEDPARTICLE, "RecoParticleCollection", "collection to filter", m_inputCollName,
+                          std::string("PandoraPFOs"));
+
+  registerProcessorParameter("FilterPIDAlgos", "PID algorithm names to filter", m_filterPidAlgos,
+                             std::vector<std::string>{});
+}
+
+void ReconstructedParticleParticleIDFilterProcessor::processEvent(LCEvent* event) {
+  try {
+    auto  recoColl      = dynamic_cast<IMPL::LCCollectionVec*>(event->getCollection(m_inputCollName));
+    auto  pidHandler    = UTIL::PIDHandler(recoColl);
+    auto& collParams    = static_cast<LCParametersFilterAccessor&>(recoColl->parameters());
+    auto& filterHandler = static_cast<PIDHandlerFilterAccessor&>(pidHandler);
+
+    for (const auto& algoName : m_filterPidAlgos) {
+      streamlog_out(DEBUG) << "Now filtering algorithm " << algoName << std::endl;
+      try {
+        const auto pidAlgoId = pidHandler.getAlgorithmID(algoName);
+        collParams.purgeAlgoMetaData(algoName);
+        filterHandler.purgeAlgoMetaData(algoName);
+
+        for (int i = 0; i < recoColl->getNumberOfElements(); ++i) {
+          auto reco = static_cast<RecoParticleIDFilterAccessor*>(recoColl->getElementAt(i));
+          reco->purgeParticleIDAlgorithm(pidAlgoId);
+        }
+      } catch (UnknownAlgorithm&) {
+        streamlog_out(WARNING) << "Cannot purge algorithm " << algoName << " from " << m_inputCollName
+                               << " because it is not known to be set on this collection" << std::endl;
+      }
+    }
+
+  } catch (DataNotAvailableException& e) {
+    streamlog_out(WARNING) << "Input collection " << m_inputCollName << " is not available" << std::endl;
+  }
+}

--- a/Analysis/PIDTools/steer/FilterParticleID.xml
+++ b/Analysis/PIDTools/steer/FilterParticleID.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<marlin>
+  <execute>
+    <processor name="ParticleIDFilter"/>
+    <processor name="FilteredOutput"/>
+  </execute>
+
+  <processor name="ParticleIDFilter" type="ReconstructedParticleParticleIDFilterProcessor">
+    <parameter name="RecoParticleCollection" type="string" value="PandoraPFOs"/>
+    <parameter name="FilterPIDAlgos" type="StringVev" value="BasicVariablePID LikelihoodPID"/>
+    <parameter name="Verbosity" type="string" value="DEBUG"/>
+  </processor>
+
+  <processor name="FilteredOutput" type="LCIOOutputProcessor">
+    <!--   standard output: full reconstruction keep all collections -->
+    <parameter name="LCIOOutputFile" type="string" >
+      filteredParticleIDs.slcio
+    </parameter>
+    <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
+    <!--parameter name="SplitFileSizekB" type="int" value="1992294"/-->
+  </processor>
+
+  <constants/>
+
+  <global>
+    <parameter name="LCIOInputFiles" value=""/>
+  </global>
+
+
+</marlin>


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a `ReconstructedParticleParticleIDFilterProcessor` that allows to filter `ParticleID` objects from existing `ReconstructedParticle`s.

ENDRELEASENOTES

This is necessary for an upcoming miniDST production and allows the further abuse of `ParticleID` as transport mechanism of potentially transient information between Marlin processors.