### PR TITLE
Fix cone energy self-counting in IsolatedLeptonFinderProcessor

### DIFF
--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -167,7 +167,21 @@ protected:
   /** If set to true, uses Pandora particle IDs */
   bool _usePandoraIDs = false;
 
-  /* DEBUG: Map from copied PFO to original PFO */
+ /**
+ * Map from internally copied PFOs to their original input PFOs.
+ *
+ * The IsolatedLeptonFinder creates internal copies of ReconstructedParticles
+ * (e.g. for dressing leptons or producing modified output collections).
+ * However, isolation quantities such as the cone energy are defined with
+ * respect to the original input PFO collection.
+ *
+ * Since the copied PFOs are distinct objects, pointer comparisons would
+ * otherwise fail (e.g. when excluding the lepton itself from the cone),
+ * leading to incorrect self-counting in the isolation energy.
+ *
+ * This map is therefore used to recover the association to the original
+ * PFO when computing isolation-related quantities.
+ */
   std::map<ReconstructedParticle*, ReconstructedParticle*> _copy2orig;
 };
 

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -36,6 +36,11 @@ public:
   virtual void processEvent(LCEvent* evt);
   virtual void end();
 
+private:
+
+  /// Return the original PFO if this particle is a copy, otherwise return itself
+  ReconstructedParticle* findOriginal(ReconstructedParticle* pfo) const;
+
 protected:
   /** Returns true if pfo is a lepton */
   bool IsGoodLepton(ReconstructedParticle* pfo);

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -18,10 +18,10 @@
 #include <lcio.h>
 #include <marlin/Processor.h>
 
+#include "IMPL/ReconstructedParticleImpl.h"
 #include <EVENT/MCParticle.h>
 #include <EVENT/ReconstructedParticle.h>
 #include <UTIL/LCRelationNavigator.h>
-#include "IMPL/ReconstructedParticleImpl.h"
 
 class IsolatedLeptonFinderProcessor : public marlin::Processor {
 public:
@@ -29,7 +29,7 @@ public:
 
   IsolatedLeptonFinderProcessor();
 
-  IsolatedLeptonFinderProcessor(const IsolatedLeptonFinderProcessor&)            = delete;
+  IsolatedLeptonFinderProcessor(const IsolatedLeptonFinderProcessor&) = delete;
   IsolatedLeptonFinderProcessor& operator=(const IsolatedLeptonFinderProcessor&) = delete;
 
   virtual void init();
@@ -37,7 +37,6 @@ public:
   virtual void end();
 
 private:
-
   /// Return the original PFO if this particle is a copy, otherwise return itself
   ReconstructedParticle* findOriginal(ReconstructedParticle* pfo) const;
 
@@ -108,85 +107,85 @@ protected:
   /** Output collection of dressed isolated leptons */
   std::string _outputDressedIsoLepCollection{};
 
-  LCCollection*                       _pfoCol       = nullptr;
-  float                               _cosConeAngle = 0;
-  std::vector<ReconstructedParticle*> _workingList  = {};
+  LCCollection* _pfoCol = nullptr;
+  float _cosConeAngle = 0;
+  std::vector<ReconstructedParticle*> _workingList = {};
 
   /** If set to true, uses PID cuts */
-  bool  _usePID                             = false;
+  bool _usePID = false;
   float _electronMinEnergyDepositByMomentum = 0;
   float _electronMaxEnergyDepositByMomentum = 0;
-  float _electronMinEcalToHcalFraction      = 0;
-  float _electronMaxEcalToHcalFraction      = 0;
-  float _muonMinEnergyDepositByMomentum     = 0;
-  float _muonMaxEnergyDepositByMomentum     = 0;
-  float _muonMinEcalToHcalFraction          = 0;
-  float _muonMaxEcalToHcalFraction          = 0;
+  float _electronMinEcalToHcalFraction = 0;
+  float _electronMaxEcalToHcalFraction = 0;
+  float _muonMinEnergyDepositByMomentum = 0;
+  float _muonMaxEnergyDepositByMomentum = 0;
+  float _muonMinEcalToHcalFraction = 0;
+  float _muonMaxEcalToHcalFraction = 0;
 
   /** If set to true, uses impact parameter cuts */
-  bool  _useImpactParameter = false;
-  float _minD0              = 0;
-  float _maxD0              = 0;
-  float _minZ0              = 0;
-  float _maxZ0              = 0;
-  float _minR0              = 0;
-  float _maxR0              = 0;
+  bool _useImpactParameter = false;
+  float _minD0 = 0;
+  float _maxD0 = 0;
+  float _minZ0 = 0;
+  float _maxZ0 = 0;
+  float _minR0 = 0;
+  float _maxR0 = 0;
 
   /** If set to true, uses impact parameter significance cuts */
-  bool  _useImpactParameterSignificance = false;
-  float _minD0Sig                       = 0;
-  float _maxD0Sig                       = 0;
-  float _minZ0Sig                       = 0;
-  float _maxZ0Sig                       = 0;
-  float _minR0Sig                       = 0;
-  float _maxR0Sig                       = 0;
+  bool _useImpactParameterSignificance = false;
+  float _minD0Sig = 0;
+  float _maxD0Sig = 0;
+  float _minZ0Sig = 0;
+  float _maxZ0Sig = 0;
+  float _minR0Sig = 0;
+  float _maxR0Sig = 0;
 
   /** If set to true, uses rectangular cuts for isolation */
-  bool  _useRectangularIsolation = false;
-  float _isoMinTrackEnergy       = 0;
-  float _isoMaxTrackEnergy       = 0;
-  float _isoMinConeEnergy        = 0;
-  float _isoMaxConeEnergy        = 0;
+  bool _useRectangularIsolation = false;
+  float _isoMinTrackEnergy = 0;
+  float _isoMaxTrackEnergy = 0;
+  float _isoMinConeEnergy = 0;
+  float _isoMaxConeEnergy = 0;
 
   /** If set to true, uses polynomial cuts for isolation */
-  bool  _usePolynomialIsolation = false;
-  float _isoPolynomialA         = 0;
-  float _isoPolynomialB         = 0;
-  float _isoPolynomialC         = 0;
+  bool _usePolynomialIsolation = false;
+  float _isoPolynomialA = 0;
+  float _isoPolynomialB = 0;
+  float _isoPolynomialC = 0;
 
   /** If set to true, uses jet-based isolation (LAL algorithm) */
-  bool                                                     _useJetIsolation = false;
-  std::string                                              _jetCollectionName{};
+  bool _useJetIsolation = false;
+  std::string _jetCollectionName{};
   std::map<ReconstructedParticle*, ReconstructedParticle*> _rpJetMap{};
-  float                                                    _jetIsoVetoMinXt = 0;
-  float                                                    _jetIsoVetoMaxXt = 0;
-  float                                                    _jetIsoVetoMinZ  = 0;
-  float                                                    _jetIsoVetoMaxZ  = 0;
+  float _jetIsoVetoMinXt = 0;
+  float _jetIsoVetoMaxXt = 0;
+  float _jetIsoVetoMinZ = 0;
+  float _jetIsoVetoMaxZ = 0;
 
   /** If set to true, uses lepton dressing */
-  bool  _useDressedLeptons    = false;
-  bool  _mergeCloseElectrons  = false;
+  bool _useDressedLeptons = false;
+  bool _mergeCloseElectrons = false;
   float _dressPhotonConeAngle = 0;
   float _mergeLeptonConeAngle = 0;
 
   /** If set to true, uses Pandora particle IDs */
   bool _usePandoraIDs = false;
 
- /**
- * Map from internally copied PFOs to their original input PFOs.
- *
- * The IsolatedLeptonFinder creates internal copies of ReconstructedParticles
- * (e.g. for dressing leptons or producing modified output collections).
- * However, isolation quantities such as the cone energy are defined with
- * respect to the original input PFO collection.
- *
- * Since the copied PFOs are distinct objects, pointer comparisons would
- * otherwise fail (e.g. when excluding the lepton itself from the cone),
- * leading to incorrect self-counting in the isolation energy.
- *
- * This map is therefore used to recover the association to the original
- * PFO when computing isolation-related quantities.
- */
+  /**
+   * Map from internally copied PFOs to their original input PFOs.
+   *
+   * The IsolatedLeptonFinder creates internal copies of ReconstructedParticles
+   * (e.g. for dressing leptons or producing modified output collections).
+   * However, isolation quantities such as the cone energy are defined with
+   * respect to the original input PFO collection.
+   *
+   * Since the copied PFOs are distinct objects, pointer comparisons would
+   * otherwise fail (e.g. when excluding the lepton itself from the cone),
+   * leading to incorrect self-counting in the isolation energy.
+   *
+   * This map is therefore used to recover the association to the original
+   * PFO when computing isolation-related quantities.
+   */
   std::map<ReconstructedParticle*, ReconstructedParticle*> _copy2orig;
 };
 

