### PR TITLE
Switch to newer nightlies and releases for Key4hep CI

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,18 +1,35 @@
 name: keyh4ep
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: 16 4 * * 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
+  build:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22"]
+        image: ["alma9"]
+        stack: ["key4hep"]
+        include:
+          - build_type: nightly
+            image: ubuntu24
+            stack: key4hep
       fail-fast: false
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: key4hep/key4hep-actions/cache-external-data@main
     - uses: key4hep/key4hep-actions/key4hep-build@main
       with:
         build_type: ${{ matrix.build_type }}
         image: ${{ matrix.image }}
+        stack: ${{ matrix.stack }}


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch to latest available nightlies and releases for Key4hep based CI workflows
  - Add `workflow_dispatch` trigger and scheduled runs every week

ENDRELEASENOTES