### PR TITLE
Fix new warnings uncovered by gcc14

### DIFF
--- a/PFOID/src/CreatePDFs.cc
+++ b/PFOID/src/CreatePDFs.cc
@@ -576,10 +576,10 @@ void CreatePDFs::processEvent( LCEvent * evt ) {
       
       if(!noCluster){
         delete helix;
-        delete ca;
-        delete cx;
-        delete cy;
-        delete cz;
+        delete[] ca;
+        delete[] cx;
+        delete[] cy;
+        delete[] cz;
         delete clsp;
       }
     }// for i ... Reco Particles


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix `mismateched-new-delete` warning uncovered by gcc14 (see [#140](https://github.com/iLCSoft/MarlinReco/issues/140))

ENDRELEASENOTES

Fixes #140 
Lifted from #141 