--- a/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
+++ b/Analysis/IsolatedLeptonFinder/include/IsolatedLeptonFinderProcessor.h
@@ -18,19 +18,18 @@
 #include <lcio.h>
 #include <marlin/Processor.h>
 
-#include "IMPL/ReconstructedParticleImpl.h"
 #include <EVENT/MCParticle.h>
 #include <EVENT/ReconstructedParticle.h>
 #include <UTIL/LCRelationNavigator.h>
+#include "IMPL/ReconstructedParticleImpl.h"
 
 class IsolatedLeptonFinderProcessor : public marlin::Processor {
-
 public:
   virtual Processor* newProcessor() { return new IsolatedLeptonFinderProcessor; }
 
   IsolatedLeptonFinderProcessor();
 
-  IsolatedLeptonFinderProcessor(const IsolatedLeptonFinderProcessor&) = delete;
+  IsolatedLeptonFinderProcessor(const IsolatedLeptonFinderProcessor&)            = delete;
   IsolatedLeptonFinderProcessor& operator=(const IsolatedLeptonFinderProcessor&) = delete;
 
   virtual void init();
@@ -104,69 +103,72 @@ protected:
   /** Output collection of dressed isolated leptons */
   std::string _outputDressedIsoLepCollection{};
 
-  LCCollection* _pfoCol = nullptr;
-  float _cosConeAngle = 0;
-  std::vector<ReconstructedParticle*> _workingList = {};
+  LCCollection*                       _pfoCol       = nullptr;
+  float                               _cosConeAngle = 0;
+  std::vector<ReconstructedParticle*> _workingList  = {};
 
   /** If set to true, uses PID cuts */
-  bool _usePID = false;
+  bool  _usePID                             = false;
   float _electronMinEnergyDepositByMomentum = 0;
   float _electronMaxEnergyDepositByMomentum = 0;
-  float _electronMinEcalToHcalFraction = 0;
-  float _electronMaxEcalToHcalFraction = 0;
-  float _muonMinEnergyDepositByMomentum = 0;
-  float _muonMaxEnergyDepositByMomentum = 0;
-  float _muonMinEcalToHcalFraction = 0;
-  float _muonMaxEcalToHcalFraction = 0;
+  float _electronMinEcalToHcalFraction      = 0;
+  float _electronMaxEcalToHcalFraction      = 0;
+  float _muonMinEnergyDepositByMomentum     = 0;
+  float _muonMaxEnergyDepositByMomentum     = 0;
+  float _muonMinEcalToHcalFraction          = 0;
+  float _muonMaxEcalToHcalFraction          = 0;
 
   /** If set to true, uses impact parameter cuts */
-  bool _useImpactParameter = false;
-  float _minD0 = 0;
-  float _maxD0 = 0;
-  float _minZ0 = 0;
-  float _maxZ0 = 0;
-  float _minR0 = 0;
-  float _maxR0 = 0;
+  bool  _useImpactParameter = false;
+  float _minD0              = 0;
+  float _maxD0              = 0;
+  float _minZ0              = 0;
+  float _maxZ0              = 0;
+  float _minR0              = 0;
+  float _maxR0              = 0;
 
   /** If set to true, uses impact parameter significance cuts */
-  bool _useImpactParameterSignificance = false;
-  float _minD0Sig = 0;
-  float _maxD0Sig = 0;
-  float _minZ0Sig = 0;
-  float _maxZ0Sig = 0;
-  float _minR0Sig = 0;
-  float _maxR0Sig = 0;
+  bool  _useImpactParameterSignificance = false;
+  float _minD0Sig                       = 0;
+  float _maxD0Sig                       = 0;
+  float _minZ0Sig                       = 0;
+  float _maxZ0Sig                       = 0;
+  float _minR0Sig                       = 0;
+  float _maxR0Sig                       = 0;
 
   /** If set to true, uses rectangular cuts for isolation */
-  bool _useRectangularIsolation = false;
-  float _isoMinTrackEnergy = 0;
-  float _isoMaxTrackEnergy = 0;
-  float _isoMinConeEnergy = 0;
-  float _isoMaxConeEnergy = 0;
+  bool  _useRectangularIsolation = false;
+  float _isoMinTrackEnergy       = 0;
+  float _isoMaxTrackEnergy       = 0;
+  float _isoMinConeEnergy        = 0;
+  float _isoMaxConeEnergy        = 0;
 
   /** If set to true, uses polynomial cuts for isolation */
-  bool _usePolynomialIsolation = false;
-  float _isoPolynomialA = 0;
-  float _isoPolynomialB = 0;
-  float _isoPolynomialC = 0;
+  bool  _usePolynomialIsolation = false;
+  float _isoPolynomialA         = 0;
+  float _isoPolynomialB         = 0;
+  float _isoPolynomialC         = 0;
 
   /** If set to true, uses jet-based isolation (LAL algorithm) */
-  bool _useJetIsolation = false;
-  std::string _jetCollectionName{};
+  bool                                                     _useJetIsolation = false;
+  std::string                                              _jetCollectionName{};
   std::map<ReconstructedParticle*, ReconstructedParticle*> _rpJetMap{};
-  float _jetIsoVetoMinXt = 0;
-  float _jetIsoVetoMaxXt = 0;
-  float _jetIsoVetoMinZ = 0;
-  float _jetIsoVetoMaxZ = 0;
+  float                                                    _jetIsoVetoMinXt = 0;
+  float                                                    _jetIsoVetoMaxXt = 0;
+  float                                                    _jetIsoVetoMinZ  = 0;
+  float                                                    _jetIsoVetoMaxZ  = 0;
 
   /** If set to true, uses lepton dressing */
-  bool _useDressedLeptons = false;
-  bool _mergeCloseElectrons = false;
+  bool  _useDressedLeptons    = false;
+  bool  _mergeCloseElectrons  = false;
   float _dressPhotonConeAngle = 0;
   float _mergeLeptonConeAngle = 0;
 
   /** If set to true, uses Pandora particle IDs */
   bool _usePandoraIDs = false;
+
+  /* DEBUG: Map from copied PFO to original PFO */
+  std::map<ReconstructedParticle*, ReconstructedParticle*> _copy2orig;
 };
 
 #endif

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -169,8 +169,15 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
 
 void IsolatedLeptonFinderProcessor::init() {
   streamlog_out(DEBUG) << "   init called  " << std::endl;
-  streamlog_out(ERROR) << "### USING FIXED IsolatedLeptonFinderProcessor (local build) ###" << std::endl;
   printParameters();
+}
+
+ReconstructedParticle* IsolatedLeptonFinderProcessor::findOriginal(ReconstructedParticle* pfo) const {
+  const auto it = _copy2orig.find(pfo);
+  if (it != _copy2orig.end()) {
+    return it->second;
+  }
+  return pfo;
 }
 
 void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
@@ -460,7 +467,7 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedPolynomial(ReconstructedParticle* 
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedJet(ReconstructedParticle* pfo) {
-  ReconstructedParticle* orig = _copy2orig.count(pfo) ? _copy2orig[pfo] : pfo;
+  ReconstructedParticle* orig = findOriginal(pfo);
 
   if (_rpJetMap.find(orig) == _rpJetMap.end()) {
     // this is often the case when jet finding fails e.g. due to too few particles in event
@@ -542,7 +549,7 @@ bool IsolatedLeptonFinderProcessor::PassesImpactParameterSignificanceCuts(Recons
 }
 
 float IsolatedLeptonFinderProcessor::getConeEnergy(ReconstructedParticle* pfo) {
-  ReconstructedParticle* orig = _copy2orig.count(pfo) ? _copy2orig[pfo] : pfo;  // Get the original address
+  ReconstructedParticle* orig = findOriginal(pfo);  // Get the original address
 
   float    coneE = 0;
   TVector3 P(orig->getMomentum());

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -22,7 +22,8 @@ using namespace marlin;
 
 IsolatedLeptonFinderProcessor aIsolatedLeptonFinderProcessor;
 
-IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("IsolatedLeptonFinderProcessor"), _copy2orig() {
+IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor()
+    : Processor("IsolatedLeptonFinderProcessor"), _copy2orig() {
   // Processor description
   _description = "Isolated Lepton Finder Processor";
 
@@ -31,8 +32,8 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
                           _inputPFOsCollection, std::string("PandoraPFOs"));
 
   registerOutputCollection(LCIO::RECONSTRUCTEDPARTICLE, "OutputCollectionWithoutIsolatedLepton",
-                           "Copy of input collection but without the isolated leptons", _outputPFOsRemovedIsoLepCollection,
-                           std::string("PandoraPFOsWithoutIsoLep"));
+                           "Copy of input collection but without the isolated leptons",
+                           _outputPFOsRemovedIsoLepCollection, std::string("PandoraPFOsWithoutIsoLep"));
 
   registerOutputCollection(LCIO::RECONSTRUCTEDPARTICLE, "OutputCollectionIsolatedLeptons",
                            "Output collection of isolated leptons", _outputIsoLepCollection, std::string("Isolep"));
@@ -43,10 +44,12 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
   registerProcessorParameter("UsePID", "Use primitive particle ID based on calorimeter energy deposits", _usePID,
                              bool(true));
 
-  registerProcessorParameter("ElectronMinEnergyDepositByMomentum", "Electron ID: Minimum energy deposit divided by momentum",
+  registerProcessorParameter("ElectronMinEnergyDepositByMomentum",
+                             "Electron ID: Minimum energy deposit divided by momentum",
                              _electronMinEnergyDepositByMomentum, float(0.7));
 
-  registerProcessorParameter("ElectronMaxEnergyDepositByMomentum", "Electron ID: Maximum energy deposit divided by momentum",
+  registerProcessorParameter("ElectronMaxEnergyDepositByMomentum",
+                             "Electron ID: Maximum energy deposit divided by momentum",
                              _electronMaxEnergyDepositByMomentum, float(1.4));
 
   registerProcessorParameter("ElectronMinEcalToHcalFraction",
@@ -71,7 +74,8 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
                              "Muon ID: Maximum Ecal deposit divided by sum of Ecal and Hcal deposits",
                              _muonMaxEcalToHcalFraction, float(0.4));
 
-  registerProcessorParameter("UseImpactParameter", "Use impact parameter cuts for consistency with primary/secondary track",
+  registerProcessorParameter("UseImpactParameter",
+                             "Use impact parameter cuts for consistency with primary/secondary track",
                              _useImpactParameter, bool(true));
 
   registerProcessorParameter("ImpactParameterMinD0", "Minimum d0 impact parameter", _minD0, float(0.0));
@@ -102,11 +106,11 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
   registerProcessorParameter("ImpactParameterMaxZ0Significance", "Maximum z0 impact parameter significance", _maxZ0Sig,
                              float(1e20));
 
-  registerProcessorParameter("ImpactParameterMin3DSignificance", "Minimum impact parameter significance in 3D", _minR0Sig,
-                             float(0.0));
+  registerProcessorParameter("ImpactParameterMin3DSignificance", "Minimum impact parameter significance in 3D",
+                             _minR0Sig, float(0.0));
 
-  registerProcessorParameter("ImpactParameterMax3DSignificance", "Maximum impact parameter significance in 3D", _maxR0Sig,
-                             float(1e20));
+  registerProcessorParameter("ImpactParameterMax3DSignificance", "Maximum impact parameter significance in 3D",
+                             _maxR0Sig, float(1e20));
 
   registerProcessorParameter("UseRectangularIsolation", "Use rectangular cuts on track and cone energy",
                              _useRectangularIsolation, bool(true));
@@ -143,16 +147,20 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
   registerInputCollection(LCIO::RECONSTRUCTEDPARTICLE, "JetCollection", "Input collection of jets for isolation",
                           _jetCollectionName, std::string("JetsForIsolation"));
 
-  registerProcessorParameter("JetIsolationVetoMinimumXt", "Minimum Xt in jet-based isolation", _jetIsoVetoMinXt, float(0.));
+  registerProcessorParameter("JetIsolationVetoMinimumXt", "Minimum Xt in jet-based isolation", _jetIsoVetoMinXt,
+                             float(0.));
 
   registerProcessorParameter("JetIsolationVetoMaximumXt", "Maximum Xt in jet-based isolation", _jetIsoVetoMaxXt,
                              float(0.25));
 
-  registerProcessorParameter("JetIsolationVetoMinimumZ", "Mininum Z in jet-based isolation", _jetIsoVetoMinZ, float(0.));
+  registerProcessorParameter("JetIsolationVetoMinimumZ", "Mininum Z in jet-based isolation", _jetIsoVetoMinZ,
+                             float(0.));
 
-  registerProcessorParameter("JetIsolationVetoMaximumZ", "Maximum Z in jet-based isolation", _jetIsoVetoMaxZ, float(0.6));
+  registerProcessorParameter("JetIsolationVetoMaximumZ", "Maximum Z in jet-based isolation", _jetIsoVetoMaxZ,
+                             float(0.6));
 
-  registerProcessorParameter("UseDressedLeptons", "Dress leptons with close-by particles", _useDressedLeptons, bool(false));
+  registerProcessorParameter("UseDressedLeptons", "Dress leptons with close-by particles", _useDressedLeptons,
+                             bool(false));
 
   registerProcessorParameter("MergeCloseElectrons", "Merge close-by electrons into higher energy lepton",
                              _mergeCloseElectrons, bool(false));
@@ -181,7 +189,7 @@ ReconstructedParticle* IsolatedLeptonFinderProcessor::findOriginal(Reconstructed
 }
 
 void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
-  _copy2orig.clear();  //Clear copy-origin map
+  _copy2orig.clear(); // Clear copy-origin map
 
   streamlog_out(DEBUG) << std::endl;
   streamlog_out(DEBUG) << "processing event: " << evt->getEventNumber() << "   in run:  " << evt->getRunNumber()
@@ -200,11 +208,11 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
   // Prepare jet/recoparticle map for jet-based isolation
   if (_useJetIsolation) {
     LCCollection* colJet = evt->getCollection(_jetCollectionName);
-    int           njet   = colJet->getNumberOfElements();
+    int njet = colJet->getNumberOfElements();
     for (int i = 0; i < njet; ++i) {
       ReconstructedParticle* jet = static_cast<ReconstructedParticle*>(colJet->getElementAt(i));
-      for (ReconstructedParticleVec::const_iterator iter = jet->getParticles().begin(); iter != jet->getParticles().end();
-           ++iter) {
+      for (ReconstructedParticleVec::const_iterator iter = jet->getParticles().begin();
+           iter != jet->getParticles().end(); ++iter) {
         _rpJetMap.insert(std::make_pair(*iter, jet));
       }
     }
@@ -212,7 +220,7 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
 
   // Determine lepton pfos
   std::vector<int> goodLeptonIndices;
-  int              npfo = _pfoCol->getNumberOfElements();
+  int npfo = _pfoCol->getNumberOfElements();
   for (int i = 0; i < npfo; i++) {
     ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(i));
     _workingList.push_back(pfo);
@@ -236,9 +244,10 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
 
   // process and save leptons
   for (unsigned int i = 0; i < goodLeptonIndices.size(); ++i) {
-    ReconstructedParticle*     pfo_tmp = static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(goodLeptonIndices.at(i)));
-    ReconstructedParticleImpl* pfo     = CopyReconstructedParticle(pfo_tmp);
-    _copy2orig[pfo]                    = pfo_tmp;  // Map the address copy-original
+    ReconstructedParticle* pfo_tmp =
+        static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(goodLeptonIndices.at(i)));
+    ReconstructedParticleImpl* pfo = CopyReconstructedParticle(pfo_tmp);
+    _copy2orig[pfo] = pfo_tmp; // Map the address copy-original
 
     if (_useDressedLeptons) {
       // don't reprocess merged leptons
@@ -246,14 +255,16 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
         continue;
       }
 
-      double energy_before         = pfo->getEnergy();
-      int    n_working_list_before = _workingList.size();
+      double energy_before = pfo->getEnergy();
+      int n_working_list_before = _workingList.size();
 
       dressLepton(pfo, goodLeptonIndices.at(i));
 
       streamlog_out(DEBUG) << "dress lepton " << i << " with " << n_working_list_before - _workingList.size()
                            << " particles: energy " << energy_before << " -> " << pfo->getEnergy() << std::endl;
-      // printf("dressedMomentum: %.2f -> %.2f, %.2f -> %.2f ,%.2f -> %.2f ,%.2f -> %.2f\n", pfo_tmp->getMomentum()[0], pfo->getMomentum()[0], pfo_tmp->getMomentum()[1], pfo->getMomentum()[1], pfo_tmp->getMomentum()[2], pfo->getMomentum()[2], pfo->getEnergy(), pfo_tmp->getEnergy());
+      // printf("dressedMomentum: %.2f -> %.2f, %.2f -> %.2f ,%.2f -> %.2f ,%.2f -> %.2f\n", pfo_tmp->getMomentum()[0],
+      // pfo->getMomentum()[0], pfo_tmp->getMomentum()[1], pfo->getMomentum()[1], pfo_tmp->getMomentum()[2],
+      // pfo->getMomentum()[2], pfo->getEnergy(), pfo_tmp->getEnergy());
     }
 
     if (IsIsolatedLepton(pfo)) {
@@ -269,8 +280,8 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
     if (std::find(goodLeptonIndices.begin(), goodLeptonIndices.end(), i) != goodLeptonIndices.end()) {
       continue;
     }
-    ReconstructedParticle*     pfo_tmp = static_cast<ReconstructedParticle*>(_workingList.at(i));
-    ReconstructedParticleImpl* pfo     = CopyReconstructedParticle(pfo_tmp);
+    ReconstructedParticle* pfo_tmp = static_cast<ReconstructedParticle*>(_workingList.at(i));
+    ReconstructedParticleImpl* pfo = CopyReconstructedParticle(pfo_tmp);
     outPFOsRemovedIsoLepCol->addElement(pfo);
   }
 
@@ -279,15 +290,15 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
   evt->addCollection(outIsoLepCol.release(), _outputIsoLepCollection.c_str());
 }
 void IsolatedLeptonFinderProcessor::dressLepton(ReconstructedParticleImpl* pfo, int PFO_idx) {
-  TVector3         P_lep(pfo->getMomentum());
-  int              npfo = _pfoCol->getNumberOfElements();
+  TVector3 P_lep(pfo->getMomentum());
+  int npfo = _pfoCol->getNumberOfElements();
   std::vector<int> _dressedPFOs{};
   for (int i = 0; i < npfo; i++) {
     ReconstructedParticle* pfo_dress = static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(i));
 
     // only add photons and electrons
-    bool isPhoton   = IsPhoton(pfo_dress);
-    bool isElectron = !isPhoton && IsElectron(pfo_dress);  // avoid electrons identified as photons to enter as both
+    bool isPhoton = IsPhoton(pfo_dress);
+    bool isElectron = !isPhoton && IsElectron(pfo_dress); // avoid electrons identified as photons to enter as both
     if (!isPhoton && !isElectron)
       continue;
 
@@ -299,7 +310,7 @@ void IsolatedLeptonFinderProcessor::dressLepton(ReconstructedParticleImpl* pfo, 
       continue;
 
     TVector3 Pdress(pfo_dress->getMomentum());
-    float    theta = TMath::ACos(P_lep.Dot(Pdress) / (P_lep.Mag() * Pdress.Mag())) * 360 / (2 * TMath::Pi());
+    float theta = TMath::ACos(P_lep.Dot(Pdress) / (P_lep.Mag() * Pdress.Mag())) * 360 / (2 * TMath::Pi());
 
     if ((isPhoton && theta <= _dressPhotonConeAngle) || (isElectron && theta <= _mergeLeptonConeAngle)) {
       if (std::find(_dressedPFOs.begin(), _dressedPFOs.end(), i) != _dressedPFOs.end()) {
@@ -310,22 +321,23 @@ void IsolatedLeptonFinderProcessor::dressLepton(ReconstructedParticleImpl* pfo, 
           streamlog_out(DEBUG) << "WARNING: lepton " << i << " with theta " << theta << " and type " << pfo->getType()
                                << " already close to another lepton!" << std::endl;
         }
-        // printf(" -- this lep: %.2f, %.2f ,%.2f ,%.2f\n", pfo->getMomentum()[0], pfo->getMomentum()[1], pfo->getMomentum()[2], pfo->getEnergy());
+        // printf(" -- this lep: %.2f, %.2f ,%.2f ,%.2f\n", pfo->getMomentum()[0], pfo->getMomentum()[1],
+        // pfo->getMomentum()[2], pfo->getEnergy());
         continue;
       }
       if (isPhoton) {
-        streamlog_out(DEBUG) << "MESSAGE: dressing photon " << i << " with theta " << theta << " and type " << pfo->getType()
-                             << std::endl;
+        streamlog_out(DEBUG) << "MESSAGE: dressing photon " << i << " with theta " << theta << " and type "
+                             << pfo->getType() << std::endl;
       } else if (isElectron) {
-        streamlog_out(DEBUG) << "MESSAGE: merging lepton " << i << " with theta " << theta << " and type " << pfo->getType()
-                             << std::endl;
+        streamlog_out(DEBUG) << "MESSAGE: merging lepton " << i << " with theta " << theta << " and type "
+                             << pfo->getType() << std::endl;
       }
       _dressedPFOs.push_back(i);
       _workingList.erase(std::remove(_workingList.begin(), _workingList.end(), pfo_dress), _workingList.end());
       double dressedMomentum[3] = {pfo->getMomentum()[0] + pfo_dress->getMomentum()[0],
                                    pfo->getMomentum()[1] + pfo_dress->getMomentum()[1],
                                    pfo->getMomentum()[2] + pfo_dress->getMomentum()[2]};
-      double dressedE           = pfo->getEnergy() + pfo_dress->getEnergy();
+      double dressedE = pfo->getEnergy() + pfo_dress->getEnergy();
       pfo->setMomentum(dressedMomentum);
       pfo->setEnergy(dressedE);
     }
@@ -374,11 +386,11 @@ bool IsolatedLeptonFinderProcessor::IsElectron(ReconstructedParticle* pfo) {
 
   float CalE[2];
   getCalEnergy(pfo, CalE);
-  double ecale    = CalE[0];
-  double hcale    = CalE[1];
-  double p        = TVector3(pfo->getMomentum()).Mag();
-  double calByP   = p > 0 ? (ecale + hcale) / p : 0;
-  double calSum   = ecale + hcale;
+  double ecale = CalE[0];
+  double hcale = CalE[1];
+  double p = TVector3(pfo->getMomentum()).Mag();
+  double calByP = p > 0 ? (ecale + hcale) / p : 0;
+  double calSum = ecale + hcale;
   double ecalFrac = calSum > 0 ? ecale / calSum : 0;
 
   if (calByP >= _electronMinEnergyDepositByMomentum && calByP <= _electronMaxEnergyDepositByMomentum &&
@@ -393,11 +405,11 @@ bool IsolatedLeptonFinderProcessor::IsMuon(ReconstructedParticle* pfo) {
 
   float CalE[2];
   getCalEnergy(pfo, CalE);
-  double ecale    = CalE[0];
-  double hcale    = CalE[1];
-  double p        = TVector3(pfo->getMomentum()).Mag();
-  double calByP   = p > 0 ? (ecale + hcale) / p : 0;
-  double calSum   = ecale + hcale;
+  double ecale = CalE[0];
+  double hcale = CalE[1];
+  double p = TVector3(pfo->getMomentum()).Mag();
+  double calByP = p > 0 ? (ecale + hcale) / p : 0;
+  double calSum = ecale + hcale;
   double ecalFrac = calSum > 0 ? ecale / calSum : 0;
 
   if (calByP >= _muonMinEnergyDepositByMomentum && calByP <= _muonMaxEnergyDepositByMomentum &&
@@ -442,7 +454,7 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedLepton(ReconstructedParticle* pfo)
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedRectangular(ReconstructedParticle* pfo) {
-  float E     = pfo->getEnergy();
+  float E = pfo->getEnergy();
   float coneE = getConeEnergy(pfo);
 
   if (E < _isoMinTrackEnergy)
@@ -458,7 +470,7 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedRectangular(ReconstructedParticle*
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedPolynomial(ReconstructedParticle* pfo) {
-  float E     = pfo->getEnergy();
+  float E = pfo->getEnergy();
   float coneE = getConeEnergy(pfo);
 
   if (coneE * coneE <= _isoPolynomialA * E * E + _isoPolynomialB * E + _isoPolynomialC)
@@ -471,20 +483,21 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedJet(ReconstructedParticle* pfo) {
 
   if (_rpJetMap.find(orig) == _rpJetMap.end()) {
     // this is often the case when jet finding fails e.g. due to too few particles in event
-    //Use original address
+    // Use original address
     return false;
   }
 
   ReconstructedParticle* jet = _rpJetMap[orig];
-  TVector3               vec1(orig->getMomentum());
-  TVector3               jetmom(jet->getMomentum());
-  TLorentzVector         jetmom4(jet->getMomentum(), jet->getEnergy());
+  TVector3 vec1(orig->getMomentum());
+  TVector3 jetmom(jet->getMomentum());
+  TLorentzVector jetmom4(jet->getMomentum(), jet->getEnergy());
 
   float jetxt = vec1.Pt(jetmom) / jetmom4.M();
-  float jetz  = orig->getEnergy() / jet->getEnergy();
+  float jetz = orig->getEnergy() / jet->getEnergy();
 
-  if (jetxt >= _jetIsoVetoMinXt && jetxt < _jetIsoVetoMaxXt && jetz >= _jetIsoVetoMinZ && jetz < _jetIsoVetoMaxZ)
+  if (jetxt >= _jetIsoVetoMinXt && jetxt < _jetIsoVetoMaxXt && jetz >= _jetIsoVetoMinZ && jetz < _jetIsoVetoMaxZ) {
     return false;
+  }
 
   return true;
 }
@@ -523,8 +536,8 @@ bool IsolatedLeptonFinderProcessor::PassesImpactParameterSignificanceCuts(Recons
     return false;
 
   // TODO: more sophisticated pfo/track matching
-  float d0    = fabs(trkvec[0]->getD0());
-  float z0    = fabs(trkvec[0]->getZ0());
+  float d0 = fabs(trkvec[0]->getD0());
+  float z0 = fabs(trkvec[0]->getZ0());
   float d0err = sqrt(trkvec[0]->getCovMatrix()[0]);
   float z0err = sqrt(trkvec[0]->getCovMatrix()[9]);
 
@@ -549,9 +562,9 @@ bool IsolatedLeptonFinderProcessor::PassesImpactParameterSignificanceCuts(Recons
 }
 
 float IsolatedLeptonFinderProcessor::getConeEnergy(ReconstructedParticle* pfo) {
-  ReconstructedParticle* orig = findOriginal(pfo);  // Get the original address
+  ReconstructedParticle* orig = findOriginal(pfo); // Get the original address
 
-  float    coneE = 0;
+  float coneE = 0;
   TVector3 P(orig->getMomentum());
 
   int npfo = _workingList.size();
@@ -575,10 +588,11 @@ float IsolatedLeptonFinderProcessor::getConeEnergy(ReconstructedParticle* pfo) {
 }
 
 void IsolatedLeptonFinderProcessor::getCalEnergy(ReconstructedParticle* pfo, float* cale) {
-  float                       ecal     = 0;
-  float                       hcal     = 0;
+  float ecal = 0;
+  float hcal = 0;
   std::vector<lcio::Cluster*> clusters = pfo->getClusters();
-  for (std::vector<lcio::Cluster*>::const_iterator iCluster = clusters.begin(); iCluster != clusters.end(); ++iCluster) {
+  for (std::vector<lcio::Cluster*>::const_iterator iCluster = clusters.begin(); iCluster != clusters.end();
+       ++iCluster) {
     ecal += (*iCluster)->getSubdetectorEnergies()[0];
     hcal += (*iCluster)->getSubdetectorEnergies()[1];
   }

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -358,7 +358,6 @@ ReconstructedParticleImpl* IsolatedLeptonFinderProcessor::CopyReconstructedParti
   pfo->setGoodnessOfPID(pfo_orig->getGoodnessOfPID());
   pfo->setStartVertex(pfo_orig->getStartVertex());
 
-  // FIXED
   for (unsigned int i = 0; i < pfo_orig->getTracks().size(); i++) {
     pfo->addTrack(pfo_orig->getTracks()[i]);
   }
@@ -479,11 +478,11 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedPolynomial(ReconstructedParticle* 
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedJet(ReconstructedParticle* pfo) {
+    // jet-based isolated lepton (LAL algorithm)
   ReconstructedParticle* orig = findOriginal(pfo);
 
   if (_rpJetMap.find(orig) == _rpJetMap.end()) {
     // this is often the case when jet finding fails e.g. due to too few particles in event
-    // Use original address
     return false;
   }
 

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -478,7 +478,7 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedPolynomial(ReconstructedParticle* 
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedJet(ReconstructedParticle* pfo) {
-    // jet-based isolated lepton (LAL algorithm)
+  // jet-based isolated lepton (LAL algorithm)
   ReconstructedParticle* orig = findOriginal(pfo);
 
   if (_rpJetMap.find(orig) == _rpJetMap.end()) {

--- a/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
+++ b/Analysis/IsolatedLeptonFinder/src/IsolatedLeptonFinderProcessor.cc
@@ -22,8 +22,7 @@ using namespace marlin;
 
 IsolatedLeptonFinderProcessor aIsolatedLeptonFinderProcessor;
 
-IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("IsolatedLeptonFinderProcessor") {
-
+IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("IsolatedLeptonFinderProcessor"), _copy2orig() {
   // Processor description
   _description = "Isolated Lepton Finder Processor";
 
@@ -32,8 +31,8 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
                           _inputPFOsCollection, std::string("PandoraPFOs"));
 
   registerOutputCollection(LCIO::RECONSTRUCTEDPARTICLE, "OutputCollectionWithoutIsolatedLepton",
-                           "Copy of input collection but without the isolated leptons",
-                           _outputPFOsRemovedIsoLepCollection, std::string("PandoraPFOsWithoutIsoLep"));
+                           "Copy of input collection but without the isolated leptons", _outputPFOsRemovedIsoLepCollection,
+                           std::string("PandoraPFOsWithoutIsoLep"));
 
   registerOutputCollection(LCIO::RECONSTRUCTEDPARTICLE, "OutputCollectionIsolatedLeptons",
                            "Output collection of isolated leptons", _outputIsoLepCollection, std::string("Isolep"));
@@ -44,12 +43,10 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
   registerProcessorParameter("UsePID", "Use primitive particle ID based on calorimeter energy deposits", _usePID,
                              bool(true));
 
-  registerProcessorParameter("ElectronMinEnergyDepositByMomentum",
-                             "Electron ID: Minimum energy deposit divided by momentum",
+  registerProcessorParameter("ElectronMinEnergyDepositByMomentum", "Electron ID: Minimum energy deposit divided by momentum",
                              _electronMinEnergyDepositByMomentum, float(0.7));
 
-  registerProcessorParameter("ElectronMaxEnergyDepositByMomentum",
-                             "Electron ID: Maximum energy deposit divided by momentum",
+  registerProcessorParameter("ElectronMaxEnergyDepositByMomentum", "Electron ID: Maximum energy deposit divided by momentum",
                              _electronMaxEnergyDepositByMomentum, float(1.4));
 
   registerProcessorParameter("ElectronMinEcalToHcalFraction",
@@ -74,8 +71,7 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
                              "Muon ID: Maximum Ecal deposit divided by sum of Ecal and Hcal deposits",
                              _muonMaxEcalToHcalFraction, float(0.4));
 
-  registerProcessorParameter("UseImpactParameter",
-                             "Use impact parameter cuts for consistency with primary/secondary track",
+  registerProcessorParameter("UseImpactParameter", "Use impact parameter cuts for consistency with primary/secondary track",
                              _useImpactParameter, bool(true));
 
   registerProcessorParameter("ImpactParameterMinD0", "Minimum d0 impact parameter", _minD0, float(0.0));
@@ -106,11 +102,11 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
   registerProcessorParameter("ImpactParameterMaxZ0Significance", "Maximum z0 impact parameter significance", _maxZ0Sig,
                              float(1e20));
 
-  registerProcessorParameter("ImpactParameterMin3DSignificance", "Minimum impact parameter significance in 3D",
-                             _minR0Sig, float(0.0));
+  registerProcessorParameter("ImpactParameterMin3DSignificance", "Minimum impact parameter significance in 3D", _minR0Sig,
+                             float(0.0));
 
-  registerProcessorParameter("ImpactParameterMax3DSignificance", "Maximum impact parameter significance in 3D",
-                             _maxR0Sig, float(1e20));
+  registerProcessorParameter("ImpactParameterMax3DSignificance", "Maximum impact parameter significance in 3D", _maxR0Sig,
+                             float(1e20));
 
   registerProcessorParameter("UseRectangularIsolation", "Use rectangular cuts on track and cone energy",
                              _useRectangularIsolation, bool(true));
@@ -147,20 +143,16 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
   registerInputCollection(LCIO::RECONSTRUCTEDPARTICLE, "JetCollection", "Input collection of jets for isolation",
                           _jetCollectionName, std::string("JetsForIsolation"));
 
-  registerProcessorParameter("JetIsolationVetoMinimumXt", "Minimum Xt in jet-based isolation", _jetIsoVetoMinXt,
-                             float(0.));
+  registerProcessorParameter("JetIsolationVetoMinimumXt", "Minimum Xt in jet-based isolation", _jetIsoVetoMinXt, float(0.));
 
   registerProcessorParameter("JetIsolationVetoMaximumXt", "Maximum Xt in jet-based isolation", _jetIsoVetoMaxXt,
                              float(0.25));
 
-  registerProcessorParameter("JetIsolationVetoMinimumZ", "Mininum Z in jet-based isolation", _jetIsoVetoMinZ,
-                             float(0.));
+  registerProcessorParameter("JetIsolationVetoMinimumZ", "Mininum Z in jet-based isolation", _jetIsoVetoMinZ, float(0.));
 
-  registerProcessorParameter("JetIsolationVetoMaximumZ", "Maximum Z in jet-based isolation", _jetIsoVetoMaxZ,
-                             float(0.6));
+  registerProcessorParameter("JetIsolationVetoMaximumZ", "Maximum Z in jet-based isolation", _jetIsoVetoMaxZ, float(0.6));
 
-  registerProcessorParameter("UseDressedLeptons", "Dress leptons with close-by particles", _useDressedLeptons,
-                             bool(false));
+  registerProcessorParameter("UseDressedLeptons", "Dress leptons with close-by particles", _useDressedLeptons, bool(false));
 
   registerProcessorParameter("MergeCloseElectrons", "Merge close-by electrons into higher energy lepton",
                              _mergeCloseElectrons, bool(false));
@@ -177,10 +169,12 @@ IsolatedLeptonFinderProcessor::IsolatedLeptonFinderProcessor() : Processor("Isol
 
 void IsolatedLeptonFinderProcessor::init() {
   streamlog_out(DEBUG) << "   init called  " << std::endl;
+  streamlog_out(ERROR) << "### USING FIXED IsolatedLeptonFinderProcessor (local build) ###" << std::endl;
   printParameters();
 }
 
 void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
+  _copy2orig.clear();  //Clear copy-origin map
 
   streamlog_out(DEBUG) << std::endl;
   streamlog_out(DEBUG) << "processing event: " << evt->getEventNumber() << "   in run:  " << evt->getRunNumber()
@@ -199,11 +193,11 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
   // Prepare jet/recoparticle map for jet-based isolation
   if (_useJetIsolation) {
     LCCollection* colJet = evt->getCollection(_jetCollectionName);
-    int njet = colJet->getNumberOfElements();
+    int           njet   = colJet->getNumberOfElements();
     for (int i = 0; i < njet; ++i) {
       ReconstructedParticle* jet = static_cast<ReconstructedParticle*>(colJet->getElementAt(i));
-      for (ReconstructedParticleVec::const_iterator iter = jet->getParticles().begin();
-           iter != jet->getParticles().end(); ++iter) {
+      for (ReconstructedParticleVec::const_iterator iter = jet->getParticles().begin(); iter != jet->getParticles().end();
+           ++iter) {
         _rpJetMap.insert(std::make_pair(*iter, jet));
       }
     }
@@ -211,7 +205,7 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
 
   // Determine lepton pfos
   std::vector<int> goodLeptonIndices;
-  int npfo = _pfoCol->getNumberOfElements();
+  int              npfo = _pfoCol->getNumberOfElements();
   for (int i = 0; i < npfo; i++) {
     ReconstructedParticle* pfo = static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(i));
     _workingList.push_back(pfo);
@@ -235,9 +229,9 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
 
   // process and save leptons
   for (unsigned int i = 0; i < goodLeptonIndices.size(); ++i) {
-    ReconstructedParticle* pfo_tmp =
-        static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(goodLeptonIndices.at(i)));
-    ReconstructedParticleImpl* pfo = CopyReconstructedParticle(pfo_tmp);
+    ReconstructedParticle*     pfo_tmp = static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(goodLeptonIndices.at(i)));
+    ReconstructedParticleImpl* pfo     = CopyReconstructedParticle(pfo_tmp);
+    _copy2orig[pfo]                    = pfo_tmp;  // Map the address copy-original
 
     if (_useDressedLeptons) {
       // don't reprocess merged leptons
@@ -245,16 +239,14 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
         continue;
       }
 
-      double energy_before = pfo->getEnergy();
-      int n_working_list_before = _workingList.size();
+      double energy_before         = pfo->getEnergy();
+      int    n_working_list_before = _workingList.size();
 
       dressLepton(pfo, goodLeptonIndices.at(i));
 
       streamlog_out(DEBUG) << "dress lepton " << i << " with " << n_working_list_before - _workingList.size()
                            << " particles: energy " << energy_before << " -> " << pfo->getEnergy() << std::endl;
-      // printf("dressedMomentum: %.2f -> %.2f, %.2f -> %.2f ,%.2f -> %.2f ,%.2f -> %.2f\n", pfo_tmp->getMomentum()[0],
-      // pfo->getMomentum()[0], pfo_tmp->getMomentum()[1], pfo->getMomentum()[1], pfo_tmp->getMomentum()[2],
-      // pfo->getMomentum()[2], pfo->getEnergy(), pfo_tmp->getEnergy());
+      // printf("dressedMomentum: %.2f -> %.2f, %.2f -> %.2f ,%.2f -> %.2f ,%.2f -> %.2f\n", pfo_tmp->getMomentum()[0], pfo->getMomentum()[0], pfo_tmp->getMomentum()[1], pfo->getMomentum()[1], pfo_tmp->getMomentum()[2], pfo->getMomentum()[2], pfo->getEnergy(), pfo_tmp->getEnergy());
     }
 
     if (IsIsolatedLepton(pfo)) {
@@ -270,8 +262,8 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
     if (std::find(goodLeptonIndices.begin(), goodLeptonIndices.end(), i) != goodLeptonIndices.end()) {
       continue;
     }
-    ReconstructedParticle* pfo_tmp = static_cast<ReconstructedParticle*>(_workingList.at(i));
-    ReconstructedParticleImpl* pfo = CopyReconstructedParticle(pfo_tmp);
+    ReconstructedParticle*     pfo_tmp = static_cast<ReconstructedParticle*>(_workingList.at(i));
+    ReconstructedParticleImpl* pfo     = CopyReconstructedParticle(pfo_tmp);
     outPFOsRemovedIsoLepCol->addElement(pfo);
   }
 
@@ -280,15 +272,15 @@ void IsolatedLeptonFinderProcessor::processEvent(LCEvent* evt) {
   evt->addCollection(outIsoLepCol.release(), _outputIsoLepCollection.c_str());
 }
 void IsolatedLeptonFinderProcessor::dressLepton(ReconstructedParticleImpl* pfo, int PFO_idx) {
-  TVector3 P_lep(pfo->getMomentum());
-  int npfo = _pfoCol->getNumberOfElements();
+  TVector3         P_lep(pfo->getMomentum());
+  int              npfo = _pfoCol->getNumberOfElements();
   std::vector<int> _dressedPFOs{};
   for (int i = 0; i < npfo; i++) {
     ReconstructedParticle* pfo_dress = static_cast<ReconstructedParticle*>(_pfoCol->getElementAt(i));
 
     // only add photons and electrons
-    bool isPhoton = IsPhoton(pfo_dress);
-    bool isElectron = !isPhoton && IsElectron(pfo_dress); // avoid electrons identified as photons to enter as both
+    bool isPhoton   = IsPhoton(pfo_dress);
+    bool isElectron = !isPhoton && IsElectron(pfo_dress);  // avoid electrons identified as photons to enter as both
     if (!isPhoton && !isElectron)
       continue;
 
@@ -300,7 +292,7 @@ void IsolatedLeptonFinderProcessor::dressLepton(ReconstructedParticleImpl* pfo, 
       continue;
 
     TVector3 Pdress(pfo_dress->getMomentum());
-    float theta = TMath::ACos(P_lep.Dot(Pdress) / (P_lep.Mag() * Pdress.Mag())) * 360 / (2 * TMath::Pi());
+    float    theta = TMath::ACos(P_lep.Dot(Pdress) / (P_lep.Mag() * Pdress.Mag())) * 360 / (2 * TMath::Pi());
 
     if ((isPhoton && theta <= _dressPhotonConeAngle) || (isElectron && theta <= _mergeLeptonConeAngle)) {
       if (std::find(_dressedPFOs.begin(), _dressedPFOs.end(), i) != _dressedPFOs.end()) {
@@ -311,32 +303,32 @@ void IsolatedLeptonFinderProcessor::dressLepton(ReconstructedParticleImpl* pfo, 
           streamlog_out(DEBUG) << "WARNING: lepton " << i << " with theta " << theta << " and type " << pfo->getType()
                                << " already close to another lepton!" << std::endl;
         }
-        // printf(" -- this lep: %.2f, %.2f ,%.2f ,%.2f\n", pfo->getMomentum()[0], pfo->getMomentum()[1],
-        // pfo->getMomentum()[2], pfo->getEnergy());
+        // printf(" -- this lep: %.2f, %.2f ,%.2f ,%.2f\n", pfo->getMomentum()[0], pfo->getMomentum()[1], pfo->getMomentum()[2], pfo->getEnergy());
         continue;
       }
       if (isPhoton) {
-        streamlog_out(DEBUG) << "MESSAGE: dressing photon " << i << " with theta " << theta << " and type "
-                             << pfo->getType() << std::endl;
+        streamlog_out(DEBUG) << "MESSAGE: dressing photon " << i << " with theta " << theta << " and type " << pfo->getType()
+                             << std::endl;
       } else if (isElectron) {
-        streamlog_out(DEBUG) << "MESSAGE: merging lepton " << i << " with theta " << theta << " and type "
-                             << pfo->getType() << std::endl;
+        streamlog_out(DEBUG) << "MESSAGE: merging lepton " << i << " with theta " << theta << " and type " << pfo->getType()
+                             << std::endl;
       }
       _dressedPFOs.push_back(i);
       _workingList.erase(std::remove(_workingList.begin(), _workingList.end(), pfo_dress), _workingList.end());
       double dressedMomentum[3] = {pfo->getMomentum()[0] + pfo_dress->getMomentum()[0],
                                    pfo->getMomentum()[1] + pfo_dress->getMomentum()[1],
                                    pfo->getMomentum()[2] + pfo_dress->getMomentum()[2]};
-      double dressedE = pfo->getEnergy() + pfo_dress->getEnergy();
+      double dressedE           = pfo->getEnergy() + pfo_dress->getEnergy();
       pfo->setMomentum(dressedMomentum);
       pfo->setEnergy(dressedE);
     }
   }
 }
 void IsolatedLeptonFinderProcessor::end() {}
+
 ReconstructedParticleImpl* IsolatedLeptonFinderProcessor::CopyReconstructedParticle(ReconstructedParticle* pfo_orig) {
-  // copy this in an ugly fashion to be modifiable - a versatile copy constructor would be much better!
   ReconstructedParticleImpl* pfo = new ReconstructedParticleImpl();
+
   pfo->setMomentum(pfo_orig->getMomentum());
   pfo->setEnergy(pfo_orig->getEnergy());
   pfo->setType(pfo_orig->getType());
@@ -346,14 +338,18 @@ ReconstructedParticleImpl* IsolatedLeptonFinderProcessor::CopyReconstructedParti
   pfo->setParticleIDUsed(pfo_orig->getParticleIDUsed());
   pfo->setGoodnessOfPID(pfo_orig->getGoodnessOfPID());
   pfo->setStartVertex(pfo_orig->getStartVertex());
-  for (unsigned int i = 0; i < pfo->getTracks().size(); i++) {
+
+  // FIXED
+  for (unsigned int i = 0; i < pfo_orig->getTracks().size(); i++) {
     pfo->addTrack(pfo_orig->getTracks()[i]);
   }
-  for (unsigned int i = 0; i < pfo->getClusters().size(); i++) {
+  for (unsigned int i = 0; i < pfo_orig->getClusters().size(); i++) {
     pfo->addCluster(pfo_orig->getClusters()[i]);
   }
+
   return pfo;
 }
+
 bool IsolatedLeptonFinderProcessor::IsCharged(ReconstructedParticle* pfo) {
   if (pfo->getCharge() == 0)
     return false;
@@ -366,17 +362,16 @@ bool IsolatedLeptonFinderProcessor::IsPhoton(ReconstructedParticle* pfo) {
   return false;
 }
 bool IsolatedLeptonFinderProcessor::IsElectron(ReconstructedParticle* pfo) {
-
   if (_usePandoraIDs)
     return (abs(pfo->getType()) == 11);
 
   float CalE[2];
   getCalEnergy(pfo, CalE);
-  double ecale = CalE[0];
-  double hcale = CalE[1];
-  double p = TVector3(pfo->getMomentum()).Mag();
-  double calByP = p > 0 ? (ecale + hcale) / p : 0;
-  double calSum = ecale + hcale;
+  double ecale    = CalE[0];
+  double hcale    = CalE[1];
+  double p        = TVector3(pfo->getMomentum()).Mag();
+  double calByP   = p > 0 ? (ecale + hcale) / p : 0;
+  double calSum   = ecale + hcale;
   double ecalFrac = calSum > 0 ? ecale / calSum : 0;
 
   if (calByP >= _electronMinEnergyDepositByMomentum && calByP <= _electronMaxEnergyDepositByMomentum &&
@@ -386,17 +381,16 @@ bool IsolatedLeptonFinderProcessor::IsElectron(ReconstructedParticle* pfo) {
   return false;
 }
 bool IsolatedLeptonFinderProcessor::IsMuon(ReconstructedParticle* pfo) {
-
   if (_usePandoraIDs)
     return (abs(pfo->getType()) == 13);
 
   float CalE[2];
   getCalEnergy(pfo, CalE);
-  double ecale = CalE[0];
-  double hcale = CalE[1];
-  double p = TVector3(pfo->getMomentum()).Mag();
-  double calByP = p > 0 ? (ecale + hcale) / p : 0;
-  double calSum = ecale + hcale;
+  double ecale    = CalE[0];
+  double hcale    = CalE[1];
+  double p        = TVector3(pfo->getMomentum()).Mag();
+  double calByP   = p > 0 ? (ecale + hcale) / p : 0;
+  double calSum   = ecale + hcale;
   double ecalFrac = calSum > 0 ? ecale / calSum : 0;
 
   if (calByP >= _muonMinEnergyDepositByMomentum && calByP <= _muonMaxEnergyDepositByMomentum &&
@@ -406,14 +400,12 @@ bool IsolatedLeptonFinderProcessor::IsMuon(ReconstructedParticle* pfo) {
   return false;
 }
 bool IsolatedLeptonFinderProcessor::IsLepton(ReconstructedParticle* pfo) {
-
   if (IsElectron(pfo) || IsMuon(pfo))
     return true;
   return false;
 }
 
 bool IsolatedLeptonFinderProcessor::IsGoodLepton(ReconstructedParticle* pfo) {
-
   if (!IsCharged(pfo))
     return false;
 
@@ -430,7 +422,6 @@ bool IsolatedLeptonFinderProcessor::IsGoodLepton(ReconstructedParticle* pfo) {
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedLepton(ReconstructedParticle* pfo) {
-
   if (_useRectangularIsolation && !IsIsolatedRectangular(pfo))
     return false;
 
@@ -444,7 +435,7 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedLepton(ReconstructedParticle* pfo)
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedRectangular(ReconstructedParticle* pfo) {
-  float E = pfo->getEnergy();
+  float E     = pfo->getEnergy();
   float coneE = getConeEnergy(pfo);
 
   if (E < _isoMinTrackEnergy)
@@ -460,7 +451,7 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedRectangular(ReconstructedParticle*
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedPolynomial(ReconstructedParticle* pfo) {
-  float E = pfo->getEnergy();
+  float E     = pfo->getEnergy();
   float coneE = getConeEnergy(pfo);
 
   if (coneE * coneE <= _isoPolynomialA * E * E + _isoPolynomialB * E + _isoPolynomialC)
@@ -469,27 +460,25 @@ bool IsolatedLeptonFinderProcessor::IsIsolatedPolynomial(ReconstructedParticle* 
 }
 
 bool IsolatedLeptonFinderProcessor::IsIsolatedJet(ReconstructedParticle* pfo) {
-  // jet-based isolated lepton (LAL algorithm)
+  ReconstructedParticle* orig = _copy2orig.count(pfo) ? _copy2orig[pfo] : pfo;
 
-  if (_rpJetMap.find(pfo) == _rpJetMap.end()) {
+  if (_rpJetMap.find(orig) == _rpJetMap.end()) {
     // this is often the case when jet finding fails e.g. due to too few particles in event
+    //Use original address
     return false;
   }
 
-  ReconstructedParticle* jet = _rpJetMap[pfo];
-  TVector3 vec1(pfo->getMomentum());
-  TVector3 jetmom(jet->getMomentum());
-  TLorentzVector jetmom4(jet->getMomentum(), jet->getEnergy());
+  ReconstructedParticle* jet = _rpJetMap[orig];
+  TVector3               vec1(orig->getMomentum());
+  TVector3               jetmom(jet->getMomentum());
+  TLorentzVector         jetmom4(jet->getMomentum(), jet->getEnergy());
 
   float jetxt = vec1.Pt(jetmom) / jetmom4.M();
-  float jetz = pfo->getEnergy() / jet->getEnergy();
+  float jetz  = orig->getEnergy() / jet->getEnergy();
 
-  if (jetxt >= _jetIsoVetoMinXt && jetxt < _jetIsoVetoMaxXt && jetz >= _jetIsoVetoMinZ && jetz < _jetIsoVetoMaxZ) {
-    // printf("xt=%f z=%f (not pass)\n",jetxt,jetz);
+  if (jetxt >= _jetIsoVetoMinXt && jetxt < _jetIsoVetoMaxXt && jetz >= _jetIsoVetoMinZ && jetz < _jetIsoVetoMaxZ)
     return false;
-  }
 
-  // printf("xt=%f z=%f (PASS)\n",jetxt,jetz);
   return true;
 }
 
@@ -527,8 +516,8 @@ bool IsolatedLeptonFinderProcessor::PassesImpactParameterSignificanceCuts(Recons
     return false;
 
   // TODO: more sophisticated pfo/track matching
-  float d0 = fabs(trkvec[0]->getD0());
-  float z0 = fabs(trkvec[0]->getZ0());
+  float d0    = fabs(trkvec[0]->getD0());
+  float z0    = fabs(trkvec[0]->getZ0());
   float d0err = sqrt(trkvec[0]->getCovMatrix()[0]);
   float z0err = sqrt(trkvec[0]->getCovMatrix()[9]);
 
@@ -553,19 +542,24 @@ bool IsolatedLeptonFinderProcessor::PassesImpactParameterSignificanceCuts(Recons
 }
 
 float IsolatedLeptonFinderProcessor::getConeEnergy(ReconstructedParticle* pfo) {
-  float coneE = 0;
+  ReconstructedParticle* orig = _copy2orig.count(pfo) ? _copy2orig[pfo] : pfo;  // Get the original address
 
-  TVector3 P(pfo->getMomentum());
+  float    coneE = 0;
+  TVector3 P(orig->getMomentum());
+
   int npfo = _workingList.size();
   for (int i = 0; i < npfo; i++) {
-    ReconstructedParticle* pfo_i = static_cast<ReconstructedParticle*>(_workingList.at(i));
+    ReconstructedParticle* pfo_i = _workingList[i];
 
     // don't add itself to the cone energy
-    if (pfo == pfo_i)
+    if (pfo_i == orig)
       continue;
 
     TVector3 P_i(pfo_i->getMomentum());
+    if (P.Mag() == 0 || P_i.Mag() == 0)
+      continue;
     float cosTheta = P.Dot(P_i) / (P.Mag() * P_i.Mag());
+
     if (cosTheta >= _cosConeAngle)
       coneE += pfo_i->getEnergy();
   }
@@ -574,11 +568,10 @@ float IsolatedLeptonFinderProcessor::getConeEnergy(ReconstructedParticle* pfo) {
 }
 
 void IsolatedLeptonFinderProcessor::getCalEnergy(ReconstructedParticle* pfo, float* cale) {
-  float ecal = 0;
-  float hcal = 0;
+  float                       ecal     = 0;
+  float                       hcal     = 0;
   std::vector<lcio::Cluster*> clusters = pfo->getClusters();
-  for (std::vector<lcio::Cluster*>::const_iterator iCluster = clusters.begin(); iCluster != clusters.end();
-       ++iCluster) {
+  for (std::vector<lcio::Cluster*>::const_iterator iCluster = clusters.begin(); iCluster != clusters.end(); ++iCluster) {
     ecal += (*iCluster)->getSubdetectorEnergies()[0];
     hcal += (*iCluster)->getSubdetectorEnergies()[1];
   }

--- a/BEGINRELEASENOTES
+++ b/BEGINRELEASENOTES
@@ -1,5 +1,0 @@
-BEGINRELEASENOTES
-- Fixed cone energy calculation in IsolatedLeptonFinderProcessor to avoid
-  self-counting when reconstructed particles are copied internally.
-ENDRELEASENOTES
-

--- a/BEGINRELEASENOTES
+++ b/BEGINRELEASENOTES
@@ -1,0 +1,5 @@
+BEGINRELEASENOTES
+- Fixed cone energy calculation in IsolatedLeptonFinderProcessor to avoid
+  self-counting when reconstructed particles are copied internally.
+ENDRELEASENOTES
+


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixes several related issues caused by comparing copied reconstructed particles with originals by pointer identity
- Avoids self-counting in isolation cone energy
- Ensures jet-based isolation uses original PFOs
- Completes copying of tracks and clusters when duplicating PFOs

ENDRELEASENOTES